### PR TITLE
WIP: Cover exclude unreachable

### DIFF
--- a/nvc.1
+++ b/nvc.1
@@ -606,9 +606,18 @@ nested arrays (array of array), disabled by default.
 - When set, NVC does not collect toggle coverage on arrays whose size is equal
 to or larger than
 .Cm <size>
+.It
+.Cm exclude-unreachable
+- When set, NVC detects unreachable coverage bins and automatically excludes
+them during code coverage report generation. NVC detects following
+unreachable coverage items:
+.Bl
+.It
+Toggle coverage on instance ports driven by constant value.
+.El
 .El
 .Pp
-All of the options above are passed comma separated to
+All additional coverage options are passed comma separated to
 .Fl -cover
 elaboration option, e.g.:
 .Bd -literal -offset indent

--- a/src/nvc.c
+++ b/src/nvc.c
@@ -244,6 +244,7 @@ static void parse_cover_options(const char *str, cover_mask_t *mask,
       { "count-from-undefined",  COVER_MASK_TOGGLE_COUNT_FROM_UNDEFINED },
       { "count-from-to-z",       COVER_MASK_TOGGLE_COUNT_FROM_TO_Z      },
       { "include-mems",          COVER_MASK_TOGGLE_INCLUDE_MEMS         },
+      { "exclude-unreachable",   COVER_MASK_EXCLUDE_UNREACHABLE         }
    };
 
    for (const char *start = str; ; str++) {

--- a/src/rt/cover.c
+++ b/src/rt/cover.c
@@ -824,11 +824,11 @@ static bool is_constant_input(rt_signal_t *s)
       decl = sc->where;
    }
 
