### PR TITLE
vhpi: Support types from package instances

### DIFF
--- a/src/vhpi/vhpi-model.c
+++ b/src/vhpi/vhpi-model.c
@@ -3183,6 +3183,13 @@ static c_typeDecl *build_typeDecl(type_t type, c_vhpiObject *obj)
             next = s;
       }
 
+      const int ndecls = tree_decls(unit);
+      for (int i = 0; next == NULL && i < ndecls; i++) {
+         tree_t d = tree_decl(unit, i);
+         if (tree_ident(d) == b)
+            next = d;
+      }
+
       if (next == NULL)
          fatal_trace("cannot find %s within %s", istr(b),
                      istr(tree_ident(unit)));

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -867,7 +867,7 @@ ieee14          normal,gold
 ieee15          fail,gold
 issue752        shell
 predef5         normal,2008
-vhpi10          normal,vhpi
+vhpi10          normal,vhpi,2008
 bounds40        fail,gold
 bounds41        fail,gold
 ieee16          normal

--- a/test/regress/vhpi10.vhd
+++ b/test/regress/vhpi10.vhd
@@ -1,3 +1,8 @@
+package counter is
+   generic (MAX: bit_vector);
+   subtype counter_t is bit_vector(MAX'range);
+end;
+
 entity sub is
     generic ( g0 : integer;
               g1 : string );
@@ -37,6 +42,9 @@ architecture test of vhpi10 is
         generic ( g0 : integer; g1 : string );
         port ( p0 : bit_vector );
     end component;
+
+   package pkg is new work.counter generic map (MAX => 10D"999");
+   signal s0: pkg.counter_t;
 begin
 
     b0: block is

--- a/test/vhpi/vhpi10.c
+++ b/test/vhpi/vhpi10.c
@@ -46,6 +46,11 @@ static void start_of_sim(const vhpiCbDataT *cb_data)
    fail_unless(vhpi_scan(it2) == NULL);
    vhpi_release_handle(it2);
 
+   vhpiHandleT s0 = vhpi_handle_by_name("s0", root);
+   check_error();
+   fail_if(s0 == NULL);
+   fail_unless(vhpi_get(vhpiKindP, s0) == vhpiSigDeclK);
+
    vhpiHandleT b0 = vhpi_handle_by_name("b0", root);
    check_error();
    fail_if(b0 == NULL);


### PR DESCRIPTION
Search declarations as well as statements so we can find package instances. This allows VHPI to use signals which have types defined in package instances.