### PR TITLE
WIP: Temporary coverage rework.

### DIFF
--- a/src/cov/cov-api.h
+++ b/src/cov/cov-api.h
@@ -235,16 +235,12 @@ void cover_export_cobertura(cover_data_t *data, FILE *f,
 void cover_push_scope(cover_data_t *data, tree_t t);
 void cover_pop_scope(cover_data_t *data);
 
-void cover_inc_array_depth(cover_data_t *data);
-void cover_dec_array_depth(cover_data_t *data);
-
 bool cover_is_stmt(tree_t t);
-bool cover_skip_array_toggle(cover_data_t *data, int a_size);
 bool cover_skip_type_state(cover_data_t *data, type_t type);
 
 unsigned cover_get_std_log_expr_flags(tree_t decl);
 
-cover_item_t *cover_add_item(cover_data_t *data, object_t *obj, ident_t suffix,
-                             cover_item_kind_t kind, uint32_t flags);
+cover_item_t *cover_add_items(cover_data_t *data, object_t *obj,
+                              cover_item_kind_t kind);
 
 #endif   // _COV_API_H

--- a/src/cov/cov-api.h
+++ b/src/cov/cov-api.h
@@ -243,4 +243,8 @@ unsigned cover_get_std_log_expr_flags(tree_t decl);
 cover_item_t *cover_add_items(cover_data_t *data, object_t *obj,
                               cover_item_kind_t kind);
 
+// XXX: remove
+cover_item_t *cover_add_item(cover_data_t *data, object_t *obj, ident_t suffix,
+                             cover_item_kind_t kind, uint32_t flags);
+
 #endif   // _COV_API_H

--- a/src/lower.c
+++ b/src/lower.c
@@ -1592,7 +1592,7 @@ static void lower_fsm_state_coverage(lower_unit_t *lu, tree_t decl)
       ident_t suffix =
          ident_prefix(ident_new("_FSM."), tree_ident(literal), '\0');
       cover_item_t *item = cover_add_item(lu->cover,  tree_to_object(decl),
-                                          suffix, COV_ITEM_STATE, 0, 0);
+                                          suffix, COV_ITEM_STATE, 0);
       if (item == NULL)
          break;
       if (i == low) {
@@ -1611,12 +1611,13 @@ static void lower_fsm_state_coverage(lower_unit_t *lu, tree_t decl)
 }
 
 static void lower_expression_coverage(lower_unit_t *lu, tree_t fcall,
+                                      unsigned flags, vcode_reg_t mask,
                                       unsigned unrc_msk)
 {
    assert(cover_enabled(lu->cover, COVER_MASK_EXPRESSION));
 
    cover_item_t *item = cover_add_item(lu->cover, tree_to_object(fcall), NULL,
-                                       COV_ITEM_EXPRESSION, flags, 0);
+                                       COV_ITEM_EXPRESSION, flags);
    if (item != NULL) {
       emit_cover_expr(mask, item->tag);
       item->unrc_msk = unrc_msk;

--- a/src/psl/psl-lower.c
+++ b/src/psl/psl-lower.c
@@ -87,7 +87,7 @@ static void psl_lower_cover(lower_unit_t *lu, psl_node_t p, cover_data_t *cover)
       return;
 
    cover_item_t *item = cover_add_item(cover, psl_to_object(p), NULL,
-                                       COV_ITEM_FUNCTIONAL, 0);
+                                       COV_ITEM_FUNCTIONAL, 0, 0);
    if (item == NULL)
       return;
 

--- a/src/psl/psl-lower.c
+++ b/src/psl/psl-lower.c
@@ -87,7 +87,7 @@ static void psl_lower_cover(lower_unit_t *lu, psl_node_t p, cover_data_t *cover)
       return;
 
    cover_item_t *item = cover_add_item(cover, psl_to_object(p), NULL,
-                                       COV_ITEM_FUNCTIONAL, 0, 0);
+                                       COV_ITEM_FUNCTIONAL, 0);
    if (item == NULL)
       return;
 


### PR DESCRIPTION
Hi,

this is the MR you were asking about in the conversation. But it is in a very "raw" state...

The ideas are following:

1. Make single `cover_item_t` for a single coverage bin. Convert all the coverage run-time
data to counters (since single `cover_item_t` will represent single bin, no masking and shifting
is needed). This will simplify handling of coverage items, coverage merging, etc. Maybe VCODE
OPs could even be reworked to have only a single VCODE OP type (coverage OP) with some
sort of sub-kind that. The lower logic would change to emit new block that is conditionally
executed/skipped if the given condition/branch/expression is evaluated to true. The execution
code for each Coverage op will be just adding +1, so no complex handling will be needed in
the JIT layer for different coverage OPs. Basically everything will be the same as Statement
coverage is now. The name of the "BIN" would then be suffixed to the name of the emited
`cover_item_t`. The coverage exclude logic will then no need to specify any bins, everything
will be simply encoded in the name of the coverage item. This is where the user interface
would change slightly.

2. Consecutive "N" coverage items (that are now encoded in single item) will be still reported
in a single "table" in the report. To do that, one would need to identify how many consecutive
items belong to "the same construct". The `num` attribute of first such item can be used to
identify how many next consecutive items are to be grouped. It is already done like that for
FSM coverage. The `num` identifies all cover items to be put into single table since they
belong to single FSM. This can be generalized for all coverage items.

3. Simplify interface between `lower` and `cover` parts. Move all the logic that emits the
coverage items into `cover` (e.g. as is now done for the toggle coverage). The `cover_add_item`
would change to `cover_add_items` and return pointer to first coverage item added. Since
`num` would contain number of consecutive items, it would be simple to iterate these items
in `lower` and create the branching logic needed to execute/skip the VCODE cover op.
All the API functions like: `cover_inc_array_depth`, `cover_dec_array_depth`, `cover_skip_array_toggle`
`cover_skip_type_state` and `cover_get_std_log_expr_flags` would be now only local to
`cover` part.

Possible implications:
- Larger COVDB (2 x more toggle items, 2 x more branch items, 2 - 4 x more expression items)
- Not sure on the performance impact. Might be faster or slower, no idea.
- Simpler way of implementing https://github.com/nickg/nvc/issues/788. Additional member of
  `cover_item_t` could provide "source DB" for each BIN, and it could be easier to achieve
  "Bin A was covered in coverage DB X". This can be usefull to see that corner-case tests
  were really the ones that covered certain part of the code.
 