### PR TITLE
fix that sem_locally_static() didn't handle deferred constants

### DIFF
--- a/src/sem.c
+++ b/src/sem.c
@@ -5822,8 +5822,10 @@ static bool sem_locally_static(tree_t t)
       tree_t decl = tree_ref(t);
       const tree_kind_t dkind = tree_kind(decl);
 
-      // A constant reference with a locally static value
+      // A constant reference (other than a deferred constant) with a locally static value
       if (dkind == T_CONST_DECL) {
+         if (!tree_has_value(decl))
+            return false;
          tree_t value = tree_value(decl);
          return sem_subtype_locally_static(tree_type(decl))
             && sem_locally_static(value)

--- a/test/sem/issue239.vhd
+++ b/test/sem/issue239.vhd
@@ -33,3 +33,11 @@ begin
     wait;
 end process;
 end architecture;
+
+package package_issue239 is
+    constant deferred : integer;
+
+    procedure proc(a : integer := deferred);    -- OK
+
+end package;
+

--- a/test/test_sem.c
+++ b/test/test_sem.c
@@ -1435,7 +1435,7 @@ START_TEST(test_issue239)
    };
    expect_errors(expect);
 
-   parse_and_check(T_ENTITY, T_ARCH);
+   parse_and_check(T_ENTITY, T_ARCH, T_PACKAGE);
 
    fail_unless(sem_errors() == ARRAY_LEN(expect) - 1);
 }


### PR DESCRIPTION
I noticed that the VITAL library doesn't compile after the fix for #239. It turns out that sem_locally_static() doesn't handle deferred constants correctly (it assumes a constant has a value). In the future, I'll make clean builds from scratch -- not just "make check" to test fixes.