### PR TITLE
Add VHDL-2019 for VUnit library installation.

### DIFF
--- a/contrib/install-vunit.sh
+++ b/contrib/install-vunit.sh
@@ -13,7 +13,7 @@ fi
 
 git_wrapper https://github.com/VUnit/vunit $tag
 
-for STD in 2008; do
+for STD in 2008 2019; do
   analyse_list vunit_lib$(std_suffix $STD) <<EOF
 vunit/vhdl/data_types/src/types.vhd
 vunit/vhdl/data_types/src/api/external_string_pkg.vhd


### PR DESCRIPTION
Add VHDL-2019 for VUnit library installation.