### PR TITLE
src: Fix coverage scope pop on case array statements

### DIFF
--- a/src/lower.c
+++ b/src/lower.c
@@ -6479,9 +6479,9 @@ static void lower_case_array(tree_t stmt, loop_stack_t *loops)
 
                cptr++;
             }
-
-            cover_pop_scope(cover_tags);
          }
+
+         cover_pop_scope(cover_tags);
 
          vcode_select_block(hit_bb);
 


### PR DESCRIPTION
I started to look into optimization of coverage and wanted to re-run the NEORV32 test.
The report generation crashed, and as I started to debug it, I figured out that `others` choice on
vectored case statements was not popping coverage scope correctly. Thus, in a complex design,
with many `others` choices on `std_logic_vector`, the coverage scope name eventually accumulated
to so long name, that I was unable to open a new HTML file (due to Linux file name limit) and
the crash occured.

This MR fixes the issue, however I don't have a test for now. I will add another MR where I will
implement option to print summary of each hierarchy into command line as the report is being
generated. Then, I will add a test to check design with multiple hierarchies (and also `others`
choices on vectored cases), and check terminal outptut towards golden output with this new
"verbose" option.