### PR TITLE
Coverage expr unreachable

### DIFF
--- a/src/lower.c
+++ b/src/lower.c
@@ -1820,7 +1820,7 @@ static vcode_reg_t lower_logical(lower_unit_t *lu, tree_t fcall,
          vcode_reg_t c_true = emit_const(vc_int, COV_FLAG_TRUE);
          vcode_reg_t c_false = emit_const(vc_int, COV_FLAG_FALSE);
          vcode_reg_t mask = emit_select(result, c_true, c_false);
-         flags |= COV_FLAG_TRUE | COV_FLAG_FALSE;
+         flags = COV_FLAG_TRUE | COV_FLAG_FALSE;
          lower_expression_coverage(lu, fcall, flags, mask, unrc_msk);
       }
    default:

--- a/src/rt/cover.h
+++ b/src/rt/cover.h
@@ -102,7 +102,7 @@ typedef struct _cover_tag {
    // Exclude mask - Bit corresponding to a bin excludes it
    int32_t        excl_msk;
 
-   // Unreachable mask - Bit corresponding to a bin indicates bin is un-reachable!
+   // Unreachable mask - Bit corresponding to a bin indicates bin is un-reachable
    int32_t        unrc_msk;
 
    // Location in the source file

--- a/src/rt/cover.h
+++ b/src/rt/cover.h
@@ -102,6 +102,9 @@ typedef struct _cover_tag {
    // Exclude mask - Bit corresponding to a bin excludes it
    int32_t        excl_msk;
 
+   // Unreachable mask - Bit corresponding to a bin indicates bin is un-reachable!
+   int32_t        unrc_msk;
+
    // Location in the source file
    loc_t          loc;
 
@@ -126,8 +129,8 @@ typedef enum {
    COV_FLAG_TOGGLE_TO_1    = (1 << 16),
    COV_FLAG_TOGGLE_SIGNAL  = (1 << 17),
    COV_FLAG_TOGGLE_PORT    = (1 << 18),
-   COV_FLAG_EXPR_STD_LOGIC = (1 << 24),
-   COV_FLAG_UNREACHABLE    = (1 << 25)
+   COV_FLAG_CONST_DRIVEN   = (1 << 19),
+   COV_FLAG_EXPR_STD_LOGIC = (1 << 24)
 } cover_flags_t;
 
 #define COVER_FLAGS_AND_EXPR (COV_FLAG_11 | COV_FLAG_10 | COV_FLAG_01)

--- a/test/regress/cover14.sh
+++ b/test/regress/cover14.sh
@@ -1,0 +1,12 @@
+set -xe
+
+pwd
+which nvc
+
+nvc -a $TESTDIR/regress/cover14.vhd -e --cover=expression,exclude-unreachable cover14 -r
+nvc -c --report html work/_WORK.COVER14.elab.covdb --exclude-file $TESTDIR/regress/data/cover14_ef1.txt 2>&1 | tee out.txt
+
+# Adjust output to be work directory relative
+sed -i -e "s/[^ ]*regress\/data\//data\//g" out.txt
+
+diff -u $TESTDIR/regress/gold/cover14.txt out.txt

--- a/test/regress/cover14.vhd
+++ b/test/regress/cover14.vhd
@@ -1,0 +1,30 @@
+entity cover14 is
+end cover14;
+
+architecture test of cover14 is
+
+    signal x   : integer := 10;
+    signal y   : integer := 0;
+
+    signal res : boolean;
+    signal res_2 : boolean;
+
+begin
+
+    res <= (y /= 0) and ((x / y) = 1);
+
+    -- Should not execute div by zero if the first condition is met
+    -- if not, then it is not div by zero
+    res_2 <= (y = 0) or ((x / y) = 1);
+
+    process
+    begin
+        x <= 10;
+        wait for 1 ns;
+        y <= 5;
+        wait for 1 ns;
+        wait;
+    end process;
+
+end architecture;
+

--- a/test/regress/data/cover14_ef1.txt
+++ b/test/regress/data/cover14_ef1.txt
@@ -1,0 +1,2 @@
+exclude WORK.COVER14._P0._S0._E2 BIN_1_1
+exclude WORK.COVER14._P1._S0._E2 BIN_0_1

--- a/test/regress/gold/cover14.txt
+++ b/test/regress/gold/cover14.txt
@@ -1,0 +1,17 @@
+** Note: excluding expression: 'WORK.COVER14._P0._S0._E2' bins: BIN_1_1
+   > data/cover14_ef1.txt:1
+   |
+ 1 | exclude WORK.COVER14._P0._S0._E2 BIN_1_1
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+** Note: excluding expression: 'WORK.COVER14._P1._S0._E2' bins: BIN_0_1
+   > data/cover14_ef1.txt:2
+   |
+ 2 | exclude WORK.COVER14._P1._S0._E2 BIN_0_1
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+** Note: Code coverage report folder: html.
+** Note: Code coverage report contains: covered, uncovered, excluded coverage details.
+** Note: code coverage results for: WORK.COVER14
+** Note:      statement:     N.A.
+** Note:      branch:        N.A.
+** Note:      toggle:        N.A.
+** Note:      expression:    85.7 % (12/14)

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -752,3 +752,4 @@ slice5          normal
 access12        normal
 arith5          fail,gold
 real4           fail,gold
+cover14         cover,shell


### PR DESCRIPTION
This MR adds the last part of "exluding unreachable" coverage bins (for now).

Un-reachable expression bins are automatically flagged and excluded in the
generated report. "Unreachability mask" is remembered per-tag and separated
from "exclude mask". Exclude mask is dropped from cov-db, since its meaning
is now only during report generation time.