### PR TITLE
src: Add implicit labeling of branches

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -31,6 +31,7 @@
 #define DUMP_TYPE_HINT  0
 #define DUMP_ADDRESS    0
 #define DUMP_STATICNESS 0
+#define DUMP_GEN_NAMES  0
 
 LCOV_EXCL_START
 
@@ -932,7 +933,9 @@ static void dump_stmt(tree_t t, int indent)
 
    if (tree_has_ident(t)) {
       const char *label = istr(tree_ident(t));
+#ifndef DUMP_GEN_NAMES
       if (label[0] != '_')   // Skip generated labels
+#endif
          printf("%s: ", label);
    }
 
@@ -1056,13 +1059,21 @@ static void dump_stmt(tree_t t, int indent)
       break;
 
    case T_IF:
-      syntax("#if ");
       for (unsigned i = 0; i < tree_conds(t); i++) {
          tree_t c = tree_cond(t, i);
          if (tree_has_value(c)) {
-            if (i > 0) {
+            if (i > 0)
                tab(indent);
+
+#ifdef DUMP_GEN_NAMES
+            // T_CONDS can only have generate name
+            const char *label = istr(tree_ident(c));
+            printf("%s: ", label);
+#endif
+            if (i > 0) {
                syntax("#elsif ");
+            } else {
+               syntax("#if ");
             }
             dump_expr(tree_value(c));
             syntax(" #then\n");
@@ -1092,7 +1103,12 @@ static void dump_stmt(tree_t t, int indent)
       syntax(" #is\n");
       for (unsigned i = 0; i < tree_assocs(t); i++) {
          tab(indent + 2);
-         tree_t a = tree_assoc(t, i);
+         tree_t a = tree_assoc(t, i);   
+#ifdef DUMP_GEN_NAMES
+         // T_ASSOC can only have generate name
+         const char *label = istr(tree_ident(a));
+         printf("%s: ", label);
+#endif
          switch (tree_subkind(a)) {
          case A_NAMED:
             syntax("#when ");

--- a/src/names.c
+++ b/src/names.c
@@ -114,6 +114,7 @@ typedef struct {
    int proc;
    int loop;
    int stmt;
+   int branch;
 } label_cnts_t;
 
 struct scope {
@@ -1206,6 +1207,26 @@ ident_t get_implicit_label(tree_t t, nametab_t *tab)
 
    checked_sprintf(buf, sizeof(buf), "_%c%d", c, (*cnt)++);
    return ident_new(buf);
+}
+
+ident_t get_branch_label(tree_t stmt, tree_t branch)
+{
+   assert (tree_kind(branch) == T_COND || tree_kind(branch) == T_ASSOC);
+   
+   char buf[16];
+   
+   tree_kind_t kind = tree_kind(branch);
+   int cnt;
+   if (kind == T_COND) {
+      cnt = tree_conds(stmt);
+   } else {
+      cnt = tree_assocs(stmt);
+   }
+
+   checked_sprintf(buf, sizeof(buf), "_B%d", cnt - 1);
+   ident_t ident = ident_new(buf);
+
+   return ident;
 }
 
 type_t resolve_type(nametab_t *tab, type_t incomplete)

--- a/src/names.c
+++ b/src/names.c
@@ -1179,8 +1179,9 @@ ident_t get_implicit_label(tree_t t, nametab_t *tab)
    char buf[22];
 
    switch (tree_kind(t)) {
-   case T_PROCESS:
    case T_CONCURRENT:
+      tab->top_scope->lbl_cnts.stmt = 0;
+   case T_PROCESS:   
       cnt = &(tab->top_scope->lbl_cnts.proc);
       c = 'P';
       break;

--- a/src/names.h
+++ b/src/names.h
@@ -93,6 +93,7 @@ void insert_spec(nametab_t *tab, tree_t spec, spec_kind_t kind,
                  ident_t ident, int depth);
 
 ident_t get_implicit_label(tree_t t, nametab_t *tab);
+ident_t get_branch_label(tree_t stmt, tree_t branch);
 void continue_proc_labelling_from(tree_t t, nametab_t *tab);
 
 tree_t resolve_name(nametab_t *tab, const loc_t *loc, ident_t name);

--- a/src/parse.c
+++ b/src/parse.c
@@ -4082,6 +4082,11 @@ static void p_choice(tree_t parent, type_t constraint)
 
    tree_set_loc(t, CURRENT_LOC);
    tree_add_assoc(parent, t);
+
+   // Parent passed only for T_CASE, T_MATCH_CASE, T_SELECT
+   // In such case assoc is coverable branch
+   if (parent)
+      tree_set_ident(t, get_branch_label(parent, t));
 }
 
 static void p_choices(tree_t parent, type_t constraint)
@@ -8271,6 +8276,7 @@ static void p_conditional_expressions(tree_t stmt, tree_t value0)
 
       tree_add_stmt(c, a);
       tree_add_cond(stmt, c);
+      tree_set_ident(c, get_branch_label(stmt, c));
 
       if (optional(tWHEN)) {
          tree_t when = p_condition();
@@ -8676,6 +8682,7 @@ static tree_t p_if_statement(ident_t label)
    tree_t c0 = tree_new(T_COND);
    tree_set_value(c0, p_condition());
    tree_add_cond(t, c0);
+   tree_set_ident(c0, get_branch_label(t, c0));
 
    consume(tTHEN);
 
@@ -8687,6 +8694,7 @@ static tree_t p_if_statement(ident_t label)
       tree_t c = tree_new(T_COND);
       tree_set_value(c, p_condition());
       tree_add_cond(t, c);
+      tree_set_ident(c, get_branch_label(t, c));
 
       consume(tTHEN);
 
@@ -8698,6 +8706,7 @@ static tree_t p_if_statement(ident_t label)
    if (optional(tELSE)) {
       tree_t c = tree_new(T_COND);
       tree_add_cond(t, c);
+      tree_set_ident(c, get_branch_label(t, c));
 
       p_sequence_of_statements(c);
 
@@ -9284,6 +9293,7 @@ static void p_conditional_waveforms(tree_t stmt, tree_t target, tree_t s0)
 
       tree_add_stmt(c, a);
       tree_add_cond(stmt, c);
+      tree_set_ident(c, get_branch_label(stmt, c));
 
       if (optional(tWHEN)) {
          tree_t when = p_condition();

--- a/src/tree.c
+++ b/src/tree.c
@@ -158,7 +158,7 @@ static const imask_t has_map[T_LAST_TREE_KIND] = {
    (I_IDENT | I_DECLS | I_STMTS | I_PORTS | I_GENERICS | I_PARAMS | I_GENMAPS),
 
    // T_COND
-   (I_VALUE | I_STMTS),
+   (I_IDENT | I_VALUE | I_STMTS),
 
    // T_TYPE_CONV
    (I_VALUE | I_TYPE | I_FLAGS),
@@ -203,7 +203,7 @@ static const imask_t has_map[T_LAST_TREE_KIND] = {
    (I_VALUE | I_POS | I_SUBKIND | I_NAME),
 
    // T_ASSOC
-   (I_VALUE | I_POS | I_NAME | I_RANGES | I_SUBKIND),
+   (I_IDENT | I_VALUE | I_POS | I_NAME | I_RANGES | I_SUBKIND),
 
    // T_USE
    (I_IDENT | I_IDENT2 | I_REF),


### PR DESCRIPTION
This PR adds implicit labeling to branches needed for implementation of
branch / decision coverage waiving.

A branch is one of:
  - T_IF conds with value - Could be covered to true / false (similarly as condition coverage now).
  - T_CASE assocs - Each assoc creates a single "branch".

Branches in Conditional signal assign, Selected signal assign, Conditional variable signal assign
are also labelled since they are converted to T_IF or T_CASE.

Branch label is generated uniquely for each branch, since it will be prefixed in the collected coverage
by name of the statement (which is unique in the given scope). Labels are numbered incrementally
when T_COND or T_ASSOC is added.