### PR TITLE
rework bounds_check_decl to support DOWNTO. Fixes #247

### DIFF
--- a/src/bounds.c
+++ b/src/bounds.c
@@ -384,27 +384,28 @@ static void bounds_check_decl(tree_t t)
 
          // Only check here if range can be determined to be non-null
 
-         int64_t dim_left, bounds_left;
-         int64_t dim_right, bounds_right;
+         int64_t dim_low, bounds_low;
+         int64_t dim_high, bounds_high;
 
          const bool is_static =
-            folded_int(dim.left, &dim_left)
-            && folded_int(bounds.left, &bounds_left)
-            && folded_int(dim.right, &dim_right)
-            && folded_int(bounds.right, &bounds_right);
+            folded_bounds(dim, &dim_low, &dim_high)
+            && folded_bounds(bounds, &bounds_low, &bounds_high);
 
          const bool is_null =
-            (dim.kind == RANGE_TO && dim_left > dim_right)
-            || (dim.kind == RANGE_DOWNTO && dim_left < dim_right);
+            dim_low > dim_high || bounds_low > bounds_high;
 
          if (is_static && !is_null) {
-            if (dim_left < bounds_left)
-               bounds_error(dim.left, "left index %"PRIi64" violates "
-                            "constraint %s", dim_left, type_pp(cons));
+            if (dim_low < bounds_low)
+               bounds_error((dim.kind == RANGE_TO) ? dim.left : dim.right,
+                            "%s index %"PRIi64" violates constraint %s",
+                            (dim.kind == RANGE_TO) ? "left" : "right",
+                            dim_low, type_pp(cons));
 
-            if (dim_right > bounds_right)
-               bounds_error(dim.right, "right index %"PRIi64" violates "
-                            "constraint %s", dim_right, type_pp(cons));
+            if (dim_high > bounds_high)
+               bounds_error((dim.kind == RANGE_TO) ? dim.right : dim.left,
+                            "%s index %"PRIi64" violates constraint %s",
+                            (dim.kind == RANGE_TO) ? "right" : "left",
+                            dim_high, type_pp(cons));
          }
       }
    }

--- a/test/bounds/issue247.vhd
+++ b/test/bounds/issue247.vhd
@@ -1,0 +1,5 @@
+package issue247 is
+    subtype natural_down is natural range 10 downto 0;
+    type array_t is array (natural_down range <>) of boolean;
+    constant c : array_t(9 downto 5);   -- ok
+end package issue247;

--- a/test/test_bounds.c
+++ b/test/test_bounds.c
@@ -196,6 +196,25 @@ START_TEST(test_issue208)
 }
 END_TEST
 
+START_TEST(test_issue247)
+{
+   const error_t expect[] = {
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   input_from_file(TESTDIR "/bounds/issue247.vhd");
+
+   tree_t a = parse_and_check(T_PACKAGE);
+   fail_unless(sem_errors() == 0);
+
+   simplify(a);
+   bounds_check(a);
+
+   fail_unless(bounds_errors() == ARRAY_LEN(expect) - 1);
+}
+END_TEST
+
 int main(void)
 {
    Suite *s = suite_create("bounds");
@@ -209,6 +228,7 @@ int main(void)
    tcase_add_test(tc_core, test_issue150);
    tcase_add_test(tc_core, test_issue200);
    tcase_add_test(tc_core, test_issue208);
+   tcase_add_test(tc_core, test_issue247);
    suite_add_tcase(s, tc_core);
 
    return nvc_run_test(s);


### PR DESCRIPTION
I also modified it to use folded_bounds() for the limits as a step towards supporting checking of enum types here.