### PR TITLE
Implicit labeling

### DIFF
--- a/src/names.c
+++ b/src/names.c
@@ -1149,6 +1149,22 @@ void insert_spec(nametab_t *tab, tree_t spec, spec_kind_t kind,
    *p = s;
 }
 
+
+int* find_impl_label_loop_cnt(nametab_t *tab)
+{
+   scope_t *s = tab->top_scope;
+
+   for (; s != NULL; s = s->parent) {
+      if (s->container == NULL)
+         continue;
+
+      if (is_subprogram(s->container) || tree_kind(s->container) == T_PROCESS)
+         return &(s->lbl_cnts.loop);
+   }
+
+   return NULL;
+}
+
 ident_t get_implicit_label(tree_t t, nametab_t *tab)
 {
    int *cnt;
@@ -1164,8 +1180,7 @@ ident_t get_implicit_label(tree_t t, nametab_t *tab)
 
    case T_FOR:
    case T_WHILE:
-      // TODO: Use scop of wrapping process or subprogram
-      cnt = &(tab->top_scope->lbl_cnts.loop);
+      cnt = find_impl_label_loop_cnt(tab);
       c = 'L';
       break;
       

--- a/src/names.c
+++ b/src/names.c
@@ -110,13 +110,11 @@ typedef struct _lazy_sym {
    void       *ctx;
 } lazy_sym_t;
 
-typedef struct _label_cnts label_cnts_t;
-
-struct _label_cnts {
+typedef struct {
    int proc;
    int loop;
    int stmt;
-};
+} label_cnts_t;
 
 struct scope {
    scope_t       *parent;
@@ -1149,7 +1147,7 @@ void insert_spec(nametab_t *tab, tree_t spec, spec_kind_t kind,
    *p = s;
 }
 
-void set_impl_label_proc_cnt(tree_t t, nametab_t *tab)
+void continue_proc_labelling_from(tree_t t, nametab_t *tab)
 {
    if (t == NULL) {
       tab->top_scope->lbl_cnts.proc = 0;
@@ -1172,7 +1170,7 @@ void set_impl_label_proc_cnt(tree_t t, nametab_t *tab)
    tab->top_scope->lbl_cnts.proc = cnt;
 }
 
-int* find_impl_label_loop_cnt(nametab_t *tab)
+static inline int* find_impl_label_loop_cnt(nametab_t *tab)
 {
    scope_t *s = tab->top_scope;
 
@@ -1212,13 +1210,9 @@ ident_t get_implicit_label(tree_t t, nametab_t *tab)
       break;
    }
 
-   checked_sprintf(buf, 22, "_%C%x", c, *cnt);
+   checked_sprintf(buf, sizeof(buf), "_%C%d", c, *cnt);
    (*cnt)++;
    ident_t ident = ident_new(buf);
-
-#if 0
-   printf("Assigning implicit name: %s.%s\n", istr(scope_prefix(tab)), istr(ident));
-#endif
 
    return ident;
 }

--- a/src/names.c
+++ b/src/names.c
@@ -1170,21 +1170,6 @@ void continue_proc_labelling_from(tree_t t, nametab_t *tab)
    tab->top_scope->lbl_cnts.proc = cnt;
 }
 
-static inline int* find_impl_label_loop_cnt(nametab_t *tab)
-{
-   scope_t *s = tab->top_scope;
-
-   for (; s != NULL; s = s->parent) {
-      if (s->container == NULL)
-         continue;
-
-      if (is_subprogram(s->container) || tree_kind(s->container) == T_PROCESS)
-         return &(s->lbl_cnts.loop);
-   }
-
-   return NULL;
-}
-
 ident_t get_implicit_label(tree_t t, nametab_t *tab)
 {
    int *cnt;
@@ -1200,7 +1185,15 @@ ident_t get_implicit_label(tree_t t, nametab_t *tab)
 
    case T_FOR:
    case T_WHILE:
-      cnt = find_impl_label_loop_cnt(tab);
+      cnt = NULL;
+      for (scope_t *s = tab->top_scope; s != NULL; s = s->parent) {
+         if (s->container == NULL)
+            continue;
+         if (is_subprogram(s->container) || tree_kind(s->container) == T_PROCESS) {
+            cnt = &(s->lbl_cnts.loop);
+            break;
+         }
+      }
       c = 'L';
       break;
       

--- a/src/names.h
+++ b/src/names.h
@@ -93,6 +93,7 @@ void insert_spec(nametab_t *tab, tree_t spec, spec_kind_t kind,
                  ident_t ident, int depth);
 
 ident_t get_implicit_label(tree_t t, nametab_t *tab);
+void set_impl_label_proc_cnt(tree_t t, nametab_t *tab);
 
 tree_t resolve_name(nametab_t *tab, const loc_t *loc, ident_t name);
 type_t resolve_type(nametab_t *tab, type_t incomplete);

--- a/src/names.h
+++ b/src/names.h
@@ -92,6 +92,8 @@ void insert_names_for_config(nametab_t *tab, tree_t unit);
 void insert_spec(nametab_t *tab, tree_t spec, spec_kind_t kind,
                  ident_t ident, int depth);
 
+ident_t get_implicit_label(tree_t t, nametab_t *tab);
+
 tree_t resolve_name(nametab_t *tab, const loc_t *loc, ident_t name);
 type_t resolve_type(nametab_t *tab, type_t incomplete);
 tree_t resolve_subprogram_name(nametab_t *tab, tree_t ref, type_t constraint);

--- a/src/names.h
+++ b/src/names.h
@@ -93,7 +93,7 @@ void insert_spec(nametab_t *tab, tree_t spec, spec_kind_t kind,
                  ident_t ident, int depth);
 
 ident_t get_implicit_label(tree_t t, nametab_t *tab);
-void set_impl_label_proc_cnt(tree_t t, nametab_t *tab);
+void continue_proc_labelling_from(tree_t t, nametab_t *tab);
 
 tree_t resolve_name(nametab_t *tab, const loc_t *loc, ident_t name);
 type_t resolve_type(nametab_t *tab, type_t incomplete);

--- a/src/parse.c
+++ b/src/parse.c
@@ -769,6 +769,8 @@ static ident_t get_implicit_label(tree_t t, const loc_t *loc)
    case T_VAR_ASSIGN:
    case T_PROT_PCALL:
    case T_PCALL:
+   case T_COND_ASSIGN:
+   case T_SELECT:
       cnt = &(imp_label_cnts.stmt);
       c = 'S';
       break;
@@ -9459,6 +9461,7 @@ static void p_selected_waveforms(tree_t stmt, tree_t target, tree_t reject)
          tree_set_value(tree_assoc(stmt, i), a);
 
       tree_set_loc(a, CURRENT_LOC);
+      ensure_labelled(a, NULL);
       sem_check(a, nametab);
    } while (optional(tCOMMA));
 }
