### PR TITLE
dump subtypes more explicitly; dump real and enums ranges

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -407,6 +407,7 @@ static void dump_decl(tree_t t, int indent)
          }
          else if (type_is_enum(type)) {
             if (is_subtype) {
+               printf("range ");
                dump_range(type_dim(type, 0));
             }
             else

--- a/src/dump.c
+++ b/src/dump.c
@@ -340,14 +340,21 @@ static void dump_decl(tree_t t, int indent)
       break;
 
    case T_TYPE_DECL:
-      printf("type %s is ", istr(tree_ident(t)));
       {
          type_t type = tree_type(t);
-         if (type_is_integer(type)) {
+         type_kind_t kind = type_kind(type);
+         bool is_subtype = (kind == T_SUBTYPE);
+
+         printf("%stype %s is ", is_subtype ? "sub" : "", istr(tree_ident(t)));
+
+         if (is_subtype) {
+            printf("%s ", istr(type_ident(type_base(type))));
+         }
+         if (type_is_integer(type) || type_is_real(type)) {
             printf("range ");
             dump_range(type_dim(type, 0));
          }
-         else if (type_kind(type) == T_PHYSICAL) {
+         else if (kind == T_PHYSICAL) {
             printf("range ");
             dump_range(type_dim(type, 0));
             printf("\n");
@@ -367,8 +374,10 @@ static void dump_decl(tree_t t, int indent)
             printf("end units\n");
          }
          else if (type_is_array(type)) {
-            printf("array (");
-            if (type_kind(type) == T_UARRAY) {
+            if (!is_subtype)
+               printf("array ");
+            printf("(");
+            if (kind == T_UARRAY) {
                const int nindex = type_index_constrs(type);
                for (int i = 0; i < nindex; i++) {
                   if (i > 0) printf(", ");
@@ -383,8 +392,11 @@ static void dump_decl(tree_t t, int indent)
                   dump_range(type_dim(type, i));
                }
             }
-            printf(") of ");
-            dump_type(type_elem(type));
+            printf(")");
+            if (!is_subtype) {
+               printf(" of ");
+               dump_type(type_elem(type));
+            }
          }
          else if (type_is_protected(type)) {
             printf("protected\n");
@@ -392,6 +404,20 @@ static void dump_decl(tree_t t, int indent)
                dump_decl(type_decl(type, i), indent + 2);
             tab(indent);
             printf("end protected");
+         }
+         else if (type_is_enum(type)) {
+            if (is_subtype) {
+               dump_range(type_dim(type, 0));
+            }
+            else
+            {
+               printf("(");
+               for (unsigned i = 0; i < type_enum_literals(type); i++) {
+                  if (i > 0) printf(", ");
+                  printf("%s", istr(tree_ident(type_enum_literal(type, i))));
+               }
+               printf(")");
+            }
          }
          else
             dump_type(type);


### PR DESCRIPTION
Dump subtypes as "subtype" rather than "type" and reference their base type rather than appearing as a new definition. Also allow dumping of real and enum types/subtypes.

```VHDL
package pkg is
    type a1 is array (integer range <>) of character;
    subtype sa1 is a1 (1 to 4);

    type a2 is array (integer range <>, integer range <>) of character;
    subtype sa2 is a2 (1 to 2, 3 to 4);

    type e is (one, two, three, four);
    subtype se is e (two to four);

    type d is ('a', 'e', 'c', 'd');
    subtype sd is d ('d' downto 'e');

    subtype n is natural range 0 to 4;
    subtype r is real range 0.0 to 5.0;
    subtype stime is time range 0 ns to 1 ns;

    type t  is range 1 to 10;
    subtype st is t range 2 to 50;

end package pkg;
```

```
$ nvc -a test.vhd --dump pkg | grep -v predefined
package WORK.PKG is
  type WORK.PKG.A1 is array (STD.STANDARD.INTEGER range <>) of STD.STANDARD.CHARACTER;
  subtype WORK.PKG.SA1 is WORK.PKG.A1 (1 to 4);
  type WORK.PKG.A2 is array (STD.STANDARD.INTEGER range <>, STD.STANDARD.INTEGER range <>) of STD.STANDARD.CHARACTER;
  subtype WORK.PKG.SA2 is WORK.PKG.A2 (1 to 2, 3 to 4);
  type WORK.PKG.E is (ONE, TWO, THREE, FOUR);
  subtype WORK.PKG.SE is WORK.PKG.E range TWO to FOUR;
  type WORK.PKG.ARR is array (TWO to FOUR) of STD.STANDARD.BOOLEAN;
  type WORK.PKG.D is ('a', 'e', 'c', 'd');
  subtype WORK.PKG.SD is WORK.PKG.D range 'd' downto 'e';
  subtype WORK.PKG.N is STD.STANDARD.NATURAL range 0 to 4;
  subtype WORK.PKG.R is STD.STANDARD.REAL range 0.000000 to 5.000000;
  subtype WORK.PKG.STIME is STD.STANDARD.TIME WORK.PKG.STIME;
  type WORK.PKG.T is range 1 to 10;
  subtype WORK.PKG.ST is WORK.PKG.T range 2 to 50;
end package;
```