### PR TITLE
Bump JIT_MAX_ARGS

### DIFF
--- a/src/jit/jit-priv.h
+++ b/src/jit/jit-priv.h
@@ -352,7 +352,7 @@ typedef struct {
 
 typedef struct _pack_writer pack_writer_t;
 
-#define JIT_MAX_ARGS 80
+#define JIT_MAX_ARGS 100
 
 typedef struct _jit_interp jit_interp_t;
 


### PR DESCRIPTION
The mem_initialize procedure in the Lattice MachXO3 behavioural simulation libraries takes more arguments than JIT_MAX_ARGS. Bump JIT_MAX_ARGS a bit so that this procedure elaborates.