### PR TITLE
Cover conditional return test

### DIFF
--- a/src/simp.c
+++ b/src/simp.c
@@ -972,7 +972,7 @@ static tree_t simp_return(tree_t t)
             assert(i == nconds - 1);
 
          tree_t s = tree_new(T_RETURN);
-         tree_set_loc(s, tree_loc(t));
+         tree_set_loc(s, tree_loc(tree_result(e)));
          tree_set_value(s, tree_result(e));
 
          tree_add_stmt(c, s);

--- a/test/regress/cover15.sh
+++ b/test/regress/cover15.sh
@@ -1,0 +1,12 @@
+set -xe
+
+pwd
+which nvc
+
+nvc --std=2019 -a $TESTDIR/regress/cover15.vhd -e --cover=statement,branch cover15 -r
+nvc -c --report html work/_WORK.COVER15.elab.covdb  2>&1 | tee out.txt
+
+# Adjust output to be work directory relative
+sed -i -e "s/[^ ]*regress\/data\//data\//g" out.txt
+
+diff -u $TESTDIR/regress/gold/cover15.txt out.txt

--- a/test/regress/cover15.vhd
+++ b/test/regress/cover15.vhd
@@ -1,0 +1,30 @@
+entity cover15 is
+end cover15;
+
+architecture test of cover15 is
+
+begin
+
+    process
+        function crop_and_saturate_time(p : in time) return integer is
+        begin
+            return 0 when (p < 10 ns) else
+                   10 when (p < 20 ns) else
+                   20 when (p < 30 ns) else
+                   30 when (p < 40 ns) else
+                   40;
+        end function;
+    begin
+        wait for 1 ns;
+        report integer'image(crop_and_saturate_time(now));
+        wait for 10 ns;
+        report integer'image(crop_and_saturate_time(now));
+        wait for 10 ns;
+        report integer'image(crop_and_saturate_time(now));
+
+        wait for 1 ns;
+        wait;
+    end process;
+
+end architecture;
+

--- a/test/regress/gold/cover15.txt
+++ b/test/regress/gold/cover15.txt
@@ -1,0 +1,7 @@
+** Note: Code coverage report folder: html.
+** Note: Code coverage report contains: covered, uncovered, excluded coverage details.
+** Note: code coverage results for: WORK.COVER15
+** Note:      statement:     85.7 % (12/14)
+** Note:      branch:        62.5 % (5/8)
+** Note:      toggle:        N.A.
+** Note:      expression:    N.A.

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -775,3 +775,4 @@ issue690        normal
 issue644        normal,2008
 cond5           normal,2019
 cond6           normal,2019
+cover15         cover,shell


### PR DESCRIPTION
Adds simple test for conditional expression in the return statement.

Minor source modification diversifies location of newly created `T_RETURN` so that when doing code coverage
analysis, different conditional values are highlighted in the report:

![image](https://github.com/nickg/nvc/assets/34539154/63de2422-d987-4893-91f6-ae4620140ab5)

This is the same as if there is a "conditional signal assign", that is converted to sequence of signal assigns
separated by "if" statements. Each new signal assign statement has "loc" corresponding to "result" of
the conditional epression, instead of "loc" from the whole "conditional signal assign" statement.