### PR TITLE
Cov different top hierarchies

### DIFF
--- a/nvc.1
+++ b/nvc.1
@@ -680,6 +680,13 @@ hierarchy coverage report in HTML format, run:
 $ nvc -c --merge=merged.covdb --report=<path_to_folder_for_html_report> \\
       first.covdb second.covdb third.covdb ...
 .Ed
+When NVC merges multiple coverage databse files, coverage items/bins with equal
+hierarchical paths in the elaborated design are merged together. If a coverage
+item/bin is covered in at least one of input coverage databases, it is covered
+in the merged coverage database. NVC creates union of all coverage items from
+all input coverage databases in the merged coverage database. This allows merging
+together coverage from different designs (e.g. where part of the hierarchy
+is formed by "if-generate" statement).
 .Ss Additional code coverage options
 NVC supports the following additional options to control coverage collection:
 .Bl -bullet

--- a/src/cov/cov-report.c
+++ b/src/cov/cov-report.c
@@ -321,8 +321,9 @@ static void cover_print_file_and_inst(FILE *f, cover_report_ctx_t *ctx, cover_sc
 
    cover_file_t *src = cover_file(&(s->loc));
    fprintf(f, "<h2 style=\"margin-left: " MARGIN_LEFT ";\">\n");
-   fprintf(f, "   File:&nbsp; <a href=\"../../%s\">../../%s</a>\n",
-               src->name, src->name);
+   if (src != NULL)
+      fprintf(f, "   File:&nbsp; <a href=\"../../%s\">../../%s</a>\n",
+                  src->name, src->name);
    fprintf(f, "</h2>\n\n");
 }
 
@@ -1178,9 +1179,14 @@ static void cover_report_scope(cover_report_ctx_t *ctx,
    for (int i = 0; i < s->items.count; i++) {
       cover_item_t *item = &(s->items.items[i]);
 
-      cover_file_t *f_src = cover_file(&(item->loc));
-      if (f_src == NULL)
+      loc_t *loc = &(item->loc);
+      cover_file_t *f_src = cover_file(loc);
+      if (f_src == NULL) {
+         warnf("Could not locate source file: %s that NVC used to collect "
+               "coverage for: %s. Dropping coverage for this hierarchy/item "
+               "from coverage report." , loc_file_str(loc), istr(s->hier));
          continue;
+      }
 
       cover_line_t *line = &(f_src->lines[item->loc.first_line-1]);
 

--- a/src/cov/cov-report.c
+++ b/src/cov/cov-report.c
@@ -287,7 +287,8 @@ static void cover_print_html_header(FILE *f)
    fprintf(f, "</header>\n\n");
 }
 
-static void cover_print_navigation_tree(FILE *f, cover_report_ctx_t *ctx, cover_scope_t *s, ...)
+static void cover_print_navigation_tree(FILE *f, cover_report_ctx_t *ctx,
+                                        cover_scope_t *s)
 {
    fprintf(f, "<nav>\n"
                "<b>Hierarchy:</b><br>\n");
@@ -313,7 +314,8 @@ static void cover_print_navigation_tree(FILE *f, cover_report_ctx_t *ctx, cover_
 
 }
 
-static void cover_print_file_and_inst(FILE *f, cover_report_ctx_t *ctx, cover_scope_t *s)
+static void cover_print_file_and_inst(FILE *f, cover_report_ctx_t *ctx,
+                                      cover_scope_t *s)
 {
    fprintf(f, "<h2 style=\"margin-left: " MARGIN_LEFT ";\">\n");
    fprintf(f, "   Instance:&nbsp;%s\n", istr(s->hier));

--- a/test/regress/cover22.sh
+++ b/test/regress/cover22.sh
@@ -1,0 +1,14 @@
+set -xe
+
+pwd
+which nvc
+
+nvc -a --psl $TESTDIR/regress/cover22.vhd -e --cover=statement cover22_a -r
+nvc --work=SECOND_LIB:work -a --psl $TESTDIR/regress/cover22.vhd -e --cover=statement cover22_b -r
+
+nvc -c --report html work/_WORK.COVER22_A.elab.covdb work/_SECOND_LIB.COVER22_B.elab.covdb 2>&1 | tee out.txt
+
+# Adjust output to be work directory relative
+sed -i -e "s/[^ ]*regress\/data\//data\//g" out.txt
+
+diff -u $TESTDIR/regress/gold/cover22.txt out.txt

--- a/test/regress/cover22.vhd
+++ b/test/regress/cover22.vhd
@@ -1,0 +1,34 @@
+entity cover22_a is
+end entity;
+
+architecture test of cover22_a is
+
+begin
+
+    process
+    begin
+        wait for 1 ns;
+        report "Dummy statement in TOP hierarchy A!";
+        wait for 1 ns;
+        wait;
+    end process;
+
+end architecture;
+
+
+entity cover22_b is
+end entity;
+
+architecture test of cover22_b is
+
+begin
+
+    process
+    begin
+        wait for 2 ns;
+        report "Dummy statement in TOP hierarchy B!";
+        wait for 2 ns;
+        wait;
+    end process;
+
+end architecture;

--- a/test/regress/gold/cover22.txt
+++ b/test/regress/gold/cover22.txt
@@ -1,0 +1,16 @@
+** Note: Code coverage report folder: html.
+** Note: Code coverage report contains: covered, uncovered, excluded coverage details.
+** Note: code coverage results for: WORK.COVER22_A
+** Note:      statement:     100.0 % (4/4)
+** Note:      branch:        N.A.
+** Note:      toggle:        N.A.
+** Note:      expression:    N.A.
+** Note:      FSM state:     N.A.
+** Note:      functional:    N.A.
+** Note: code coverage results for: SECOND_LIB.COVER22_B
+** Note:      statement:     100.0 % (4/4)
+** Note:      branch:        N.A.
+** Note:      toggle:        N.A.
+** Note:      expression:    N.A.
+** Note:      FSM state:     N.A.
+** Note:      functional:    N.A.

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -921,3 +921,4 @@ issue824        normal
 issue825        normal
 issue826        normal,2008
 issue827        normal,2008
+cover22         shell


### PR DESCRIPTION
Hi,

this MR is follow-up of issue by @sean-anderson-seco  :
https://github.com/nickg/nvc/issues/823

It handles code coverage report generation when there are multiple scope children in the root
coverage scope. Previously, only first scope was reported.

