### PR TITLE
Use INT*_C and UINT*_C macros for special integer constants.

### DIFF
--- a/src/cgen.c
+++ b/src/cgen.c
@@ -218,11 +218,11 @@ static unsigned bit_width(type_t t)
 
          if (elements <= 2)
             return 1;
-         if (elements <= 0x100ull)
+         if (elements <= UINT64_C(0x100))
             return 8;
-         else if (elements <= 0x10000ull)
+         else if (elements <= UINT64_C(0x10000))
             return 16;
-         else if (elements <= 0x100000000ull)
+         else if (elements <= UINT64_C(0x100000000))
             return 32;
          else
             return 64;

--- a/src/fbuf.c
+++ b/src/fbuf.c
@@ -219,30 +219,30 @@ void fbuf_close(fbuf_t *f)
 void write_u32(uint32_t u, fbuf_t *f)
 {
    fbuf_maybe_flush(f, 4, false);
-   *(f->wbuf + f->wpend++) = (u >> 0) & 0xff;
-   *(f->wbuf + f->wpend++) = (u >> 8) & 0xff;
-   *(f->wbuf + f->wpend++) = (u >> 16) & 0xff;
-   *(f->wbuf + f->wpend++) = (u >> 24) & 0xff;
+   *(f->wbuf + f->wpend++) = (u >>  0) & UINT32_C(0xff);
+   *(f->wbuf + f->wpend++) = (u >>  8) & UINT32_C(0xff);
+   *(f->wbuf + f->wpend++) = (u >> 16) & UINT32_C(0xff);
+   *(f->wbuf + f->wpend++) = (u >> 24) & UINT32_C(0xff);
 }
 
 void write_u64(uint64_t u, fbuf_t *f)
 {
    fbuf_maybe_flush(f, 8, false);
-   *(f->wbuf + f->wpend++) = (u >> 0) & 0xff;
-   *(f->wbuf + f->wpend++) = (u >> 8) & 0xff;
-   *(f->wbuf + f->wpend++) = (u >> 16) & 0xff;
-   *(f->wbuf + f->wpend++) = (u >> 24) & 0xff;
-   *(f->wbuf + f->wpend++) = (u >> 32) & 0xff;
-   *(f->wbuf + f->wpend++) = (u >> 40) & 0xff;
-   *(f->wbuf + f->wpend++) = (u >> 48) & 0xff;
-   *(f->wbuf + f->wpend++) = (u >> 56) & 0xff;
+   *(f->wbuf + f->wpend++) = (u >>  0) & UINT64_C(0xff);
+   *(f->wbuf + f->wpend++) = (u >>  8) & UINT64_C(0xff);
+   *(f->wbuf + f->wpend++) = (u >> 16) & UINT64_C(0xff);
+   *(f->wbuf + f->wpend++) = (u >> 24) & UINT64_C(0xff);
+   *(f->wbuf + f->wpend++) = (u >> 32) & UINT64_C(0xff);
+   *(f->wbuf + f->wpend++) = (u >> 40) & UINT64_C(0xff);
+   *(f->wbuf + f->wpend++) = (u >> 48) & UINT64_C(0xff);
+   *(f->wbuf + f->wpend++) = (u >> 56) & UINT64_C(0xff);
 }
 
 void write_u16(uint16_t s, fbuf_t *f)
 {
    fbuf_maybe_flush(f, 2, false);
-   *(f->wbuf + f->wpend++) = (s >> 0) & 0xff;
-   *(f->wbuf + f->wpend++) = (s >> 8) & 0xff;
+   *(f->wbuf + f->wpend++) = (s >> 0) & UINT16_C(0xff);
+   *(f->wbuf + f->wpend++) = (s >> 8) & UINT16_C(0xff);
 }
 
 void write_u8(uint8_t u, fbuf_t *f)

--- a/src/hash.c
+++ b/src/hash.c
@@ -45,7 +45,7 @@ static inline int hash_slot(hash_t *h, const void *key)
    a = (a ^ 61) ^ (a >> 16);
    a = a + (a << 3);
    a = a ^ (a >> 4);
-   a = a * 0x27d4eb2d;
+   a = a * UINT32_C(0x27d4eb2d);
    a = a ^ (a >> 15);
 
    return a & (h->size - 1);

--- a/src/rt/rtkern.c
+++ b/src/rt/rtkern.c
@@ -229,11 +229,11 @@ static const char *fmt_time_r(char *buf, size_t len, uint64_t t)
       uint64_t time;
       const char *unit;
    } units[] = {
-      { 1ull, "fs" },
-      { 1000ull, "ps" },
-      { 1000000ull, "ns" },
-      { 1000000000ull, "us" },
-      { 1000000000000ull, "ms" },
+      { UINT64_C(1), "fs" },
+      { UINT64_C(1000), "ps" },
+      { UINT64_C(1000000), "ns" },
+      { UINT64_C(1000000000), "us" },
+      { UINT64_C(1000000000000), "ms" },
       { 0, NULL }
    };
 

--- a/src/type.c
+++ b/src/type.c
@@ -172,7 +172,7 @@ static void type_one_time_init(void)
       assert(nitems <= MAX_ITEMS);
 
       // Knuth's multiplicative hash
-      format_digest += has_map[i] * 2654435761u;
+      format_digest += has_map[i] * UINT32_C(2654435761);
 
       int n = 0;
       for (int j = 0; j < 32; j++) {
@@ -678,13 +678,13 @@ void type_write(type_t t, type_wr_ctx_t ctx)
    fbuf_t *f = tree_write_file(ctx->tree_ctx);
 
    if (t == NULL) {
-      write_u16(0xffff, f);   // Null marker
+      write_u16(UINT16_C(0xffff), f);   // Null marker
       return;
    }
 
    if (t->generation == ctx->generation) {
       // Already visited this type
-      write_u16(0xfffe, f);   // Back reference marker
+      write_u16(UINT16_C(0xfffe), f);   // Back reference marker
       write_u32(t->index, f);
       return;
    }
@@ -738,10 +738,10 @@ type_t type_read(type_rd_ctx_t ctx)
 {
    fbuf_t *f = tree_read_file(ctx->tree_ctx);
 
-   unsigned short marker = read_u16(f);
-   if (marker == 0xffff)
+   uint16_t marker = read_u16(f);
+   if (marker == UINT16_C(0xffff))
       return NULL;   // Null marker
-   else if (marker == 0xfffe) {
+   else if (marker == UINT16_C(0xfffe)) {
       // Back reference marker
       unsigned index = read_u32(f);
       assert(index < ctx->n_types);

--- a/test/test_value.c
+++ b/test/test_value.c
@@ -22,7 +22,7 @@ START_TEST(test_integer)
    fail_unless(v == 14124);
 
    fail_unless(parse_value(t, "25252781781981", &v));
-   fail_unless(v == 25252781781981ll);
+   fail_unless(v == INT64_C(25252781781981));
 
    fail_unless(parse_value(t, "1_2_3", &v));
    fail_unless(v == 123);


### PR DESCRIPTION
SSIA.
following points are worth to consider, IMHO.
- unify Knuth's multiplicative hash.
- define markers which are commonly used in `src/tree.c` and `src/type.c`.
- clean up some integer usage like `unsigned` and `int`.  
  replace `size_t` and `ssize_t` looks better in some cases, but this change will affect function decls/calls.  
