### PR TITLE
Fix that unconstrained deferred constant arrays didn't get their type set

### DIFF
--- a/src/sem.c
+++ b/src/sem.c
@@ -1947,6 +1947,9 @@ static bool sem_check_decl(tree_t t)
                    sem_type_str(tree_type(deferred)), istr(tree_ident(t)),
                    sem_type_str(type));
 
+      if (type_is_unconstrained(tree_type(deferred)))
+         tree_set_type(deferred, tree_type(tree_value(t)));
+
       tree_set_value(deferred, tree_value(t));
       return true;
    }

--- a/test/sem/const2.vhd
+++ b/test/sem/const2.vhd
@@ -1,0 +1,9 @@
+package deferred is
+    type t_int_array is array (natural range <>) of integer;
+    constant def_arr : t_int_array;
+end package;
+
+package body deferred is
+    constant def_arr : t_int_array := (0 to 2 => 10);
+end package body;
+

--- a/test/test_sem.c
+++ b/test/test_sem.c
@@ -249,6 +249,36 @@ START_TEST(test_const)
 }
 END_TEST
 
+START_TEST(test_const2)
+{
+   input_from_file(TESTDIR "/sem/const2.vhd");
+
+   tree_t p = parse();
+   fail_if(p == NULL);
+   fail_unless(tree_kind(p) == T_PACKAGE);
+   sem_check(p);
+
+   fail_unless(sem_errors() == 0);
+
+   fail_unless(tree_kind(p) == T_PACKAGE);
+
+   // The deferred constant array's type is originally unconstrained
+   tree_t d = tree_decl(p, 1);
+   fail_unless(tree_kind(d) == T_CONST_DECL);
+   fail_unless(type_is_unconstrained(tree_type(d)));
+
+   tree_t pb = parse();
+   fail_if(pb == NULL);
+   fail_unless(tree_kind(pb) == T_PACK_BODY);
+   sem_check(pb);
+
+   fail_unless(sem_errors() == 0);
+
+   // and then gets constrained after analysing the package body
+   fail_unless(!type_is_unconstrained(tree_type(d)));
+}
+END_TEST
+
 START_TEST(test_std)
 {
    input_from_file(TESTDIR "/sem/std.vhd");
@@ -1482,6 +1512,7 @@ int main(void)
    tcase_add_test(tc_core, test_scope);
    tcase_add_test(tc_core, test_ambiguous);
    tcase_add_test(tc_core, test_const);
+   tcase_add_test(tc_core, test_const2);
    tcase_add_test(tc_core, test_std);
    tcase_add_test(tc_core, test_wait);
    tcase_add_test(tc_core, test_func);


### PR DESCRIPTION
Fixed that the type wasn't getting set from the value supplied in the package body.