@@ -9473,6 +9476,8 @@ static tree_t p_selected_signal_assignment(void)
 
    tree_t conc = tree_new(T_CONCURRENT);
    tree_t stmt = tree_new(T_SELECT);
+   imp_label_cnts.stmt = 0;
+   ensure_labelled(stmt, NULL);
    tree_add_stmt(conc, stmt);
 
    tree_t value = p_expression();

--- a/src/parse.c
+++ b/src/parse.c
@@ -6127,6 +6127,8 @@ static tree_t p_concurrent_assertion_statement(ident_t label)
       tree_set_flag(conc, TREE_F_POSTPONED);
 
    tree_t s = p_assertion();
+   imp_label_cnts.stmt = 0;
+   tree_set_ident(s, get_implicit_label(s, CURRENT_LOC));
    tree_add_stmt(conc, s);
 
    consume(tSEMI);

--- a/src/parse.c
+++ b/src/parse.c
@@ -7134,6 +7134,9 @@ static tree_t p_subprogram_body(tree_t spec)
 
    consume(tBEGIN);
 
+   // Reset label counter since 'subprogram_statement_part' is in new
+   // declarative scope where loop statements can occur.
+   imp_label_cnts.loop = 0;
    p_sequence_of_statements(spec);
 
    consume(tEND);
@@ -7268,6 +7271,9 @@ static void p_process_statement_part(tree_t proc)
 
    BEGIN("process statement part");
 
