### PR TITLE
test/run.sh: fix little bug to launch run.sh in tools directory

### DIFF
--- a/tools/run.sh
+++ b/tools/run.sh
@@ -4,4 +4,4 @@ export NVC_LIBPATH=./lib/
 if [ -e lib/$1.so ]; then
     vhpi="--load lib/$1.so --vhpi-trace"
 fi
-./bin/nvc --std=$std -a ../test/regress/$1.vhd -e $* -r --trace --stats $vhpi
+../bin/nvc --std=$std -a ../test/regress/$1.vhd -e $* -r --trace --stats $vhpi


### PR DESCRIPTION
I couldn't launch test without it.