-   if (tree_kind(decl) != T_PORT_DECL) {
+   if (tree_kind(decl) != T_PORT_DECL)
       return false;
-   } else if (tree_subkind(decl) != PORT_IN) {
+   else if (tree_subkind(decl) != PORT_IN)
       return false;
-   } else {
+   else {
       rt_nexus_t *n = &(s->nexus);
       for (unsigned i = 0; i < s->n_nexus; i++, n = n->chain) {
          if (n->n_sources > 0)

--- a/src/rt/cover.c
+++ b/src/rt/cover.c
@@ -849,8 +849,7 @@ void x_cover_setup_toggle_cb(sig_shared_t *ss, int32_t *toggle_mask)
       for (int i = 0; i < s->shared.size; i++) {
          // Remember un-reachability in run-time data. Exclude mask not
          // available at run-time.
-         (*toggle_mask) |= COV_FLAG_UNREACHABLE;
-         toggle_mask++;
+         (*toggle_mask++) |= COV_FLAG_UNREACHABLE;
       }
       return;
    }

--- a/src/rt/cover.c
+++ b/src/rt/cover.c
@@ -1718,7 +1718,7 @@ static bool cover_tag_unreachable(cover_report_ctx_t *ctx, cover_tag_t *tag)
 {
    if ((ctx->tagging->mask & COVER_MASK_EXCLUDE_UNREACHABLE) == 0)
       return false;
-   return (tag->data & COV_FLAG_UNREACHABLE);
+   return !!(tag->data & COV_FLAG_UNREACHABLE);
 }
 
 static void cover_tag_to_chain(cover_report_ctx_t *ctx, cover_tag_t *tag,

--- a/src/rt/cover.h
+++ b/src/rt/cover.h
@@ -126,7 +126,8 @@ typedef enum {
    COV_FLAG_TOGGLE_TO_1    = (1 << 16),
    COV_FLAG_TOGGLE_SIGNAL  = (1 << 17),
    COV_FLAG_TOGGLE_PORT    = (1 << 18),
-   COV_FLAG_EXPR_STD_LOGIC = (1 << 24)
+   COV_FLAG_EXPR_STD_LOGIC = (1 << 24),
+   COV_FLAG_UNREACHABLE    = (1 << 25)
 } cover_flags_t;
 
 #define COVER_FLAGS_AND_EXPR (COV_FLAG_11 | COV_FLAG_10 | COV_FLAG_01)
@@ -151,6 +152,7 @@ typedef enum {
    COVER_MASK_TOGGLE_COUNT_FROM_UNDEFINED = (1 << 8),
    COVER_MASK_TOGGLE_COUNT_FROM_TO_Z      = (1 << 9),
    COVER_MASK_TOGGLE_INCLUDE_MEMS         = (1 << 10),
+   COVER_MASK_EXCLUDE_UNREACHABLE         = (1 << 11),
    COVER_MASK_DONT_PRINT_COVERED          = (1 << 16),
    COVER_MASK_DONT_PRINT_UNCOVERED        = (1 << 17),
    COVER_MASK_DONT_PRINT_EXCLUDED         = (1 << 18)

--- a/test/regress/cover12.sh
+++ b/test/regress/cover12.sh
@@ -1,0 +1,12 @@
+set -xe
+
+pwd
+which nvc
+
+nvc -a $TESTDIR/regress/cover12.vhd -e --cover=toggle,exclude-unreachable cover12 -r
+nvc -c --report html work/_WORK.COVER12.elab.covdb 2>&1 | tee out.txt
+
+nvc -a $TESTDIR/regress/cover12.vhd -e --cover=toggle cover12 -r
+nvc -c --report html work/_WORK.COVER12.elab.covdb 2>&1 | tee -a out.txt
+
+diff -u $TESTDIR/regress/gold/cover12.txt out.txt

--- a/test/regress/cover12.vhd
+++ b/test/regress/cover12.vhd
@@ -1,0 +1,83 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity clk_gate is
+    port (
+        clk_in              : in    std_logic;
+        clk_en              : in    std_logic;
+        scan_enable         : in    std_logic;
+        vector_input        : in    std_logic_vector(3 downto 0);
+        clk_out             : out   std_logic
+    );
+end clk_gate;
+
+architecture rtl of clk_gate is
+
+    signal clk_en_q : std_logic;
+
+begin
+
+    -- Latch
+    process(clk_in, scan_enable, clk_en)
+    begin
+        if (clk_in = '0') then
+            clk_en_q <= (clk_en or scan_enable);
+        end if;
+    end process;
+
+    clk_out <= clk_in and clk_en_q;
+
+end architecture;
+
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity cover12 is
+end entity;
+
+architecture test of cover12 is
+
+    signal clk                  : std_logic;
+    signal my_clock_gate_signal : std_logic := '0';
+    signal clk_gated            : std_logic;
+
+begin
+
+    i_clk_gate : entity work.clk_gate
+    port map (
+        clk_in              => clk,
+        clk_en              => my_clock_gate_signal,
+        scan_enable         => '0',
+        vector_input        => "0000",
+        clk_out             => clk_gated
+    );
+
+    clk_gen_proc : process
+    begin
+        for i in 0 to 10 loop
+            clk <= '0';
+            wait for 5 ns;
+            clk <= '1';
+            wait for 5 ns;
+        end loop;
+        wait;
+    end process;
+
+    test_ctrl_proc: process
+    begin
+        wait for 1 ns;
+        wait until rising_edge(clk);
+
+        wait for 1 ns;
+        my_clock_gate_signal <= '1';
+        wait until rising_edge(clk);
+
+        wait until rising_edge(clk);
+        my_clock_gate_signal <= '0';
+        wait until rising_edge(clk);
+
+        wait;
+    end process;
+
+end architecture;

--- a/test/regress/gold/cover12.txt
+++ b/test/regress/gold/cover12.txt
@@ -1,0 +1,14 @@
+** Note: Code coverage report folder: html.
+** Note: Code coverage report contains: covered, uncovered, excluded coverage details.
+** Note: code coverage results for: WORK.COVER12
+** Note:      statement:     N.A.
+** Note:      branch:        N.A.
+** Note:      toggle:        100.0 % (24/24)
+** Note:      expression:    N.A.
+** Note: Code coverage report folder: html.
+** Note: Code coverage report contains: covered, uncovered, excluded coverage details.
+** Note: code coverage results for: WORK.COVER12
+** Note:      statement:     N.A.
+** Note:      branch:        N.A.
+** Note:      toggle:        58.3 % (14/24)
+** Note:      expression:    N.A.

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -716,4 +716,8 @@ stdenv3         normal,2019
 issue603        normal
 cover11         cover,shell
 issue609        normal
+<<<<<<< HEAD
 implicit5       normal
+=======
+cover12         cover,shell
+>>>>>>> test: Add cover12 to test exclusion of constant driven port.

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -716,8 +716,5 @@ stdenv3         normal,2019
 issue603        normal
 cover11         cover,shell
 issue609        normal
-<<<<<<< HEAD
 implicit5       normal
-=======
 cover12         cover,shell
->>>>>>> test: Add cover12 to test exclusion of constant driven port.


### PR DESCRIPTION
This MR adds basic exclude support on unreachable toggles on instance ports.
Unreachability is remembered in run-time data and checked during report
generation if according CLI option is set. Exclude reason is now placed in
third column of excluded bins to distinguish between the ones coming from
exclude file and automatically excluded bins.

The implementation handles `std_logic` and `std_logic_vector`.

The MR does not handle the cases where part of the port is driven by non-const
value (e.g. single bit of a vector, or single field of a record port).