### PR TITLE
Add parsing changes for LCS-2016-071a.

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -5098,8 +5098,13 @@ static void p_interface_list(class_t def_class, tree_t parent, tree_kind_t kind)
 
    p_interface_element(def_class, parent, kind);
 
-   while (optional(tSEMI))
+   while (optional(tSEMI)) {
+      if (peek() == tRPAREN) {
+         require_std(STD_19, "optional trailing semicolons on interface lists");
+         break;
+      }
       p_interface_element(def_class, parent, kind);
+   }
 }
 
 static void p_port_list(tree_t parent)

--- a/test/parse/vhdl2019.vhd
+++ b/test/parse/vhdl2019.vhd
@@ -1,3 +1,11 @@
+-- LCS-2016-071a: Trailing semicolion
+entity ent is
+  port (
+    a : in  boolean ;
+    b : out boolean ;
+  ) ;
+end entity ;
+
 -- LCS-2016-082: Empty record
 package pack is
 

--- a/www/features.html.in
+++ b/www/features.html.in
@@ -150,12 +150,18 @@ table below.
         LCS2016_030</td>
     <td>Garbage collection</td>
     <td class="feature-done">1.7</td>
-  </tr>      
+  </tr>
   <tr>
     <td><a href="http://www.eda-twiki.org/cgi-bin/view.cgi/P1076/LCS2016_061">
         LCS2016_061</td>
     <td>Conditional compilation</td>
     <td class="feature-done">1.4</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.eda-twiki.org/cgi-bin/view.cgi/P1076/LCS2016_071a">
+        LCS2016_071a</td>
+    <td>Optional Trailing Semicolon</td>
+    <td class="feature-done">master</td>
   </tr>
   <tr>
     <td><a href="http://www.eda-twiki.org/cgi-bin/view.cgi/P1076/LCS2016_082">


### PR DESCRIPTION
This allows for optional trailing semicolon on interface lists.