### PR TITLE
Use pkg-config to detect zlib

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,6 +19,7 @@ AM_CFLAGS += \
 	$(check_CFLAGS) \
 	$(libdw_CFLAGS) \
 	$(libffi_CFLAGS) \
+	$(zlib_CFLAGS) \
 	$(capstone_CFLAGS) \
 	$(LLVM_CFLAGS) \
 	$(libzstd_CFLAGS) \

--- a/configure.ac
+++ b/configure.ac
@@ -178,7 +178,7 @@ AC_SEARCH_LIBS([pow], [m], [], [
   AC_MSG_ERROR([unable to find the pow() function])
 ])
 
-AC_CHECK_LIB([z], [deflate], [], [AC_MSG_ERROR(zlib not found)])
+PKG_CHECK_MODULES([zlib], [zlib >= 1.0.0])
 
 AC_DEFINE_UNQUOTED([FST_REMOVE_DUPLICATE_VC], [1], [Enable FST glitch removal])
 

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -75,6 +75,7 @@ bin_nvc_LDADD = \
 	lib/libcpustate.a \
 	lib/libgnulib.a \
 	lib/libsha1.a \
+	$(zlib_LIBS) \
 	$(libdw_LIBS) \
 	$(libffi_LIBS) \
 	$(capstone_LIBS) \

--- a/test/Makemodule.am
+++ b/test/Makemodule.am
@@ -65,7 +65,7 @@ bin_run_regr_SOURCES = test/run_regr.c
 
 bin_fstdump_SOURCES = test/fstdump.c
 
-bin_fstdump_LDADD = lib/libfst.a lib/libfastlz.a
+bin_fstdump_LDADD = lib/libfst.a lib/libfastlz.a $(zlib_LIBS)
 
 bin_lockbench_SOURCES = test/lockbench.c
 


### PR DESCRIPTION
The old code used to detect zlib by trying to compile a program. All well and good, until you want to use a zlib that is not in a standardized location.

This change allows providing zlib via a pkgconfig path.