### PR TITLE
Adding VHDL-2019 to OSVVM installation.

### DIFF
--- a/contrib/install-osvvm.tcl
+++ b/contrib/install-osvvm.tcl
@@ -2,7 +2,7 @@ source "Scripts/StartNVC.tcl"
 set ::osvvm::VhdlLibraryDirectory "${::env(NVC_INSTALL_DEST)}"
 set ::osvvm::VhdlLibrarySubdirectory "."
 
-foreach std {2008} {
+foreach std {2008 2019} {
     SetVHDLVersion $std
     source "OsvvmLibraries.pro"
 }


### PR DESCRIPTION
Add a VHDL-2019 compiled installation to OSVVM when installing from nvc.