### PR TITLE
Cover saturate toggle

### DIFF
--- a/src/cov/cov-api.h
+++ b/src/cov/cov-api.h
@@ -83,6 +83,7 @@ typedef enum {
    COV_SRC_LOOP_STMT,
    COV_SRC_CONDITION,
    COV_SRC_STATEMENT,
+   COV_SRC_PSL_COVER,
    COV_SRC_UNKNOWN,
 } cover_src_t;
 

--- a/src/cov/cov-data.c
+++ b/src/cov/cov-data.c
@@ -24,6 +24,7 @@
 #include "object.h"
 #include "option.h"
 #include "tree.h"
+#include "psl/psl-node.h"
 #include "type.h"
 
 #include <assert.h>
@@ -112,6 +113,17 @@ static cover_src_t get_cover_source(cover_item_kind_t kind, object_t *obj)
          default:
             return COV_SRC_CONDITION;
          }
+      default:
+         return COV_SRC_UNKNOWN;
+      }
+   }
+
+   psl_node_t p = psl_from_object(obj);
+   if (p != NULL) {
+      printf("PSL NOT NULL!!!\n");
+      switch (kind) {
+      case COV_ITEM_FUNCTIONAL:
+         return COV_SRC_PSL_COVER;
       default:
          return COV_SRC_UNKNOWN;
       }

--- a/src/cov/cov-data.c
+++ b/src/cov/cov-data.c
@@ -120,7 +120,6 @@ static cover_src_t get_cover_source(cover_item_kind_t kind, object_t *obj)
 
    psl_node_t p = psl_from_object(obj);
    if (p != NULL) {
-      printf("PSL NOT NULL!!!\n");
       switch (kind) {
       case COV_ITEM_FUNCTIONAL:
          return COV_SRC_PSL_COVER;

--- a/src/cov/cov-data.c
+++ b/src/cov/cov-data.c
@@ -687,8 +687,10 @@ static void cover_merge_one_item(cover_item_t *item, int32_t data)
    case COV_ITEM_STATE:
    case COV_ITEM_EXPRESSION:
       inc = item->data + data;
-      if (likely(inc > item->data))
+      if (likely(inc >= item->data))
          item->data = inc;
+      else
+         item->data = INT32_MAX;
       break;
 
    // Highest bit of run-time data for COV_ITEM_TOGGLE is used to track
@@ -705,8 +707,10 @@ static void cover_merge_one_item(cover_item_t *item, int32_t data)
       else
       {
          inc = item->data + data;
-         if (likely(inc > item->data))
+         if (likely(inc >= item->data))
             item->data = inc;
+         else
+            item->data = INT32_MAX;
       }
       break;
 

--- a/src/cov/cov-report.c
+++ b/src/cov/cov-report.c
@@ -59,7 +59,6 @@ typedef struct {
 typedef struct {
    cover_line_t *line;
    cover_item_t *item;
-   int flags;
 } cover_pair_t;
 
 typedef struct {
@@ -752,7 +751,7 @@ static void cover_print_bins(FILE *f, cover_pair_t *first_pair, cov_pair_kind_t 
          cover_print_bin(f, pair, COV_FLAG_TRUE, pkind, 1, "True");
          cover_print_bin(f, pair, COV_FLAG_FALSE, pkind, 1, "False");
 
-         if (pair->flags & COV_FLAG_CHOICE) {
+         if (pair->item->flags & COV_FLAG_CHOICE) {
             int curr = loc.first_column;
             int last = (loc.line_delta) ? strlen(pair->line->text) :
                                           loc.column_delta + curr;
@@ -1034,8 +1033,6 @@ static bool cover_bin_unreachable(cover_report_ctx_t *ctx, cover_item_t *item)
    return false;
 }
 
-// TODO: Remove "flag" from "cover_pair_t" once all cover item kinds are reworked
-//       to contain only single bin. It will not be needed then!
 #define CHAIN_APPEND(chn, type, first_chn_item, curr_item, curr_line)            \
       do {                                                                       \
          if (chn->n_##type == chn->alloc_##type) {                               \

--- a/src/cov/cov-report.c
+++ b/src/cov/cov-report.c
@@ -603,6 +603,7 @@ static void cover_print_item_title(FILE *f, cover_pair_t *pair)
       [COV_SRC_LOOP_STMT] = "Loop statement",
       [COV_SRC_STATEMENT] = "Sequential statement",
       [COV_SRC_CONDITION] = "Condition",
+      [COV_SRC_PSL_COVER] = "PSL cover point",
       [COV_SRC_UNKNOWN] = "",
    };
 
@@ -611,6 +612,7 @@ static void cover_print_item_title(FILE *f, cover_pair_t *pair)
    switch (pair->item->kind) {
    case COV_ITEM_STMT:
    case COV_ITEM_BRANCH:
+   case COV_ITEM_FUNCTIONAL:
       fprintf(f, "%s:", text[pair->item->source]);
       break;
    case COV_ITEM_EXPRESSION:
@@ -971,7 +973,7 @@ static void cover_print_chain(FILE *f, cover_data_t *data, cover_chain_t *chn,
       else if (kind == COV_ITEM_STATE)
          fprintf(f, "FSM states:");
       else if (kind == COV_ITEM_FUNCTIONAL)
-         fprintf(f, "sequences:");
+         fprintf(f, "functional coverage:");
       fprintf(f, "</h2>\n");
 
       fprintf(f, "  <section style=\"padding:0px 10px;\">\n");

--- a/src/cov/cov-report.c
+++ b/src/cov/cov-report.c
@@ -1111,7 +1111,7 @@ static int cover_append_item_to_chain(cover_report_ctx_t *ctx, cover_item_t *fir
       nested_total = &(ctx->nested_stats.total_functional);
       flat_hits = &(ctx->flat_stats.hit_functional);
       nested_hits = &(ctx->nested_stats.hit_functional);
-      chn = &(ctx->ch_expression);
+      chn = &(ctx->ch_functional);
       break;
    default:
       fatal("unsupported type of code coverage: %d at 'cover_append_item_to_chain'!",

--- a/src/cov/cov-report.c
+++ b/src/cov/cov-report.c
@@ -631,8 +631,6 @@ static void cover_print_code_loc(FILE *f, cover_pair_t *pair)
    cover_line_t *curr_line = pair->line;
    cover_line_t *last_line = pair->line + loc.line_delta;
 
-   cover_print_item_title(f, pair);
-
    if (loc.line_delta == 0) {
       fprintf(f, "<code>");
       fprintf(f, "%d:", loc.first_line);
@@ -664,7 +662,8 @@ static void cover_print_code_loc(FILE *f, cover_pair_t *pair)
             curr_char++;
          }
 
-         fprintf(f, "<br>");
+         if (curr_line < last_line)
+            fprintf(f, "<br>");
          curr_line++;
 
       } while (curr_line <= last_line);
@@ -704,6 +703,8 @@ static void cover_print_bin(FILE *f, cover_pair_t *pair, uint32_t flag,
          fprintf(f, "<td>%s</td>", val);
       }
 
+      fprintf(f, "<td>%d</td>", pair->item->data);
+
       if (pkind == PAIR_UNCOVERED)
          cover_print_get_exclude_button(f, pair->item, flag, true);
 
@@ -729,6 +730,8 @@ static void cover_print_bin_header(FILE *f, cov_pair_kind_t pkind, int cols, ...
       const char *val = va_arg(argp, const char *);
       fprintf(f, "<th>%s</th>", val);
    }
+
+   fprintf(f, "<th>Count</th>");
 
    if (pkind == PAIR_UNCOVERED)
       fprintf(f, "<th>Exclude Command</th>");
@@ -830,10 +833,13 @@ static void cover_print_pairs(FILE *f, cover_pair_t *first, cov_pair_kind_t pkin
          if (pkind == PAIR_EXCLUDED)
             fprintf(f, "<div style=\"float: right\"><b>Excluded due to:</b> Exclude file</div>");
 
+         cover_print_item_title(f, curr);
          cover_print_code_loc(f, curr);
+         fprintf(f, "<br><b>Count:</b> %d", curr->item->data);
          break;
 
       case COV_ITEM_BRANCH:
+         cover_print_item_title(f, curr);
          cover_print_code_loc(f, curr);
          cover_print_bin_header(f, pkind, 1, (curr->item->flags & COV_FLAG_CHOICE) ?
                                 "Choice of" : "Evaluated to");
@@ -855,7 +861,9 @@ static void cover_print_pairs(FILE *f, cover_pair_t *first, cov_pair_kind_t pkin
          break;
 
       case COV_ITEM_EXPRESSION:
+         cover_print_item_title(f, curr);
          cover_print_code_loc(f, curr);
+
          if ((curr->item->flags & COV_FLAG_TRUE) || (curr->item->flags & COV_FLAG_FALSE))
             cover_print_bin_header(f, pkind, 1, "Evaluated to");
          else
@@ -865,6 +873,7 @@ static void cover_print_pairs(FILE *f, cover_pair_t *first, cov_pair_kind_t pkin
          break;
 
       case COV_ITEM_STATE:
+         cover_print_item_title(f, curr);
          cover_print_code_loc(f, curr);
          cover_print_bin_header(f, pkind, 1, "State");
          cover_print_bins(f, curr, pkind);
@@ -873,7 +882,9 @@ static void cover_print_pairs(FILE *f, cover_pair_t *first, cov_pair_kind_t pkin
       case COV_ITEM_FUNCTIONAL:
          if (pkind == PAIR_UNCOVERED)
             cover_print_get_exclude_button(f, curr->item, 0, false);
+         cover_print_item_title(f, curr);
          cover_print_code_loc(f, curr);
+         fprintf(f, "<br><b>Count:</b> %d", curr->item->data);
          break;
 
       default:

--- a/src/cov/cov-report.c
+++ b/src/cov/cov-report.c
@@ -819,8 +819,9 @@ static void cover_print_pairs(FILE *f, cover_pair_t *first, cov_pair_kind_t pkin
    int step;
 
    do {
-      step = 1;
       fprintf(f, "    <p>");
+
+      step = curr->item->consecutive;
 
       switch (curr->item->kind) {
       case COV_ITEM_STMT:
@@ -851,7 +852,6 @@ static void cover_print_pairs(FILE *f, cover_pair_t *first, cov_pair_kind_t pkin
 
          cover_print_bin_header(f, pkind, 2, "From", "To");
          cover_print_bins(f, curr, pkind);
-         step = curr->item->consecutive;
          break;
 
       case COV_ITEM_EXPRESSION:
@@ -862,15 +862,12 @@ static void cover_print_pairs(FILE *f, cover_pair_t *first, cov_pair_kind_t pkin
             cover_print_bin_header(f, pkind, 2, "LHS", "RHS");
 
          cover_print_bins(f, curr, pkind);
-         step = curr->item->consecutive;
          break;
 
       case COV_ITEM_STATE:
          cover_print_code_loc(f, curr);
          cover_print_bin_header(f, pkind, 1, "State");
          cover_print_bins(f, curr, pkind);
-
-         step = curr->item->consecutive;
          break;
 
       case COV_ITEM_FUNCTIONAL:

--- a/src/rt/cover.c
+++ b/src/rt/cover.c
@@ -214,8 +214,8 @@ void x_cover_setup_toggle_cb(sig_shared_t *ss, int32_t tag)
       for (int i = 0; i < s->shared.size; i++) {
          // Remember constant driver in run-time data.
          // Unreachable mask not available at run-time.
-         *toggle_01 |= COV_FLAG_UNREACHABLE;
-         *toggle_10 |= COV_FLAG_UNREACHABLE;
+         *toggle_01 = COV_FLAG_UNREACHABLE;
+         *toggle_10 = COV_FLAG_UNREACHABLE;
          toggle_01 += 2;
          toggle_10 += 2;
       }

--- a/src/rt/cover.c
+++ b/src/rt/cover.c
@@ -47,7 +47,6 @@ enum std_ulogic {
 
 #define INCS_I32(i32_ptr)                                               \
       do {                                                              \
-         int32_t inc = *i32_ptr + 1;                                    \
          if (unlikely(__builtin_add_overflow(*i32_ptr, 1, i32_ptr)))    \
             *i32_ptr = INT32_MAX;                                       \
       } while (0)

--- a/src/rt/cover.c
+++ b/src/rt/cover.c
@@ -45,11 +45,11 @@ enum std_ulogic {
    _DC = 0x8
 };
 
-#define INCS_I32(i32_ptr)                          \
-      do {                                         \
-         int32_t inc = *i32_ptr + 1;               \
-         if (likely(inc > *i32_ptr))               \
-            *i32_ptr = inc;                        \
+#define INCS_I32(i32_ptr)                                               \
+      do {                                                              \
+         int32_t inc = *i32_ptr + 1;                                    \
+         if (unlikely(__builtin_add_overflow(*i32_ptr, 1, i32_ptr)))    \
+            *i32_ptr = INT32_MAX;                                       \
       } while (0)
 
 //#define COVER_DEBUG_CALLBACK

--- a/test/perf/toggle_cov.vhd
+++ b/test/perf/toggle_cov.vhd
@@ -1,0 +1,57 @@
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity toggle_cov is
+end entity;
+
+architecture tb of toggle_cov is
+
+    constant C_MEM_DEPTH : natural := 2 ** 18;
+
+    type t_large_mem is
+        array (0 to C_MEM_DEPTH - 1) of std_logic_vector(31 downto 0);
+
+    signal large_mem : t_large_mem := (others => (others => '0'));
+
+begin
+
+    process
+    begin
+
+        wait for 1 ns;
+
+        for j in 1 to 500 loop
+
+            report "Iteration: " & integer'image(j);
+
+            for i in 0 to C_MEM_DEPTH - 1 loop
+                large_mem(i) <= "00000000000000000000000000000000";
+            end loop;
+
+            wait for 1 ns;
+
+            for i in 0 to C_MEM_DEPTH - 1 loop
+                large_mem(i) <= "11111111111111111111111111111111";
+            end loop;
+
+            wait for 1 ns;
+
+            for i in 0 to C_MEM_DEPTH - 1 loop
+                large_mem(i) <= "00000000000000000000000000000000";
+            end loop;
+
+            wait for 1 ns;
+
+            for i in 0 to C_MEM_DEPTH - 1 loop
+                large_mem(i) <= "11111111111111111111111111111111";
+            end loop;
+
+            wait for 1 ns;
+        end loop;
+
+        wait;
+    end process;
+
+end architecture;
+


### PR DESCRIPTION
Hi,

this is a MR with some left-overs from previous refactor:

- Couple of bug-fixes that creeped in and were un-recognized since they are related to Coverage report printing that is not checked.
- Removed `flag` from `cover_pair_t` -> Redundant now
- Added run-time saturation also for Toggle Items
- Optimizes toggle items in cases when `count-from-undefined` and `count-from-to-z` are enabled.
- Slightly improves coverage report for PSL assertions
- Added Cover item data into the Coverage report (now that it means how many times an item was covered).
- Added a test for saturation during merging. Testing Saturation on increments during run-time is excessively long.