### PR TITLE
add last check similar to those for issue #224

### DIFF
--- a/src/sem.c
+++ b/src/sem.c
@@ -2102,6 +2102,9 @@ static bool sem_check_interface_class(tree_t port)
        tree_t value = tree_value(port);
        if (!sem_globally_static(value))
           sem_error(value, "default value must be a static expression");
+
+       if (kind == T_PROTECTED)
+          sem_error(port, "parameter with protected type can not have a default value");
    }
 
    if (kind == T_FILE && class != C_FILE)

--- a/test/sem/protected.vhd
+++ b/test/sem/protected.vhd
@@ -55,6 +55,16 @@ architecture a of e is
 
     shared variable y : SharedCounter := 1;  -- Error
 
+    function make return SharedCounter is
+        variable result : SharedCounter;
+    begin
+        return result;
+    end function;
+
+    procedure proc(variable sh : in SharedCounter := make) is   -- error
+    begin
+    end procedure;
+
 begin
 
 end architecture;

--- a/test/test_sem.c
+++ b/test/test_sem.c
@@ -906,10 +906,11 @@ START_TEST(test_protected)
       {  50, "subtypes may not have protected base types" },
       {  52, "shared variable X must have protected type" },
       {  56, "variable Y with protected type may not have an initial value" },
-      { 108, "no visible declaration for X.COUNTER" },
-      { 109, "no suitable overload for procedure X.DECREMENT" },
-      { 114, "object X with protected type must have class VARIABLE" },
-      { 132, "missing body for protected type WORK.PKG.PROTECTED_T" },
+      {  64, "parameter with protected type can not have a default value" },
+      { 118, "no visible declaration for X.COUNTER" },
+      { 119, "no suitable overload for procedure X.DECREMENT" },
+      { 124, "object X with protected type must have class VARIABLE" },
+      { 142, "missing body for protected type WORK.PKG.PROTECTED_T" },
       { -1, NULL }
    };
    expect_errors(expect);


### PR DESCRIPTION
This implements the fourth (and final) error specified by the LRM for default expressions in interface declarations -- it does not permit a protected type parameter to have a default expression.