### PR TITLE
Fix build for LDFLAGS="-Wl,--as-needed".

### DIFF
--- a/thirdparty/lxt_write.c
+++ b/thirdparty/lxt_write.c
@@ -1499,7 +1499,7 @@ if((lt)&&(!lt->emitted)&&(!lt->sorted_facs))
 		{
 		lt_set_zmode(lt, lt->zmode = LT_ZMODE_BZIP2);
 		fflush(lt->handle);
-		lt->zhandle = BZ2_bzdopen(dup(fileno(lt->handle)), "wb9");
+		lt->zhandle = NULL; /* BZ2_bzdopen(dup(fileno(lt->handle)), "wb9"); */
 		}
 
 	if((lt->sorted_facs = (struct lt_symbol **)calloc(lt->numfacs, sizeof(struct lt_symbol *))))


### PR DESCRIPTION
Commit 4f2646506d048613e287f3f6990c6633b1812e17 breaks b/c
thirdparty/lxt_write.c:1502 has undefined reference to `BZ2_bzdopen'.
