### PR TITLE
src: Add parsing of Compound SERE

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -247,6 +247,7 @@ BIT           ?i:bit
 BITVECTOR     ?i:bitvector
 NUMERIC       ?i:numeric
 STRING_K      ?i:string
+WITHIN        ?i:within
 
 %%
 
@@ -481,6 +482,8 @@ STRING_K      ?i:string
 <PSL>"[+]"               { TOKEN(tPLUSRPT); }
 <PSL>"[="                { TOKEN(tGOTORPT); }
 <PSL>"[->"               { TOKEN(tARROWRPT); }
+<PSL>"&&"                { TOKEN(tDBLAMP); }
+<PSL>{WITHIN}            { TOKEN(tWITHIN); }
 
 <VLOG>"module"           { return tMODULE; }
 <VLOG>"endmodule"        { return tENDMODULE; }

--- a/src/object.c
+++ b/src/object.c
@@ -64,7 +64,7 @@ typedef struct _object_arena {
                           | I_NAME | I_SPEC | I_RESOLUTION              \
                           | I_LEFT | I_RIGHT | I_TYPE | I_BASE | I_ELEM \
                           | I_ACCESS | I_RESULT | I_FILE | I_PRIMARY    \
-                          | I_GUARD | I_FOREIGN | I_CLOCK)
+                          | I_GUARD | I_FOREIGN | I_CLOCK | I_REPEAT)
 #define ITEM_OBJ_ARRAY   (I_DECLS | I_STMTS | I_PORTS | I_GENERICS      \
                           | I_WAVES | I_CONDS | I_TRIGGERS | I_CONSTR   \
                           | I_PARAMS | I_GENMAPS | I_ASSOCS | I_CONTEXT \

--- a/src/psl/psl-fsm.c
+++ b/src/psl/psl-fsm.c
@@ -66,7 +66,7 @@ static void build_implication(psl_fsm_t *fsm, fsm_state_t *state, psl_node_t p)
    case P_NEXT:
       {
          fsm_state_t *new = add_state(fsm);
-         add_edge(state, new, EDGE_NEXT, psl_operand(psl_operand(p, 0), 0));
+         add_edge(state, new, EDGE_NEXT, psl_operand(p, 0));
          build_node(fsm, new, psl_value(rhs));
       }
       break;

--- a/src/psl/psl-fsm.c
+++ b/src/psl/psl-fsm.c
@@ -89,9 +89,12 @@ static void build_sere(psl_fsm_t *fsm, fsm_state_t *state, psl_node_t p)
       psl_node_t rhs = psl_operand(p, i);
       switch (psl_subkind(p)) {
       case PSL_SERE_CONCAT:
-         fsm_state_t *new = add_state(fsm);
-         add_edge(state, new, EDGE_NEXT, psl_value(rhs));
-         build_node(fsm, new, rhs);
+         {
+            fsm_state_t *new = add_state(fsm);
+            add_edge(state, new, EDGE_NEXT, psl_value(rhs));
+            build_node(fsm, new, rhs);
+         }
+         break;
       default:
          CANNOT_HANDLE(p);
       }

--- a/src/psl/psl-node.c
+++ b/src/psl/psl-node.c
@@ -81,7 +81,7 @@ static const imask_t has_map[P_LAST_PSL_KIND] = {
    (I_REF | I_PARAMS),
 
    // P_SEQUENCE_INST
-   (I_REF | I_PARAMS),
+   (I_REF | I_PARAMS | I_CLOCK | I_REPEAT),
 };
 
 static const char *kind_text_map[P_LAST_PSL_KIND] = {
@@ -349,6 +349,11 @@ psl_node_t psl_repeat(psl_node_t p)
    item_t *item = lookup_item(&psl_object, p, I_REPEAT);
    assert(item->object != NULL);
    return container_of(item->object, struct _psl_node, object);
+}
+
+bool psl_has_repeat(psl_node_t p)
+{
+   return lookup_item(&psl_object, p, I_REPEAT)->object != NULL;
 }
 
 object_t *psl_to_object(psl_node_t p)

--- a/src/psl/psl-node.h
+++ b/src/psl/psl-node.h
@@ -139,6 +139,7 @@ psl_node_t psl_ref(psl_node_t p);
 
 void psl_set_repeat(psl_node_t p, psl_node_t r);
 psl_node_t psl_repeat(psl_node_t p);
+bool psl_has_repeat(psl_node_t p);
 
 void psl_locus(psl_node_t p, ident_t *unit, ptrdiff_t *offset);
 

--- a/src/psl/psl-node.h
+++ b/src/psl/psl-node.h
@@ -79,6 +79,18 @@ typedef enum {
    PSL_ARROW_REPEAT
 } psl_repeat_t;
 
+typedef enum {
+   PSL_SERE_CONCAT,
+   PSL_SERE_FUSION,
+   PSL_SERE_OR,
+   PSL_SERE_EQU_AND,
+   PSL_SERE_NEQ_AND,
+   PSL_SERE_WITHIN,
+   PSL_SERE_PARAM_NEQ_AND,
+   PSL_SERE_PARAM_EQU_AND,
+   PSL_SERE_PARAM_OR
+} psl_sere_kind_t;
+
 psl_node_t psl_new(psl_kind_t kind);
 psl_kind_t psl_kind(psl_node_t p);
 const char *psl_kind_str(psl_kind_t kind);

