### PR TITLE
Add parsing changes for LCS-2016-086.

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -4643,8 +4643,9 @@ static void p_interface_constant_declaration(tree_t parent, tree_kind_t kind)
       add_interface(parent, d, kind);
       sem_check(d, nametab);
 
-      if (kind == T_GENERIC_DECL && standard() >= STD_08) {
+      if ((standard() >= STD_19) || (kind == T_GENERIC_DECL && standard() >= STD_08)) {
          // Generics are immediately visible in VHDL-2008
+         // Everything is immediately visible in VHDL-2019
          insert_name(nametab, d, NULL);
       }
    }
@@ -4691,6 +4692,10 @@ static void p_interface_signal_declaration(tree_t parent, tree_kind_t kind)
 
       add_interface(parent, d, kind);
       sem_check(d, nametab);
+
+      // 2019: Ports and generics are immediately visible
+      if (standard() >= STD_19)
+         insert_name(nametab, d, NULL);
    }
 }
 
@@ -4730,6 +4735,9 @@ static void p_interface_variable_declaration(tree_t parent, tree_kind_t kind)
 
       add_interface(parent, d, kind);
       sem_check(d, nametab);
+
+      if (standard() >= STD_19)
+         insert_name(nametab, d, NULL);
    }
 }
 
@@ -4757,6 +4765,9 @@ static void p_interface_file_declaration(tree_t parent, tree_kind_t kind)
 
       add_interface(parent, d, kind);
       sem_check(d, nametab);
+
+      if (standard() >= STD_19)
+         insert_name(nametab, d, NULL);
    }
 }
 
@@ -7097,7 +7108,6 @@ static tree_t p_subprogram_body(tree_t spec)
    push_scope(nametab);
    scope_set_subprogram(nametab, spec);
 
-   insert_generics(nametab, spec);
    insert_ports(nametab, spec);
 
    sem_check(spec, nametab);

--- a/src/parse.c
+++ b/src/parse.c
@@ -4643,8 +4643,11 @@ static void p_interface_constant_declaration(tree_t parent, tree_kind_t kind)
       add_interface(parent, d, kind);
       sem_check(d, nametab);
 
-      if ((standard() >= STD_19) || (kind == T_GENERIC_DECL && standard() >= STD_08)) {
+      if (kind == T_GENERIC_DECL && standard() >= STD_08) {
          // Generics are immediately visible in VHDL-2008
+         insert_name(nametab, d, NULL);
+      }
+      else if (standard() >= STD_19) {
          // Everything is immediately visible in VHDL-2019
          insert_name(nametab, d, NULL);
       }

--- a/src/parse.c
+++ b/src/parse.c
@@ -7108,6 +7108,7 @@ static tree_t p_subprogram_body(tree_t spec)
    push_scope(nametab);
    scope_set_subprogram(nametab, spec);
 
+   insert_generics(nametab, spec);
    insert_ports(nametab, spec);
 
    sem_check(spec, nametab);

--- a/test/parse/vhdl2019.vhd
+++ b/test/parse/vhdl2019.vhd
@@ -13,3 +13,10 @@ package pack is
     end record ;
 
 end package ;
+
+-- LCS-2016-086
+entity E is
+    generic (G1: INTEGER; G2: INTEGER := G1; G3, G4, G5, G6: INTEGER;G7:G6'SUBTYPE);
+    port (P1: STRING(G3 to G4); P2: STRING(P1'RANGE); P3: P1'SUBTYPE);
+    procedure X (Y1, Y2: INTEGER; Y3: INTEGER range Y1 to Y2; Y4: Y1'SUBTYPE);
+end E;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -3725,8 +3725,19 @@ START_TEST(test_vhdl2019)
    set_standard(STD_19);
    input_from_file(TESTDIR "/parse/vhdl2019.vhd");
 
-   tree_t e = parse();
-   fail_if(e == NULL);
+   tree_t e071a = parse();
+   fail_if(e071a == NULL);
+   fail_unless(tree_kind(e071a) == T_ENTITY);
+
+   tree_t p082 = parse();
+   fail_if(p082 == NULL);
+   fail_unless(tree_kind(p082) == T_PACKAGE);
+
+   tree_t e086 = parse();
+   fail_if(e086 == NULL);
+   fail_unless(tree_kind(e086) == T_ENTITY);
+
+   fail_unless(parse() == NULL);
 
    fail_if_errors();
 }

--- a/www/features.html.in
+++ b/www/features.html.in
@@ -169,4 +169,10 @@ table below.
     <td>Empty Record</td>
     <td class="feature-done">master</td>
   </tr>
+  <tr>
+    <td><a href="http://www.eda-twiki.org/cgi-bin/view.cgi/P1076/LCS2016_086">
+        LCS2016_086</td>
+    <td>All Interface Lists Can be Ordered</td>
+    <td class="feature-done">master</td>
+  </tr>
 </table>


### PR DESCRIPTION
All interface lists can be ordered.

This allows for entities and subprograms to reference earlier elements in the interface list.