### PR TITLE
Add LCS-2016-055a (Optional Component Ending).

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -4842,7 +4842,7 @@ static tree_t p_interface_function_specification(void)
 
    // 2019:
    // [ pure | impure ] function designator
-   //    [ [ parameter ] ( formal_parameter_list ) ] 
+   //    [ [ parameter ] ( formal_parameter_list ) ]
    //    return [ return_identifier of ] type_mark
 
    BEGIN("interface function specification");
@@ -6148,7 +6148,7 @@ static tree_t p_subprogram_specification(void)
 
    // 2019:
    //  [ pure | impure ] function designator subprogram_header
-   //       [ [parameter] ( formal_parameter_list ) ] 
+   //       [ [parameter] ( formal_parameter_list ) ]
    //       return [ return_identifier of ] type_mark
 
    BEGIN("subprogram specification");
@@ -7479,6 +7479,10 @@ static tree_t p_component_declaration(void)
    // component identifier [ is ] [ generic_clause ] [ port_clause ]
    //   end component [ simple_name ] ;
 
+   // 2019:
+   // component identifier [ is ] [ generic_clause ] [ port_clause ]
+   //   end [ component ] [ simple_name ] ;
+
    BEGIN("component declaration");
 
    tree_t c = tree_new(T_COMPONENT);
@@ -7501,7 +7505,12 @@ static tree_t p_component_declaration(void)
    pop_scope(nametab);
 
    consume(tEND);
-   consume(tCOMPONENT);
+   if (peek() != tCOMPONENT) {
+      require_std(STD_19, "optional end component");
+      optional(tCOMPONENT);
+   }
+   else
+      consume(tCOMPONENT);
    p_trailing_label(tree_ident(c));
    consume(tSEMI);
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -7505,10 +7505,8 @@ static tree_t p_component_declaration(void)
    pop_scope(nametab);
 
    consume(tEND);
-   if (peek() != tCOMPONENT) {
+   if (peek() != tCOMPONENT)
       require_std(STD_19, "optional end component");
-      optional(tCOMPONENT);
-   }
    else
       consume(tCOMPONENT);
    p_trailing_label(tree_ident(c));

--- a/test/parse/vhdl2019.vhd
+++ b/test/parse/vhdl2019.vhd
@@ -19,6 +19,17 @@ package body pack006f is
 
 end package body ;
 
+-- LCS-2016-055a: Syntax Regularization for endings
+package pack055a is
+
+    component silly is
+      port (
+        a : bit_vector
+      ) ;
+    end ;
+
+end package ;
+
 -- LCS-2016-071a: Trailing semicolion
 entity ent is
   port (

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -3723,7 +3723,7 @@ END_TEST
 START_TEST(test_vhdl2019)
 {
    const error_t expect[] = {
-      { 39, "declaration of variable RV cannot have unconstrained type RV_T" },
+      { 50, "declaration of variable RV cannot have unconstrained type RV_T" },
       { -1, NULL }
    };
    expect_errors(expect);
@@ -3740,6 +3740,10 @@ START_TEST(test_vhdl2019)
    tree_t pb006f = parse();
    fail_if(pb006f == NULL);
    fail_unless(tree_kind(pb006f) == T_PACK_BODY);
+
+   tree_t p055a = parse();
+   fail_if(p055a == NULL);
+   fail_unless(tree_kind(p055a) == T_PACKAGE);
 
    tree_t e071a = parse();
    fail_if(e071a == NULL);

--- a/www/features.html.in
+++ b/www/features.html.in
@@ -329,7 +329,7 @@ table below.
     <td><a href="http://www.eda-twiki.org/cgi-bin/view.cgi/P1076/LCS2016_055a">
         LCS2016-055a</td>
     <td>Syntax Regulatization - component declarations</td>
-    <td class="feature-missing"></td>
+    <td class="feature-done">master</td>
   </tr>
   <tr>
     <td><a href="http://www.eda-twiki.org/cgi-bin/view.cgi/P1076/LCS2016_059">


### PR DESCRIPTION
Makes the `component` keyword at the end of a component declaration optional.