--- a/src/scan.h
+++ b/src/scan.h
@@ -266,5 +266,7 @@ void reset_verilog_parser(void);
 #define tPLUSRPT       378
 #define tGOTORPT       379
 #define tARROWRPT      380
+#define tDBLAMP        381
+#define tWITHIN        382
 
 #endif  // _SCAN_H

--- a/test/psl/parse4.vhd
+++ b/test/psl/parse4.vhd
@@ -54,4 +54,8 @@ begin
 
     -- psl cover {a;b;c} @ rising_edge(clk);
 
+    -- psl cover {a:b}[*4 to 5];
+
+    -- psl cover a;
+
 end architecture;

--- a/test/psl/parse4.vhd
+++ b/test/psl/parse4.vhd
@@ -2,10 +2,10 @@ Library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-entity parse3 is
+entity parse4 is
 end entity;
 
-architecture test of parse3 is
+architecture test of parse4 is
 
     signal a, b, c, clk : bit;
 
@@ -53,9 +53,5 @@ begin
     -- psl cover {a;b} [[signal sig : unsigned(3 downto 0); sig <= "0000";]];
 
     -- psl cover {a;b;c} @ rising_edge(clk);
-
-    -- psl cover {a:b}[*4 to 5];
-
-    -- psl cover a;
 
 end architecture;

--- a/test/psl/parse5.vhd
+++ b/test/psl/parse5.vhd
@@ -1,0 +1,32 @@
+Library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity parse5 is
+end entity;
+
+architecture test of parse5 is
+
+    signal a, b, c, d, e, f, clk : bit;
+
+begin
+
+    -- psl default clock is rising_edge(clk);
+
+    -- psl cover {a:b:c:d};
+
+    -- psl cover {a;b:c};
+
+    -- psl cover {{a}|{b}};
+    -- psl cover {a[*5]|b[+]};
+    -- psl cover {{a;b}|{c;d}|{d;a}};
+
+    -- psl cover {{a;b} within {c;d;e;f}};
+
+    -- psl cover {{a;b;c} && {d;e;f}};
+
+    -- psl cover {{a;b;c} & {d;e}};
+
+    -- psl cover {{a:b} & {c;d} && {e;f} | {d;e}};
+
+end architecture;

--- a/test/test_psl.c
+++ b/test/test_psl.c
@@ -153,10 +153,8 @@ START_TEST(test_parse4)
 
    psl_node_t p3 = tree_psl(tree_stmt(a, 3));
    psl_node_t p3_v = psl_value(p3);
-   psl_node_t p3_v_op = psl_operand(p3_v, 0);
    fail_unless(psl_kind(p3) == P_COVER);
-   fail_unless(psl_kind(p3_v) == P_SERE);
-   fail_unless(psl_kind(p3_v_op) == P_SEQUENCE_INST);
+   fail_unless(psl_kind(p3_v) == P_SEQUENCE_INST);
 
 
    psl_node_t p6 = tree_psl(tree_stmt(a, 6));
@@ -237,7 +235,7 @@ START_TEST(test_parse5)
    fail_unless(psl_subkind(p0_v) == PSL_SERE_FUSION);
    fail_unless(psl_kind(p1_v0) == P_SERE);
    fail_unless(psl_subkind(p1_v0) == PSL_SERE_CONCAT);
-   fail_unless(psl_kind(p1_v1) == P_SERE);
+   fail_unless(psl_kind(p1_v1) == P_HDL_EXPR);
 
    psl_node_t p2 = tree_psl(tree_stmt(a, 3));
    psl_node_t p2_v = psl_value(p2);
@@ -298,11 +296,11 @@ START_TEST(test_dump)
    tb_rewind(tb);
 
    psl_dump(tree_psl(tree_stmt(a, 1)));
-   ck_assert_str_eq(tb_get(tb), "assert never {B}");
+   ck_assert_str_eq(tb_get(tb), "assert never B");
    tb_rewind(tb);
 
    psl_dump(tree_psl(tree_stmt(a, 6)));
-   ck_assert_str_eq(tb_get(tb), "assert {{A}; {\"and\"(B, C)}}");
+   ck_assert_str_eq(tb_get(tb), "assert {A; \"and\"(B, C)}");
    tb_rewind(tb);
 
    fail_if_errors();

--- a/test/test_psl.c
+++ b/test/test_psl.c
@@ -213,6 +213,75 @@ START_TEST(test_parse4)
 }
 END_TEST
 
