### PR TITLE
added curl dependency to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ On a Debian derivative the following should be sufficient to install all require
 dependencies:
 
     sudo apt-get install build-essential automake autoconf autoconf-archive flex \
-        libreadline-dev tcl-dev check llvm-dev pkg-config zlib1g-dev
+        libreadline-dev tcl-dev check llvm-dev pkg-config zlib1g-dev curl
 
 #### Mac OS X
 


### PR DESCRIPTION
Curl isn't installed by default on at least Ubuntu 14.04, but is needed by `tools/fetch-ieee.sh`.