### PR TITLE
Update entity name list parsing.

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -5270,6 +5270,7 @@ static ident_t p_entity_designator()
    ident_t id = p_identifier();
 
    if (peek() == tLSQUARE) {
+      // XXX: Review what to do here
       type_t constraints = p_signature();
    }
    return id;
@@ -5281,17 +5282,12 @@ static ident_list_t *p_entity_name_list(void)
    ident_list_t *result = NULL;
 
    switch (peek()) {
-   // LRM-2019 7.2 - Attribute Specification
    case tOTHERS:
-      // Attribute applies to the names entities of the class declared in the
-      // immediately enclosing declarative part, provided that each such entity
-      // is not explicitly named in the entity name list of the previous
-      // attribute specification for the given attribute. Error if this isn't
-      // the last attribute for the given entity class.
+      consume(tOTHERS);
+      break;
    case tALL:
-      // Attribute applies to all named entities of the class declared in the
-      // immediately enclosing declarative part. Error if this isn't the last
-      // attribute for the given entity class.
+      consume(tALL);
+      ident_list_push(&result, well_known(W_ALL), last_loc);
       break;
    default:
       ident_list_push(&result, p_entity_designator(), last_loc);
@@ -5323,10 +5319,6 @@ static void p_attribute_specification(tree_t parent, add_func_t addf)
    BEGIN("attribute specification");
 
    consume(tATTRIBUTE);
-   // entity_name_list ::=
-   //   entity_designator { , entity_designator }
-   //  |others
-   //  |all
    ident_t head = p_identifier();
 
    type_t type;

--- a/src/parse.c
+++ b/src/parse.c
@@ -5271,7 +5271,8 @@ static ident_t p_entity_designator()
 
    if (peek() == tLSQUARE) {
       // XXX: Review what to do here
-      type_t constraints = p_signature();
+      (void)p_signature();
+      warn_at(CURRENT_LOC, "sorry, signature in attribute entity name list is not yet supported");
    }
    return id;
 }


### PR DESCRIPTION
When working with the [all08.vhdl](https://github.com/ghdl/ghdl/blob/c33f41e4612347d1fcbb9a37bc82249d7b8366eb/testsuite/sanity/004all08/all08.vhdl) file from the GHDL repository, there was a parsing error with the following:

```vhdl
  attribute user_attr of clear [std_logic_vector]: procedure is true;
```

The LRM states that the `entity_name_list` can be a list of `entity_designator` which could also include a `signature`.  It can also be the keywords `all` or `others`, if they are the last attribute for that particular class in the declarative part.  It's an error if they aren't the last.

With that being said, this gets past the parsing issue because of the other parsing examples in the file, but obviously things aren't correct with the tree entries.

`nvc` subsequently dies later in the analysis, but I believe it's more due to generics being applied than this parsing.