### PR TITLE
Fixes drop_tokens_until exit condition

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -386,7 +386,7 @@ static void drop_tokens_until(token_t tok)
    do {
       next = peek();
       drop_token();
-   } while ((tok != next) && (tok != tEOF));
+   } while ((tok != next) && (next != tEOF));
 
 #if TRACE_RECOVERY
    if (peek() != tEOF)


### PR DESCRIPTION
It hangs on the following input without the fix.

```vhdl

entity bug is
end entity;

architecture a of bug is
begin
  main : process is
  begin
  end;
end;
```