+   // Reset label counter since 'process_statement_part' is in new
+   // declarative scope where loop statements can occur.
+   imp_label_cnts.loop = 0;
    p_sequence_of_statements(proc);
 }
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -9817,6 +9817,8 @@ static void p_architecture_body(tree_t unit)
       insert_decls(nametab, e);
    }
 
+   set_impl_label_proc_cnt(e, nametab);
+
    p_architecture_declarative_part(unit);
 
    consume(tBEGIN);

--- a/src/parse.c
+++ b/src/parse.c
@@ -757,6 +757,22 @@ static ident_t get_implicit_label(tree_t t, const loc_t *loc)
       c = 'L';
       break;
 
+   case T_WAIT:
+   case T_ASSERT:
+   case T_IF:
+   case T_NULL:
+   case T_RETURN:
+   case T_CASE:
+   case T_EXIT:
+   case T_NEXT:
+   case T_SIGNAL_ASSIGN:
+   case T_VAR_ASSIGN:
+   case T_PROT_PCALL:
+   case T_PCALL:
+      cnt = &(imp_label_cnts.stmt);
+      c = 'S';
+      break;
+
    default:
       return loc_to_ident(loc);
    }
@@ -7137,6 +7153,7 @@ static tree_t p_subprogram_body(tree_t spec)
    // Reset label counter since 'subprogram_statement_part' is in new
    // declarative scope where loop statements can occur.
    imp_label_cnts.loop = 0;
+   imp_label_cnts.stmt = 0;
    p_sequence_of_statements(spec);
 
    consume(tEND);
@@ -7274,6 +7291,7 @@ static void p_process_statement_part(tree_t proc)
    // Reset label counter since 'process_statement_part' is in new
    // declarative scope where loop statements can occur.
    imp_label_cnts.loop = 0;
+   imp_label_cnts.stmt = 0;
    p_sequence_of_statements(proc);
 }
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -8670,6 +8670,7 @@ static tree_t p_if_statement(ident_t label)
    EXTEND("if statement");
 
    tree_t t = tree_new(T_IF);
+   ensure_labelled(t, label);
 
    consume(tIF);
 
@@ -8709,7 +8710,7 @@ static tree_t p_if_statement(ident_t label)
    p_trailing_label(label);
    consume(tSEMI);
 
-   set_label_and_loc(t, label, CURRENT_LOC);
+   tree_set_loc(t, CURRENT_LOC);
    sem_check(t, nametab);
    return t;
 }
@@ -9022,6 +9023,8 @@ static tree_t p_case_statement(ident_t label)
 
    tree_t value = p_expression();
    tree_set_value(t, value);
+   ensure_labelled(t, label);
+
    solve_types(nametab, value, NULL);
 
    consume(tIS);
@@ -9039,7 +9042,7 @@ static tree_t p_case_statement(ident_t label)
    p_trailing_label(label);
    consume(tSEMI);
 
-   set_label_and_loc(t, label, CURRENT_LOC);
+   tree_set_loc(t, CURRENT_LOC);
    sem_check(t, nametab);
    return t;
 }

--- a/src/parse.c
+++ b/src/parse.c
@@ -8983,7 +8983,7 @@ static void p_case_statement_alternative(tree_t stmt)
    consume(tASSOC);
 
    tree_t b = tree_new(T_SEQUENCE);
-   // TODO: Do we really need identifier here?? Not a 
+   // TODO: Do we really need identifier here??
    //tree_set_ident(b, loc_to_ident(CURRENT_LOC));
    p_sequence_of_statements(b);
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -9368,6 +9368,8 @@ static void p_conditional_waveforms(tree_t stmt, tree_t target, tree_t s0)
       else
          s0 = NULL;
 
+      tree_set_ident(a, get_implicit_label(a, CURRENT_LOC));
+      
       tree_set_loc(a, CURRENT_LOC);
       tree_set_loc(c, CURRENT_LOC);
 
@@ -9397,6 +9399,8 @@ static tree_t p_conditional_signal_assignment(tree_t name)
    tree_t stmt = tree_new(T_COND_ASSIGN);
    tree_add_stmt(conc, stmt);
 
