### PR TITLE
Bounds check delays

### DIFF
--- a/src/bounds.c
+++ b/src/bounds.c
@@ -876,6 +876,14 @@ static void bounds_check_attr_ref(tree_t t)
    }
 }
 
+static void bounds_check_wait(tree_t t)
+{
+   int64_t delay = 0;
+   if (tree_has_delay(t) && folded_int(tree_delay(t), &delay))
+      if (delay < 0)
+         bounds_error(tree_delay(t), "wait timeout may not be negative");
+}
+
 static void bounds_visit_fn(tree_t t, void *context)
 {
    switch (tree_kind(t)) {
@@ -914,6 +922,9 @@ static void bounds_visit_fn(tree_t t, void *context)
       break;
    case T_ATTR_REF:
       bounds_check_attr_ref(t);
+      break;
+   case T_WAIT:
+      bounds_check_wait(t);
       break;
    default:
       break;

--- a/test/bounds/bounds2.vhd
+++ b/test/bounds/bounds2.vhd
@@ -1,0 +1,37 @@
+entity bounds2 is
+end entity;
+
+architecture test of bounds2 is
+begin
+
+    asssignment_delays: block
+        signal b1,b2,b3,b4,b5,b6,b7 : boolean;
+    begin
+        b1 <= true;                     -- OK
+        b2 <= true after 10 ns;         -- OK
+        b3 <= true after 0 ns;          -- OK
+        b4 <= true after -1 ns;         -- Error
+
+        process
+        begin
+            b5 <= true;                 -- OK
+            b5 <= true after 0 ns;      -- OK
+            b5 <= true after 1 fs;      -- OK
+            b5 <= true after -1 fs;     -- Error
+            wait;
+        end process;
+
+        b6 <= true after -10 ns when true else false;
+        b7 <= true when true else false after -10 ns;
+
+    end block;
+
+    rejection_limits: block
+        signal b1,b2,b3 : boolean;
+    begin
+        b1 <= reject  10 ns inertial true after 10 ns;  -- OK
+        b2 <= reject -10 ns inertial true;              -- Error
+        b3 <= reject  10 ns inertial true after 5 ns;   -- Error
+    end block;
+
+end architecture;

--- a/test/bounds/bounds2.vhd
+++ b/test/bounds/bounds2.vhd
@@ -34,4 +34,10 @@ begin
         b3 <= reject  10 ns inertial true after 5 ns;   -- Error
     end block;
 
+    process
+    begin
+        wait for -10 ns;            -- Error
+        wait;
+    end process;
+
 end architecture;

--- a/test/test_bounds.c
+++ b/test/test_bounds.c
@@ -61,6 +61,7 @@ START_TEST(test_bounds2)
       {  25, "assignment delay may not be negative"},
       {  33, "rejection limit may not be negative"},
       {  34, "rejection limit may not be greater than first assignment delay"},
+      {  39, "wait timeout may not be negative"},
       { -1, NULL }
    };
    expect_errors(expect);

--- a/test/test_bounds.c
+++ b/test/test_bounds.c
@@ -52,6 +52,31 @@ START_TEST(test_bounds)
 }
 END_TEST
 
+START_TEST(test_bounds2)
+{
+   const error_t expect[] = {
+      {  13, "assignment delay may not be negative"},
+      {  20, "assignment delay may not be negative"},
+      {  24, "assignment delay may not be negative"},
+      {  25, "assignment delay may not be negative"},
+      {  33, "rejection limit may not be negative"},
+      {  34, "rejection limit may not be greater than first assignment delay"},
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   input_from_file(TESTDIR "/bounds/bounds2.vhd");
+
+   tree_t a = parse_and_check(T_ENTITY, T_ARCH);
+   fail_unless(sem_errors() == 0);
+
+   simplify(a);
+   bounds_check(a);
+
+   fail_unless(bounds_errors() == (sizeof(expect) / sizeof(error_t)) - 1);
+}
+END_TEST
+
 START_TEST(test_case)
 {
    const error_t expect[] = {
@@ -222,6 +247,7 @@ int main(void)
 
    TCase *tc_core = nvc_unit_test();
    tcase_add_test(tc_core, test_bounds);
+   tcase_add_test(tc_core, test_bounds2);
    tcase_add_test(tc_core, test_case);
    tcase_add_test(tc_core, test_issue36);
    tcase_add_test(tc_core, test_issue54);


### PR DESCRIPTION
Add bounds-checking for rejection limits, signal assignment delays and for the delay in wait statements.