+START_TEST(test_parse5)
+{
+   opt_set_int(OPT_PSL_COMMENTS, 1);
+
+   input_from_file(TESTDIR "/psl/parse5.vhd");
+
+   tree_t a = parse_and_check(T_ENTITY, T_ARCH);
+
+   psl_node_t p0 = tree_psl(tree_stmt(a, 1));
+   psl_node_t p0_v = psl_value(p0);
+   fail_unless(psl_kind(p0) == P_COVER);
+   fail_unless(psl_kind(p0_v) == P_SERE);
+   fail_unless(psl_subkind(p0_v) == PSL_SERE_FUSION);
+   fail_unless(psl_operands(p0_v) == 4);
+
+   psl_node_t p1 = tree_psl(tree_stmt(a, 2));
+   psl_node_t p1_v = psl_value(p1);
+   psl_node_t p1_v0 = psl_operand(p1_v, 0);
+   psl_node_t p1_v1 = psl_operand(p1_v, 1);
+   fail_unless(psl_kind(p1_v) == P_SERE);
+   // Check right-most tree
+   fail_unless(psl_subkind(p0_v) == PSL_SERE_FUSION);
+   fail_unless(psl_kind(p1_v0) == P_SERE);
+   fail_unless(psl_subkind(p1_v0) == PSL_SERE_CONCAT);
+   fail_unless(psl_kind(p1_v1) == P_SERE);
+
+   psl_node_t p2 = tree_psl(tree_stmt(a, 3));
+   psl_node_t p2_v = psl_value(p2);
+   fail_unless(psl_kind(p2_v) == P_SERE);
+   fail_unless(psl_subkind(p2_v) == PSL_SERE_OR);
+
+   psl_node_t p3 = tree_psl(tree_stmt(a, 4));
+   psl_node_t p3_v = psl_value(p3);
+   psl_node_t p3_v0 = psl_operand(p3_v, 0);
+   psl_node_t p3_v1 = psl_operand(p3_v, 1);
+   psl_node_t p3_v0_r = psl_repeat(p3_v0);
+   fail_unless(psl_kind(p3_v) == P_SERE);
+   fail_unless(psl_subkind(p3_v) == PSL_SERE_OR);
+   fail_unless(psl_kind(p3_v0) == P_SERE);
+   fail_unless(psl_kind(p3_v1) == P_SERE);
+   fail_unless(psl_subkind(p3_v0_r) == PSL_TIMES_REPEAT);
+
+   psl_node_t p4 = tree_psl(tree_stmt(a, 5));
+   psl_node_t p4_v = psl_value(p4);
+   psl_node_t p4_v0 = psl_operand(p4_v, 0);
+   fail_unless(psl_kind(p4_v) == P_SERE);
+   fail_unless(psl_subkind(p4_v) == PSL_SERE_OR);
+   fail_unless(psl_subkind(p4_v0) == PSL_SERE_CONCAT);
+
+   psl_node_t p5 = tree_psl(tree_stmt(a, 6));
+   psl_node_t p5_v = psl_value(p5);
+   fail_unless(psl_kind(p5_v) == P_SERE);
+   fail_unless(psl_subkind(p5_v) == PSL_SERE_WITHIN);
+
+   psl_node_t p6 = tree_psl(tree_stmt(a, 7));
+   psl_node_t p6_v = psl_value(p6);
+   fail_unless(psl_kind(p6_v) == P_SERE);
+   fail_unless(psl_subkind(p6_v) == PSL_SERE_EQU_AND);
+
+   psl_node_t p7 = tree_psl(tree_stmt(a, 8));
+   psl_node_t p7_v = psl_value(p7);
+   fail_unless(psl_kind(p7_v) == P_SERE);
+   fail_unless(psl_subkind(p7_v) == PSL_SERE_NEQ_AND);
+
+   fail_if_errors();
+}
+END_TEST
+
+
 START_TEST(test_dump)
 {
    opt_set_int(OPT_PSL_COMMENTS, 1);
@@ -250,6 +319,7 @@ Suite *get_psl_tests(void)
    tcase_add_test(tc_core, test_sem1);
    tcase_add_test(tc_core, test_parse3);
    tcase_add_test(tc_core, test_parse4);
+   tcase_add_test(tc_core, test_parse5);
    tcase_add_test(tc_core, test_dump);
    suite_add_tcase(s, tc_core);
 

--- a/test/test_psl.c
+++ b/test/test_psl.c
@@ -229,11 +229,11 @@ START_TEST(test_dump)
    tb_rewind(tb);
 
    psl_dump(tree_psl(tree_stmt(a, 1)));
-   ck_assert_str_eq(tb_get(tb), "assert never B");
+   ck_assert_str_eq(tb_get(tb), "assert never {B}");
    tb_rewind(tb);
 
    psl_dump(tree_psl(tree_stmt(a, 6)));
-   ck_assert_str_eq(tb_get(tb), "assert {A; \"and\"(B, C)}");
+   ck_assert_str_eq(tb_get(tb), "assert {{A}; {\"and\"(B, C)}}");
    tb_rewind(tb);
 
    fail_if_errors();


### PR DESCRIPTION
Adds parsing of `SERE` and `Compound_SERE`. SEREs are parsed recursively. If a SERE
contains chain of SEREs connectd with the same operator (e.g. `{a;b;c;d;e}`) the top most
SERE is a single SERE.