### PR TITLE
Fix basic_identifier

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -94,7 +94,7 @@ extern yylval_t yylval;
 
 LOWER           [a-z\xdf-\xf6\xf8-\xff]
 UPPER           [A-Z\xc0-\xd6\xd8-\xde]
-VHDL_ID         ({LOWER}|{UPPER})({LOWER}|{UPPER}|[_0-9])*
+VHDL_ID         ({LOWER}|{UPPER})(_?({LOWER}|{UPPER}|[0-9]))*
 EXID            \\([^\\\n]|\\\\)*\\
 VLOG_ID         [a-zA-Z_]([a-zA-Z0-9_$])*
 SYSTASK         \$[a-zA-Z_$]([a-zA-Z0-9_$])*

--- a/test/dist.mk
+++ b/test/dist.mk
@@ -368,6 +368,7 @@ EXTRA_DIST += \
 	test/parse/attr.vhd \
 	test/parse/badprimary.vhd \
 	test/parse/based.vhd \
+	test/parse/basic_identifier.vhd \
 	test/parse/bitstring.vhd \
 	test/parse/block.vhd \
 	test/parse/comp.vhd \

--- a/test/parse/basic_identifier.vhd
+++ b/test/parse/basic_identifier.vhd
@@ -1,0 +1,18 @@
+entity ee_ is end entity; -- ERROR expecting is (after ee)
+entity e__e is end entity; -- ERROR expecting is (after e)
+entity _e is end entity; -- ERROR expecting identifier (instead of _e)
+
+entity e_e is end entity; -- OK
+entity e_ee_e is end entity; -- OK
+
+architecture aa_ of e_e is -- ERROR expecting of (after aa)
+begin
+end architecture;
+
+architecture a__a of e_e is -- ERROR expecting of (after a)
+begin
+end architecture;
+
+architecture a_a of e_e is -- OK
+begin
+end architecture;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -6519,6 +6519,39 @@ START_TEST(test_vests5)
 }
 END_TEST
 
+START_TEST(test_basic_identifier)
+{
+   input_from_file(TESTDIR "/parse/basic_identifier.vhd");
+
+   const error_t expect[] = {
+      { 1, "unexpected error while parsing entity declaration, expecting is" },
+      { 2, "unexpected error while parsing entity declaration, expecting is" },
+      { 3, "unexpected error while parsing entity declaration, expecting identifier" },
+      { 8, "unexpected error while parsing architecture body, expecting of" },
+      { 12, "unexpected error while parsing architecture body, expecting of" },
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   for (int i = 0; i < 5; i++) {
+      tree_t e = parse();
+      fail_if(e == NULL);
+      fail_unless(tree_kind(e) == T_ENTITY);
+      lib_put(lib_work(), e);
+   }
+
+   for (int i = 0; i < 3; i++) {
+      tree_t a = parse();
+      fail_if(a == NULL);
+      fail_unless(tree_kind(a) == T_ARCH);
+   }
+
+   fail_unless(parse() == NULL);
+
+   check_expected_errors();
+}
+END_TEST
+
 Suite *get_parse_tests(void)
 {
    Suite *s = suite_create("parse");
@@ -6667,6 +6700,7 @@ Suite *get_parse_tests(void)
    tcase_add_test(tc_core, test_vests3);
    tcase_add_test(tc_core, test_vests4);
    tcase_add_test(tc_core, test_vests5);
+   tcase_add_test(tc_core, test_basic_identifier);
    suite_add_tcase(s, tc_core);
 
    return s;


### PR DESCRIPTION
In the LRM (VHDL-2008 at least) basic identifiers are defined as:

```
 basic_identifier ::= letter { [ underline ] letter_or_digit }
```

The LRM defines brackets `[]` as optional elements (regex question mark `?`) and braces `{}` as optional repeated (zero or more, regex asterisk `*`).

For underlines, this means that an identifier must never start with it, end with it, and there must never be more than one underscore in sequence. Before this PR, nvc doesn’t parse basic identifiers according to that definition but permits underscores in any place of an identifier, except for the first position. This patch checks for the proper behavior and also fixes the issue in the parser.

With just 47d0963 applied, `make check` fails. 62c2c0a fixes the issue. Neither verilog nor tcl were enabled, so a couple of unrelated tests have not been run.

While regenerating `test/dist.mk`, a lot of missing entries show up, but for atomicity of the patch, only the new dependency was added.