### PR TITLE
Coverage report enhancements

### DIFF
--- a/src/rt/cover.h
+++ b/src/rt/cover.h
@@ -97,8 +97,12 @@ typedef struct _cover_tag {
    // Unreachable mask - Bit corresponding to a bin indicates bin is un-reachable
    int32_t        unrc_msk;
 
-   // Location in the source file
+   // Location of the tag in the source file
    loc_t          loc;
+
+   // Locations of LHS/RHS operands
+   loc_t          loc_rhs;
+   loc_t          loc_lhs;
 
    // Hierarchy path of the covered object
    ident_t        hier;
@@ -126,6 +130,8 @@ typedef enum {
 #define COVER_FLAGS_AND_EXPR (COV_FLAG_11 | COV_FLAG_10 | COV_FLAG_01)
 #define COVER_FLAGS_OR_EXPR (COV_FLAG_00 | COV_FLAG_10 | COV_FLAG_01)
 #define COVER_FLAGS_XOR_EXPR (COV_FLAG_11 | COV_FLAG_00 | COV_FLAG_10 | COV_FLAG_01)
+
+#define COVER_FLAGS_LHS_RHS_BINS (COV_FLAG_11 | COV_FLAG_00 | COV_FLAG_10 | COV_FLAG_01)
 
 #define COVER_FLAGS_ALL_BINS (COV_FLAG_TRUE | COV_FLAG_FALSE | COV_FLAG_CHOICE | \
                               COV_FLAG_00 | COV_FLAG_01 | COV_FLAG_10 | COV_FLAG_11 | \

--- a/src/rt/cover.h
+++ b/src/rt/cover.h
@@ -107,6 +107,12 @@ typedef struct _cover_tag {
    // Hierarchy path of the covered object
    ident_t        hier;
 
+   // Name of the function for expression coverage
+   ident_t        func_name;
+
+   // Type of underlying tree object
+   tree_kind_t    tree_kind;
+
    // Start position for signal name
    int            sig_pos;
 } cover_tag_t;
@@ -178,8 +184,9 @@ unsigned cover_get_std_log_expr_flags(tree_t decl);
 
 fbuf_t *cover_open_lib_file(tree_t top, fbuf_mode_t mode, bool check_null);
 
-cover_tag_t *cover_add_tag(tree_t t, ident_t suffix, cover_tagging_t *ctx,
-                           tag_kind_t kind, uint32_t flags);
+cover_tag_t *cover_add_tag(tree_t t, const loc_t *loc, ident_t suffix,
+                           cover_tagging_t *ctx, tag_kind_t kind,
+                           uint32_t flags);
 
 void cover_load_exclude_file(const char *path, cover_tagging_t *tagging);
 void cover_report(const char *path, cover_tagging_t *tagging, int item_limit);


### PR DESCRIPTION
This MR contains bunch of improvements in Code coverage report generation. I tried to focus on clarity of the generated report since it seems to me that current format is not very "self-explaining".

From user perspective following changes:
- Multiline code samples are printed complete (If they are too long, middle lines are skipped)
![image](https://github.com/nickg/nvc/assets/34539154/181a3f60-9c5b-4974-9468-33dc7db236b6)
![image](https://github.com/nickg/nvc/assets/34539154/5e10e23d-e25e-4771-8fc2-04afb3e4bffb)

- Line numbers are shown before the line
- Statement kind is shown. Branch "type/category" is shown. Expression name is shown. 
![image](https://github.com/nickg/nvc/assets/34539154/5bc99eda-b280-49a2-9d8d-21c36c2afb69)

- For single line expressions, `LHS` and `RHS` hints are given with arrows. This is usefull for nested expressions: 
![image](https://github.com/nickg/nvc/assets/34539154/d58442ec-39ab-4606-9768-eb2cff37543a)

I hope this helps for better debugability of code coverage. Still, there is a small drawback, that multi-line
source code is printed without any hints. This is OK for long statements or branches (its somewhat
clear what statement/branch the report reffers to). For expressions, this is worse. E.g. following is confusing:
![image](https://github.com/nickg/nvc/assets/34539154/2008b6b7-91f3-49c5-8270-f3766a2afcb7)

Which `OR` is the report above reffering to? Its not clear. I had an idea of drawing the LHS/RHS arrows
also under each line, but then I need to compute where exactly to put those arrows. Plus, the code
sample would be interrupted by those arrows. Maybe better approach would be using different
background color for each of the `LHS` and `RHS` and throwing out the arrows completely. Background
color of LHS / RHS in the bin table would then correspond to background color in code sample.
OTOH, the report already uses some colors so adding another ones might make it less readable.
Also, all the corner-case of properly coloring LHS and RHS with multi-line code sample where some
of the middle lines get skipped can be tricky...

Consider this last topic as a small TODO.

 Implementation-wise, following changed:
- Cover tag no longer keeps the same `loc` as its `tree_t`. This is to distinguish Branch coverage condition location and tree kind.
- Cover tag has LHS loc and RHS loc that allow drawing LHS/RHS lines
- Cover tag for expression coverage has `func_name` to remember what expression type this is