+   imp_label_cnts.stmt = 0;
+   tree_set_ident(stmt, get_implicit_label(stmt, CURRENT_LOC));
    tree_t target = p_target(name);
    tree_set_target(stmt, target);
 
@@ -9461,7 +9465,7 @@ static void p_selected_waveforms(tree_t stmt, tree_t target, tree_t reject)
          tree_set_value(tree_assoc(stmt, i), a);
 
       tree_set_loc(a, CURRENT_LOC);
-      ensure_labelled(a, NULL);
+      tree_set_ident(a, get_implicit_label(a, CURRENT_LOC));
       sem_check(a, nametab);
    } while (optional(tCOMMA));
 }
@@ -9477,7 +9481,7 @@ static tree_t p_selected_signal_assignment(void)
    tree_t conc = tree_new(T_CONCURRENT);
    tree_t stmt = tree_new(T_SELECT);
    imp_label_cnts.stmt = 0;
-   ensure_labelled(stmt, NULL);
+   tree_set_ident(stmt, get_implicit_label(stmt, CURRENT_LOC));
    tree_add_stmt(conc, stmt);
 
    tree_t value = p_expression();

--- a/src/parse.c
+++ b/src/parse.c
@@ -6056,7 +6056,7 @@ static tree_t p_concurrent_assertion_statement(ident_t label)
 
    ensure_labelled(conc, label);
 
-   insert_name(nametab, conc, NULL);
+   if (label) insert_name(nametab, conc, NULL);
    sem_check(conc, nametab);
    return conc;
 }
@@ -9450,7 +9450,7 @@ static tree_t p_concurrent_signal_assignment_statement(ident_t label,
    if (postponed)
       tree_set_flag(t, TREE_F_POSTPONED);
 
-   insert_name(nametab, t, NULL);
+   if (label) insert_name(nametab, t, NULL);
    sem_check(t, nametab);
    return t;
 }
@@ -9490,7 +9490,7 @@ static tree_t p_concurrent_procedure_call_statement(ident_t label, tree_t name)
    ensure_labelled(conc, label);
    tree_set_ident(call, tree_ident(conc));
 
-   insert_name(nametab, conc, NULL);
+   if (label) insert_name(nametab, conc, NULL);
    sem_check(conc, nametab);
    return conc;
 }

--- a/src/parse.c
+++ b/src/parse.c
@@ -7366,7 +7366,7 @@ static void p_entity_declaration(tree_t unit)
 
    if (optional(tBEGIN))
       p_entity_statement_part(unit);
-   
+
    consume(tEND);
    optional(tENTITY);
    p_trailing_label(id);
@@ -8984,8 +8984,6 @@ static void p_case_statement_alternative(tree_t stmt)
    consume(tASSOC);
 
    tree_t b = tree_new(T_SEQUENCE);
-   // TODO: Do we really need identifier here??
-   //tree_set_ident(b, loc_to_ident(CURRENT_LOC));
    p_sequence_of_statements(b);
 
    const int nassocs = tree_assocs(stmt);
@@ -9820,7 +9818,7 @@ static void p_architecture_body(tree_t unit)
       insert_decls(nametab, e);
    }
 
-   set_impl_label_proc_cnt(e, nametab);
+   continue_proc_labelling_from(e, nametab);
 
    p_architecture_declarative_part(unit);
 

--- a/src/simp.c
+++ b/src/simp.c
@@ -1202,6 +1202,7 @@ static tree_t simp_select(tree_t t)
    tree_t c = tree_new(T_CASE);
    tree_set_loc(c, tree_loc(t));
    tree_set_value(c, tree_value(t));
+   tree_set_ident(c, tree_ident(t));
 
    const int nassocs = tree_assocs(t);
    for (int i = 0; i < nassocs; i++)

