### PR TITLE
src: Add coverage-spec

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@
 - NVC is now supported by [VUnit](https://vunit.github.io/).
 - Implicit signal attributes like `'transaction` are now considered
   static signal names (#640).
+- Add support for fine-grained coverage collection via
+  `--coverage-spec` elab option (#567).
 
 ## Version 1.8.2 - 2023-02-14
 - Fixed "failed to suspend thread" crash on macOS.

--- a/nvc.1
+++ b/nvc.1
@@ -704,6 +704,15 @@ An example of coverage specification file is following:
 # Example how to disable collecting code coverage on entity or block:
 -block clock_gate_model
 .Ed
+In Coverage specification file
+.Ql block
+has priority over
+.Ql hierarchy
+, disabled hierarchy / block (
+.Ql -
+) has priority over enabled hierarchy / block (
+.Ql +
+).
 .Ss Exclude file
 NVC can exclude any coverage items when generating code coverage report.
 When a coverage item is excluded, it is counted as "Covered" in the

--- a/nvc.1
+++ b/nvc.1
@@ -213,6 +213,14 @@ Enable code coverage reporting (see the
 .Sx CODE COVERAGE
 section below).
 .\"
+.It Fl -cover-spec= Ns Ar sfile
+Specify design part where code coverage is collected by
+.Ar sfile
+coverage specification file
+(see the
+.Sx CODE COVERAGE
+section below).
+.\"
 .It Fl -dump-llvm
 Write generated LLVM IR to the work library directory before and after
 optimisation.
@@ -670,6 +678,32 @@ Toggle coverage collection on specific signals can be also disabled:
 signal cnt : std_logic_vector(3 downto 0);
 -- coverage on
 .Ed
+.Ss Coverage specification file
+NVC can collect code coverage only on part of the simulated design.
+When Coverage specification file is passed during elaboration time,
+NVC collects code coverage only as specified in this file. If
+the file is ommited, NVC collects code coverage on whole design.
+Format of commands in coverage specification file is following:
+.Bd -literal -offset indent
+(+|-)block <ENTITY_NAME>
+(+|-)hierarchy <HIERARCHY>
+.Ed
+An example of coverage specification file is following:
+.Bd -literal -offset indent
+# Placing '#' is treated as comment till end of line
+
+# Example how to enable collecting code coverage on a hierarchy:
++hierarchy WORK.TOP.DUT_INST*
+
+# Example how to disable collecting code coverage on a hierarchy:
+-hierarchy WORK.TOP.DUT_INST.THIRD_PARTY_SUB_BLOCK_INST*
+
+# Example how to enable collecting code coverage on entity or block:
++block async_fifo
+
+# Example how to disable collecting code coverage on entity or block:
+-block clock_gate_model
+.Ed
 .Ss Exclude file
 NVC can exclude any coverage items when generating code coverage report.
 When a coverage item is excluded, it is counted as "Covered" in the
@@ -751,6 +785,15 @@ exclude WORK.TOP._P0._S0._B0 BIN_FALSE
 exclude WORK.TOP.SIGNAL_NAME BIN_0_TO_1
 exclude WORK.TOP.SUB_BLOCK_INST.PORT_NAME
 .Ed
+.Ss Additional Information
+In Coverage specification file and Exclude file
+.Ql <ENTITY_NAME>
+and
+.Ql <HIERARCHY>
+are case-insensitive. You can get examples of
+.Ql <HIERARCHY>
+from generated Code coverage report by clicking on
+a "Get Exclude Command" button.
 .\" ------------------------------------------------------------
 .\" Relaxed rules
 .\" ------------------------------------------------------------

--- a/src/lower.c
+++ b/src/lower.c
@@ -10817,17 +10817,23 @@ lower_unit_t *lower_instance(lower_unit_t *parent, cover_tagging_t *cover,
    lower_unit_t *lu = lower_unit_new(parent, vu, cover, block);
 
    if (cover_enabled(lu->cover, COVER_MASK_ALL)) {
-      lower_unit_t *it;
-      for (it = lu; it != NULL; it = it->parent) {
-         if (it->hier == NULL)
-            continue;
 
-         tree_t unit = tree_ref(it->hier);
-         if (tree_kind(unit) == T_ARCH) {
-            ident_t ename = ident_rfrom(tree_ident(tree_primary(unit)), '.');
-            cover_set_block_name(lu->cover, ename);
+      // Need to find corresponding T_HIER in advance before hier
+      // of lower_scope_t is assigned.
+      tree_t inst_hier = NULL;
+      for (int i = 0; i < tree_decls(block); i++) {
+         tree_t decl = tree_decl(block, i);
+         if (tree_kind(decl) == T_HIER) {
+            inst_hier = decl;
             break;
          }
+      }
+      assert(inst_hier != NULL);
+
+      tree_t unit = tree_ref(inst_hier);
+      if (tree_kind(unit) == T_ARCH) {
+         ident_t ename = ident_rfrom(tree_ident(tree_primary(unit)), '.');
+         cover_set_block_name(lu->cover, ename);
       }
 
       cover_add_tag(block, NULL, lu->cover, TAG_HIER, COV_FLAG_HIER_DOWN);

--- a/src/lower.c
+++ b/src/lower.c
@@ -10820,7 +10820,7 @@ lower_unit_t *lower_instance(lower_unit_t *parent, cover_tagging_t *cover,
       tree_t hier = tree_decl(block, 0);
       assert(tree_kind(hier) == T_HIER);
 
-      tree_t unit = tree_ref(inst_hier);
+      tree_t unit = tree_ref(hier);
       if (tree_kind(unit) == T_ARCH) {
          ident_t ename = ident_rfrom(tree_ident(tree_primary(unit)), '.');
          cover_set_block_name(lu->cover, ename);

--- a/src/lower.c
+++ b/src/lower.c
@@ -10817,18 +10817,8 @@ lower_unit_t *lower_instance(lower_unit_t *parent, cover_tagging_t *cover,
    lower_unit_t *lu = lower_unit_new(parent, vu, cover, block);
 
    if (cover_enabled(lu->cover, COVER_MASK_ALL)) {
-
-      // Need to find corresponding T_HIER in advance before hier
-      // of lower_scope_t is assigned.
-      tree_t inst_hier = NULL;
-      for (int i = 0; i < tree_decls(block); i++) {
-         tree_t decl = tree_decl(block, i);
-         if (tree_kind(decl) == T_HIER) {
-            inst_hier = decl;
-            break;
-         }
-      }
-      assert(inst_hier != NULL);
+      tree_t hier = tree_decl(block, 0);
+      assert(tree_kind(hier) == T_HIER);
 
       tree_t unit = tree_ref(inst_hier);
       if (tree_kind(unit) == T_ARCH) {

--- a/src/lower.c
+++ b/src/lower.c
@@ -10816,8 +10816,22 @@ lower_unit_t *lower_instance(lower_unit_t *parent, cover_tagging_t *cover,
 
    lower_unit_t *lu = lower_unit_new(parent, vu, cover, block);
 
-   if (cover_enabled(lu->cover, COVER_MASK_ALL))
+   if (cover_enabled(lu->cover, COVER_MASK_ALL)) {
+      lower_unit_t *it;
+      for (it = lu; it != NULL; it = it->parent) {
+         if (it->hier == NULL)
+            continue;
+
+         tree_t unit = tree_ref(it->hier);
+         if (tree_kind(unit) == T_ARCH) {
+            ident_t ename = ident_rfrom(tree_ident(tree_primary(unit)), '.');
+            cover_set_block_name(lu->cover, ename);
+            break;
+         }
+      }
+
       cover_add_tag(block, NULL, lu->cover, TAG_HIER, COV_FLAG_HIER_DOWN);
+   }
 
    tree_t hier = tree_decl(block, 0);
    assert(tree_kind(hier) == T_HIER);

--- a/src/nvc.c
+++ b/src/nvc.c
@@ -296,17 +296,19 @@ static int parse_optimise_level(const char *str)
 static int elaborate(int argc, char **argv)
 {
    static struct option long_options[] = {
-      { "dump-llvm",   no_argument,       0, 'd' },
-      { "dump-vcode",  optional_argument, 0, 'v' },
-      { "cover",       optional_argument, 0, 'c' },
-      { "verbose",     no_argument,       0, 'V' },
-      { "no-save",     no_argument,       0, 'N' },
-      { "jit",         no_argument,       0, 'j' },
+      { "dump-llvm",       no_argument,       0, 'd' },
+      { "dump-vcode",      optional_argument, 0, 'v' },
+      { "cover",           optional_argument, 0, 'c' },
+      { "cover-spec",      required_argument, 0, 's' },
+      { "verbose",         no_argument,       0, 'V' },
+      { "no-save",         no_argument,       0, 'N' },
+      { "jit",             no_argument,       0, 'j' },
       { 0, 0, 0, 0 }
    };
 
    bool use_jit = false;
    cover_mask_t cover_mask = 0;
+   char *cover_spec_file = NULL;
    int cover_array_limit = 0;
    const int next_cmd = scan_cmd(2, argc, argv);
    int c, index = 0;
@@ -340,6 +342,9 @@ static int elaborate(int argc, char **argv)
       case 'g':
          parse_generic(optarg);
          break;
+      case 's':
+         cover_spec_file = optarg;
+         break;
       case 0:
          // Set a flag
          break;
@@ -369,6 +374,9 @@ static int elaborate(int argc, char **argv)
    cover_tagging_t *cover = NULL;
    if (cover_mask != 0)
       cover = cover_tags_init(cover_mask, cover_array_limit);
+
+   if (cover_spec_file)
+      cover_load_spec_file(cover, cover_spec_file);
 
    tree_t top = elab(unit, cover);
    if (top == NULL)

--- a/src/nvc.c
+++ b/src/nvc.c
@@ -372,11 +372,12 @@ static int elaborate(int argc, char **argv)
    progress("loading top-level unit");
 
    cover_tagging_t *cover = NULL;
-   if (cover_mask != 0)
+   if (cover_mask != 0) {
       cover = cover_tags_init(cover_mask, cover_array_limit);
 
-   if (cover_spec_file)
-      cover_load_spec_file(cover, cover_spec_file);
+      if (cover_spec_file)
+         cover_load_spec_file(cover, cover_spec_file);
+   }
 
    tree_t top = elab(unit, cover);
    if (top == NULL)

--- a/src/rt/cover.c
+++ b/src/rt/cover.c
@@ -52,12 +52,14 @@ typedef struct {
 
 typedef A(cover_tag_t) tag_array_t;
 typedef A(line_range_t) range_array_t;
+typedef A(text_buf_t*) tb_array_t;
 
 typedef struct _cover_report_ctx    cover_report_ctx_t;
 typedef struct _cover_file          cover_file_t;
 typedef struct _cover_scope         cover_scope_t;
 typedef struct _cover_exclude_ctx   cover_exclude_ctx_t;
 typedef struct _cover_rpt_buf       cover_rpt_buf_t;
+typedef struct _cover_spec          cover_spec_t;
 
 typedef struct _cover_scope {
    ident_t        name;
@@ -67,6 +69,7 @@ typedef struct _cover_scope {
    cover_scope_t *parent;
    range_array_t  ignore_lines;
    int            sig_pos;
+   bool           emit;
 } cover_scope_t;
 
 struct _cover_rpt_buf {
@@ -74,20 +77,29 @@ struct _cover_rpt_buf {
    cover_rpt_buf_t *prev;
 };
 
+struct _cover_spec {
+   tb_array_t hier_include;
+   tb_array_t hier_exclude;
+   tb_array_t block_include;
+   tb_array_t block_exclude;
+};
+
 struct _cover_tagging {
-   int               next_stmt_tag;
-   int               next_branch_tag;
-   int               next_toggle_tag;
-   int               next_expression_tag;
-   int               next_hier_tag;
-   ident_t           hier;
-   tag_array_t       tags;
-   cover_mask_t      mask;
-   int               array_limit;
-   int               array_depth;
-   int               report_item_limit;
-   cover_rpt_buf_t  *rpt_buf;
-   cover_scope_t    *top_scope;
+   int                  next_stmt_tag;
+   int                  next_branch_tag;
+   int                  next_toggle_tag;
+   int                  next_expression_tag;
+   int                  next_hier_tag;
+   ident_t              hier;
+   ident_t              block_name;
+   tag_array_t          tags;
+   cover_mask_t         mask;
+   int                  array_limit;
+   int                  array_depth;
+   int                  report_item_limit;
+   cover_rpt_buf_t     *rpt_buf;
+   cover_spec_t        *spec;
+   cover_scope_t       *top_scope;
 };
 
 typedef struct {
@@ -294,6 +306,9 @@ cover_tag_t *cover_add_tag(tree_t t, ident_t suffix, cover_tagging_t *ctx,
    int *cnt;
    assert (ctx != NULL);
 
+   if (!ctx->top_scope->emit && kind != TAG_HIER)
+      return NULL;
+
    // TODO: need a better way to determine if a scope comes from an instance
    cover_scope_t *ignore_scope = ctx->top_scope;
    for (; ignore_scope->ignore_lines.count == 0 && ignore_scope->parent;
@@ -458,6 +473,31 @@ void cover_reset_scope(cover_tagging_t *tagging, ident_t hier)
    tagging->hier = hier;
 }
 
+bool cover_should_emit_scope(cover_tagging_t *tagging, tree_t t)
+{
+   // Hierarchy
+   for (int i = 0; i < tagging->spec->hier_exclude.count; i++)
+      if (ident_glob(tagging->hier, tb_get(AGET(tagging->spec->hier_exclude, i)), -1))
+         return false;
+
+   for (int i = 0; i < tagging->spec->hier_include.count; i++)
+      if (ident_glob(tagging->hier, tb_get(AGET(tagging->spec->hier_include, i)), -1))
+         return true;
+
+   // Block (entity, package instance or block) name
+   if (tagging->block_name) {
+      for (int i = 0; i < tagging->spec->block_exclude.count; i++)
+         if (ident_glob(tagging->block_name, tb_get(AGET(tagging->spec->block_exclude, i)), -1))
+            return false;
+
+      for (int i = 0; i < tagging->spec->block_include.count; i++)
+         if (ident_glob(tagging->block_name, tb_get(AGET(tagging->spec->block_include, i)), -1))
+            return true;
+   }
+
+   return false;
+}
+
 void cover_push_scope(cover_tagging_t *tagging, tree_t t)
 {
    if (tagging == NULL || t == NULL)
@@ -513,9 +553,16 @@ void cover_push_scope(cover_tagging_t *tagging, tree_t t)
    tagging->top_scope = s;
    tagging->hier = ident_prefix(tagging->hier, name, '.');
 
+   s->emit = true;
+   if (tagging->spec) {
+      s->emit = false;
+      s->emit = cover_should_emit_scope(tagging, t);
+   }
+
 #ifdef COVER_DEBUG_SCOPE
    printf("Pushing cover scope: %s\n", istr(tagging->hier));
    printf("Tree_kind: %s\n\n", tree_kind_str(tree_kind(t)));
+   printf("Coverage emit: %d\n\n", s->emit);
 #endif
 }
 
@@ -538,6 +585,13 @@ void cover_pop_scope(cover_tagging_t *tagging)
 
    tagging->hier = ident_runtil(tagging->hier, '.');
    assert(tagging->hier != NULL);
+}
+
+void cover_set_block_name(cover_tagging_t *tagging, ident_t name)
+{
+   assert(tagging != NULL);
+
+   tagging->block_name = name;
 }
 
 void cover_ignore_from_pragmas(cover_tagging_t *tagging, tree_t unit)
@@ -714,6 +768,76 @@ void cover_count_tags(cover_tagging_t *tagging, int32_t *n_stmts,
       *n_expressions = tagging->next_expression_tag;
    }
 }
+
+void cover_load_spec_file(cover_tagging_t *tagging, const char *path)
+{
+   cover_exclude_ctx_t ctx = {};
+
+   ctx.ef = fopen(path, "r");
+   if (ctx.ef == NULL)
+      fatal_errno("failed to open coverage specification file: %s\n", path);
+
+   tagging->spec = xcalloc(sizeof(cover_spec_t));
+
+   char *delim = " ";
+   ssize_t read;
+   loc_file_ref_t file_ref = loc_file_ref(path, NULL);
+   int line_num = 1;
+   size_t line_len;
+
+   while ((read = getline(&(ctx.line), &line_len, ctx.ef)) != -1) {
+
+      // Strip comments and newline
+      char *p = ctx.line;
+      for (; *p != '\0' && *p != '#' && *p != '\n'; p++);
+      *p = '\0';
+
+      ctx.loc = get_loc(line_num, 0, line_num, p - ctx.line - 1, file_ref);
+
+      // Parse line as space separated tokens
+      for (char *tok = strtok(ctx.line, delim); tok; tok = strtok(NULL, delim)) {
+         bool include;
+         if (tok[0] == '+')
+            include = true;
+         else if (tok[0] == '-')
+            include = false;
+         else
+            fatal_at(&ctx.loc, "Coverage specification command must "
+                               "start with '+' or '-");
+         tok++;
+
+         tb_array_t *arr;
+         if (!strcmp(tok, "hierarchy")) {
+            if (include)
+               arr = &(tagging->spec->hier_include);
+            else
+               arr = &(tagging->spec->hier_exclude);
+         }
+         else if (!strcmp(tok, "block")) {
+            if (include)
+               arr = &(tagging->spec->block_include);
+            else
+               arr = &(tagging->spec->block_exclude);
+         }
+         else
+            fatal_at(&ctx.loc, "invalid command: $bold$%s$$", tok);
+
+         char *hier = strtok(NULL, delim);
+            if (!hier)
+               fatal_at(&ctx.loc, "%s name missing", tok);
+
+         text_buf_t *tb = tb_new();
+         tb_printf(tb, "%s", hier);
+         APUSH(*arr, tb);
+
+         tok = strtok(NULL, delim);
+      }
+      line_num++;
+   }
+
+   fclose(ctx.ef);
+}
+
 
 ///////////////////////////////////////////////////////////////////////////////
 // Runtime handling

--- a/src/rt/cover.c
+++ b/src/rt/cover.c
@@ -823,7 +823,7 @@ void cover_load_spec_file(cover_tagging_t *tagging, const char *path)
          else if (tok[0] == '-')
             include = false;
          else
-            fatal_at(&ctx.loc, "Coverage specification command must "
+            fatal_at(&ctx.loc, "coverage specification command must "
                                "start with '+' or '-");
          tok++;
 

--- a/src/rt/cover.c
+++ b/src/rt/cover.c
@@ -579,11 +579,7 @@ void cover_push_scope(cover_tagging_t *tagging, tree_t t)
    tagging->top_scope = s;
    tagging->hier = ident_prefix(tagging->hier, name, '.');
 
-   s->emit = true;
-   if (tagging->spec) {
-      s->emit = false;
-      s->emit = cover_should_emit_scope(tagging, t);
-   }
+   s->emit = (tagging->spec && cover_should_emit_scope(tagging, t));
 
 #ifdef COVER_DEBUG_SCOPE
    printf("Pushing cover scope: %s\n", istr(tagging->hier));

--- a/src/rt/cover.c
+++ b/src/rt/cover.c
@@ -800,7 +800,7 @@ void cover_load_spec_file(cover_tagging_t *tagging, const char *path)
 
    tagging->spec = xcalloc(sizeof(cover_spec_t));
 
-   char *delim = " ";
+   const char *delim = " ";
    ssize_t read;
    loc_file_ref_t file_ref = loc_file_ref(path, NULL);
    int line_num = 1;

--- a/src/rt/cover.c
+++ b/src/rt/cover.c
@@ -474,7 +474,7 @@ void cover_reset_scope(cover_tagging_t *tagging, ident_t hier)
    tagging->hier = hier;
 }
 
-bool cover_should_emit_scope(cover_tagging_t *tagging, tree_t t)
+static bool cover_should_emit_scope(cover_tagging_t *tagging, tree_t t)
 {
    cover_scope_t *ts = tagging->top_scope;
    cover_spec_t *spc = tagging->spec;

--- a/src/rt/cover.c
+++ b/src/rt/cover.c
@@ -34,6 +34,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <time.h>
+#include <ctype.h>
 
 //#define COVER_DEBUG_EMIT
 //#define COVER_DEBUG_DUMP
@@ -1161,6 +1162,12 @@ void cover_load_exclude_file(const char *path, cover_tagging_t *tagging)
 
             if (!excl_hier)
                fatal_at(&ctx.loc, "exclude hierarchy missing!");
+
+            int i = 0;
+            while (excl_hier[i]) {
+               excl_hier[i] = toupper(excl_hier[i]);
+               i++;
+            }
 
             cover_exclude_hier(tagging, &ctx, excl_hier, bin);
          }

--- a/src/rt/cover.c
+++ b/src/rt/cover.c
@@ -86,20 +86,20 @@ struct _cover_spec {
 };
 
 struct _cover_tagging {
-   int                  next_stmt_tag;
-   int                  next_branch_tag;
-   int                  next_toggle_tag;
-   int                  next_expression_tag;
-   int                  next_hier_tag;
-   ident_t              hier;
-   tag_array_t          tags;
-   cover_mask_t         mask;
-   int                  array_limit;
-   int                  array_depth;
-   int                  report_item_limit;
-   cover_rpt_buf_t     *rpt_buf;
-   cover_spec_t        *spec;
-   cover_scope_t       *top_scope;
+   int               next_stmt_tag;
+   int               next_branch_tag;
+   int               next_toggle_tag;
+   int               next_expression_tag;
+   int               next_hier_tag;
+   ident_t           hier;
+   tag_array_t       tags;
+   cover_mask_t      mask;
+   int               array_limit;
+   int               array_depth;
+   int               report_item_limit;
+   cover_rpt_buf_t  *rpt_buf;
+   cover_spec_t     *spec;
+   cover_scope_t    *top_scope;
 };
 
 typedef struct {
@@ -615,7 +615,6 @@ void cover_pop_scope(cover_tagging_t *tagging)
 void cover_set_block_name(cover_tagging_t *tagging, ident_t name)
 {
    assert(tagging != NULL);
-
    tagging->top_scope->block_name = name;
 }
 

--- a/src/rt/cover.h
+++ b/src/rt/cover.h
@@ -166,8 +166,10 @@ bool cover_enabled(cover_tagging_t *tagging, cover_mask_t mask);
 void cover_reset_scope(cover_tagging_t *tagging, ident_t hier);
 void cover_push_scope(cover_tagging_t *tagging, tree_t t);
 void cover_pop_scope(cover_tagging_t *tagging);
+void cover_set_block_name(cover_tagging_t *tagging, ident_t name);
 
 void cover_ignore_from_pragmas(cover_tagging_t *tagging, tree_t unit);
+void cover_load_spec_file(cover_tagging_t *tagging, const char *path);
 
 void cover_inc_array_depth(cover_tagging_t *tagging);
 void cover_dec_array_depth(cover_tagging_t *tagging);

--- a/src/util.c
+++ b/src/util.c
@@ -1364,6 +1364,12 @@ void tb_downcase(text_buf_t *tb)
       tb->buf[i] = tolower((int)tb->buf[i]);
 }
 
+void tb_upcase(text_buf_t *tb)
+{
+   for (size_t i = 0; i < tb->len; i++)
+      tb->buf[i] = toupper((int)tb->buf[i]);
+}
+
 void tb_replace(text_buf_t *tb, char old, char rep)
 {
    for (size_t i = 0; i < tb->len; i++) {

--- a/src/util.h
+++ b/src/util.h
@@ -270,6 +270,7 @@ void tb_rewind(text_buf_t *tb);
 void tb_trim(text_buf_t *tb, size_t newlen);
 size_t tb_len(text_buf_t *tb);
 void tb_downcase(text_buf_t *tb);
+void tb_upcase(text_buf_t *tb);
 void tb_replace(text_buf_t *tb, char old, char rep);
 
 #define LOCAL __attribute__((cleanup(_local_free)))

--- a/test/regress/cover13.sh
+++ b/test/regress/cover13.sh
@@ -1,0 +1,12 @@
+set -xe
+
+pwd
+which nvc
+
+nvc -a $TESTDIR/regress/cover13.vhd -e --cover=all --cover-spec=$TESTDIR/regress/data/cover13_spec.txt cover13 -r
+nvc -c -V --report html work/_WORK.COVER13.elab.covdb 2>&1 | tee out.txt
+
+# Filter out info lines with verbose that throw amount of allocated memory
+sed -i -e 1,3d out.txt
+
+diff -u $TESTDIR/regress/gold/cover13.txt out.txt

--- a/test/regress/cover13.vhd
+++ b/test/regress/cover13.vhd
@@ -1,0 +1,159 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+
+
+entity leaf_entity is
+    port (
+        a              : in    std_logic;
+        b              : out   std_logic
+    );
+end leaf_entity;
+
+architecture test of leaf_entity is
+
+begin
+
+    inv : process (a)
+    begin
+        b <= not a;
+    end process;
+
+    process
+    begin
+        wait for 1 ns;
+        report "HALOO";
+        wait for 1 ns;
+        report "NEXT HALOO";
+        wait for 1 ns;
+        wait;
+    end process;
+
+end architecture;
+
+
+-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity not_interesting_entity is
+    port (
+        a              : in    std_logic;
+        b              : out   std_logic
+    );
+end not_interesting_entity;
+
+architecture test of not_interesting_entity is
+
+begin
+
+    b <= not a;
+
+end architecture;
+
+-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity level_2 is
+end entity;
+
+architecture test of level_2 is
+
+begin
+
+    process
+    begin
+        wait for 1 ns;
+        report "Message from level_2";
+        wait for 1 ns;
+        wait;
+    end process;
+
+end architecture;
+
+
+-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity level_1 is
+end entity;
+
+architecture test of level_1 is
+
+begin
+
+    level_2_inst : entity work.level_2;
+
+    not_interesting_entity_inst : entity work.not_interesting_entity
+    port map (
+        a    => '1',
+        b    => open
+    );
+
+    process
+    begin
+        wait for 1 ns;
+        report "Message from level_1";
+        wait for 1 ns;
+        wait;
+    end process;
+
+end architecture;
+
+
+-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity cover13 is
+end cover13;
+
+architecture test of cover13 is
+
+    signal a    : std_logic;
+    signal b    : std_logic;
+
+begin
+
+    leaf_entity_inst : entity work.leaf_entity
+    port map (
+        a    => a,
+        b    => b
+    );
+
+    not_interesting_entity_inst : entity work.not_interesting_entity
+    port map (
+        a    => a,
+        b    => open
+    );
+
+    level_1_inst : entity work.level_1;
+
+    process
+    begin
+        wait for 1 ns;
+        a <= '1';
+        wait for 1 ns;
+        a <= '0';
+        wait for 1 ns;
+
+        wait;
+    end process;
+
+end architecture;
+

--- a/test/regress/data/cover13_spec.txt
+++ b/test/regress/data/cover13_spec.txt
@@ -1,0 +1,6 @@
+
++block leaf_entity
+-block not_interesting_entity
+
++hierarchy WORK.COVER13.level_1_inst.*
+-hierarchy WORK.COVER13.level_1_inst.LEVEL_2_INST.*

--- a/test/regress/data/cover9_ef1.txt
+++ b/test/regress/data/cover9_ef1.txt
@@ -9,7 +9,7 @@ exclude WORK.COVER9.SUB_BLOCK_INST.*
 ###############################################################################
 exclude WORK.COVER9.AND_GATE._S0._B0._S0
 exclude WORK.COVER9._P1._S0._S3
-exclude WORK.COVER9._P1._S0._S4
+exclude WORK.COVER9._p1._S0._S4
 exclude WORK.COVER9._P1._S0._S5
 
 ###############################################################################
@@ -23,14 +23,14 @@ exclude WORK.COVER9.AND_GATE._S0._B0 BIN_TRUE
 exclude WORK.COVER9._P1._S0._B3._B0 BIN_CHOICE
 
 # Choices excluded without bin name
-exclude WORK.COVER9._P1._S0._B4._B0
+exclude WORK.COVER9._P1._s0._B4._B0
 exclude WORK.COVER9._P1._S0._B_OTHERS
 
 ###############################################################################
 # Test expression excluding
 ###############################################################################
 exclude WORK.COVER9._P0._S0._E0 BIN_0_0
-exclude WORK.COVER9._P0._S0._E0 BIN_0_1
+exclude WORK.cover9._P0._S0._E0 BIN_0_1
 exclude WORK.COVER9._P0._S0._E0 BIN_1_0
 exclude WORK.COVER9._P0._S0._E0 BIN_1_1
 

--- a/test/regress/gold/cover13.txt
+++ b/test/regress/gold/cover13.txt
@@ -1,0 +1,14 @@
+** Note: Code coverage report folder: html.
+** Note: Code coverage report contains: covered, uncovered, excluded coverage details.
+** Note: code coverage results for: WORK.COVER13
+** Note:      statement:     100.0 % (11/11)
+** Note:      branch:        N.A.
+** Note:      toggle:        50.0 % (2/4)
+** Note:      expression:    N.A.
+** Note: Coverage for sub-hierarchies:
+Hierarchy                                               Statement            Branch               Toggle               Expression          
+   LEVEL_1_INST                                          100.0 % (4/4)         0.0 % (0/0)        0.0 % (0/0)        0.0 % (0/0)
+     NOT_INTERESTING_ENTITY_INST                           0.0 % (0/0)         0.0 % (0/0)        0.0 % (0/0)        0.0 % (0/0)
+     LEVEL_2_INST                                          0.0 % (0/0)         0.0 % (0/0)        0.0 % (0/0)        0.0 % (0/0)
+   NOT_INTERESTING_ENTITY_INST                             0.0 % (0/0)         0.0 % (0/0)        0.0 % (0/0)        0.0 % (0/0)
+   LEAF_ENTITY_INST                                      100.0 % (7/7)         0.0 % (0/0)       50.0 % (2/4)        0.0 % (0/0)

--- a/test/regress/gold/cover9.txt
+++ b/test/regress/gold/cover9.txt
@@ -136,7 +136,7 @@
 ** Note: excluding statement: 'WORK.COVER9._P1._S0._S4'
     > data/cover9_ef1.txt:12
     |
- 12 | exclude WORK.COVER9._P1._S0._S4
+ 12 | exclude WORK.COVER9._p1._S0._S4
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ** Note: excluding statement: 'WORK.COVER9._P1._S0._S5'
     > data/cover9_ef1.txt:13
@@ -156,7 +156,7 @@
 ** Note: excluding branch: 'WORK.COVER9._P1._S0._B4._B0' bins: BIN_CHOICE
     > data/cover9_ef1.txt:26
     |
- 26 | exclude WORK.COVER9._P1._S0._B4._B0
+ 26 | exclude WORK.COVER9._P1._s0._B4._B0
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ** Note: excluding branch: 'WORK.COVER9._P1._S0._B_OTHERS' bins: BIN_CHOICE
     > data/cover9_ef1.txt:27
@@ -171,7 +171,7 @@
 ** Note: excluding expression: 'WORK.COVER9._P0._S0._E0' bins: BIN_0_1
     > data/cover9_ef1.txt:33
     |
- 33 | exclude WORK.COVER9._P0._S0._E0 BIN_0_1
+ 33 | exclude WORK.cover9._P0._S0._E0 BIN_0_1
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ** Note: excluding expression: 'WORK.COVER9._P0._S0._E0' bins: BIN_1_0
     > data/cover9_ef1.txt:34

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -734,4 +734,8 @@ issue640        normal
 vests49         normal
 signal30        normal
 psl1            normal,psl
+<<<<<<< HEAD
 elab36          normal
+=======
+cover13         cover,shell
+>>>>>>> 66acdbd1 (test: Add cover13 to test block/hierarchy name exclusions.)

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -734,8 +734,5 @@ issue640        normal
 vests49         normal
 signal30        normal
 psl1            normal,psl
-<<<<<<< HEAD
 elab36          normal
-=======
 cover13         cover,shell
->>>>>>> 66acdbd1 (test: Add cover13 to test block/hierarchy name exclusions.)


### PR DESCRIPTION
This MR adds `coverage-spec` argument to `elaborate`. A coverage specification file shall be passed
to this option. Coverage specification file allows controlling hierarchy / entity names on which coverage
is collected. Following is allowed within coverage specification file:

`(+|-)hierarchy <HIERARCHY>`  - Enables/disables collecting coverage for given hierarchy
`(+|-)block <BLOCK_NAME>`  - Enables/disables collecting coverage for given entity names / block names

Tests and manual edit still to be added in this MR.