--- a/src/simp.c
+++ b/src/simp.c
@@ -1187,9 +1187,7 @@ static tree_t simp_cond_assign(tree_t t)
    else {
       tree_t s = tree_new(T_IF);
       tree_set_loc(s, tree_loc(t));
-      
-      if (tree_has_ident(t))
-         tree_set_ident(s, tree_ident(t));
+      tree_set_ident(s, tree_ident(t));
 
       for (int i = 0; i < nconds; i++)
          tree_add_cond(s, tree_cond(t, i));

--- a/src/simp.c
+++ b/src/simp.c
@@ -1187,6 +1187,9 @@ static tree_t simp_cond_assign(tree_t t)
    else {
       tree_t s = tree_new(T_IF);
       tree_set_loc(s, tree_loc(t));
+      ident_t label = tree_ident(t);
+      if (label != NULL)
+         tree_set_ident(s, label);
 
       for (int i = 0; i < nconds; i++)
          tree_add_cond(s, tree_cond(t, i));

--- a/src/simp.c
+++ b/src/simp.c
@@ -1187,9 +1187,9 @@ static tree_t simp_cond_assign(tree_t t)
    else {
       tree_t s = tree_new(T_IF);
       tree_set_loc(s, tree_loc(t));
-      ident_t label = tree_ident(t);
-      if (label != NULL)
-         tree_set_ident(s, label);
+      
+      if (tree_has_ident(t))
+         tree_set_ident(s, tree_ident(t));
 
       for (int i = 0; i < nconds; i++)
          tree_add_cond(s, tree_cond(t, i));

--- a/src/tree.c
+++ b/src/tree.c
@@ -27,7 +27,7 @@
 
 static const imask_t has_map[T_LAST_TREE_KIND] = {
    // T_ENTITY
-   (I_IDENT | I_PORTS | I_GENERICS | I_CONTEXT | I_DECLS | I_STMTS | I_IVAL),
+   (I_IDENT | I_PORTS | I_GENERICS | I_CONTEXT | I_DECLS | I_STMTS),
 
    // T_ARCH
    (I_IDENT | I_IDENT2 | I_DECLS | I_STMTS | I_CONTEXT | I_PRIMARY),

--- a/src/tree.c
+++ b/src/tree.c
@@ -27,7 +27,7 @@
 
 static const imask_t has_map[T_LAST_TREE_KIND] = {
    // T_ENTITY
-   (I_IDENT | I_PORTS | I_GENERICS | I_CONTEXT | I_DECLS | I_STMTS),
+   (I_IDENT | I_PORTS | I_GENERICS | I_CONTEXT | I_DECLS | I_STMTS | I_IVAL),
 
    // T_ARCH
    (I_IDENT | I_IDENT2 | I_DECLS | I_STMTS | I_CONTEXT | I_PRIMARY),

--- a/test/regress/gold/bounds18.txt
+++ b/test/regress/gold/bounds18.txt
@@ -1,3 +1,3 @@
 actual length 3 does not match parameter X length 5
 Procedure PROC [POSITIVE]
-Process :bounds18:line_19
+Process :bounds18:_p0

--- a/test/regress/gold/bounds19.txt
+++ b/test/regress/gold/bounds19.txt
@@ -1,3 +1,3 @@
 actual length 2 for dimension 2 does not match parameter X length 3
 Procedure PROC [POSITIVE, POSITIVE]
-Process :bounds19:line_21
+Process :bounds19:_p0

--- a/test/regress/gold/debug3.txt
+++ b/test/regress/gold/debug3.txt
@@ -1,4 +1,4 @@
 write to closed file
 Procedure FILE_PROC []
 Procedure PROC []
-Process :debug3:line_41
+Process :debug3:_p0


### PR DESCRIPTION
This MR adds implicit label creation. Processes and Loops are labelled according to VHDL 2008 LRM.
Statements are labelled extra.

Processes are labeled with _PX, where X starts from 0. Statements
equivalent to processes are also labeled. If equivalent process statements
exist in entity, X is not reset in architecture, but it keeps on counting.
Process counter is passed as I_IVAL attribute of T_ENTITY.

Loops are labeled with _LX, where X is reset upon each declarative
scope in which loops can occur (process body or subprogram body).

Statements are labelled with _SX, where X is reset in the same
scenarios as _LX. This-way labels of statements from different
processes do not affect each other.

Labels of statements for concurrent conditional, selected signal
assignment and concurrent assertion are preserved during simplification
pass.

The modifications are pre-condition for unique naming of statements
for statement code coverage collection.

Btw. I have received some tests failing from the CI build. Are these known
issues, or is it something I caused and I should debug them? If so, how
do I run tests locally please?

