### PR TITLE
OSVVM functional coverage integration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,9 @@
 - Fixed a crash when a generic subprogram is associated with `open`
   (#1025).
 - Record subtype constraints can now be accessed over VHPI (#1035).
+- OSVVM functional coverage is reported as part of functional coverage
+- Add `threshold-<value>` option for coverage to set minimal coun a
+  coverage bin must reach to be reported as covered
 
 ## Version 1.14.0 - 2024-09-22
 - Waiting on implicit `'stable` and `'quiet` signals now works

--- a/lib/nvc/cover_pkg-body.vhd
+++ b/lib/nvc/cover_pkg-body.vhd
@@ -26,7 +26,6 @@ package body cover_pkg is
                               item      : out t_item_handle;
                               name      : in string;
                               atleast   : in integer;
-                              n_ranges  : in integer;
                               ranges    : in t_item_range_array) is
     begin
         -- Foreign subprogram

--- a/lib/nvc/cover_pkg-body.vhd
+++ b/lib/nvc/cover_pkg-body.vhd
@@ -25,7 +25,7 @@ package body cover_pkg is
     procedure add_cover_item (scope     : inout t_scope_handle;
                               item      : out t_item_handle;
                               name      : in string;
-                              atleast   : in integer;
+                              atleast   : in positive;
                               ranges    : in t_item_range_array) is
     begin
         -- Foreign subprogram

--- a/lib/nvc/cover_pkg-body.vhd
+++ b/lib/nvc/cover_pkg-body.vhd
@@ -26,7 +26,6 @@ package body cover_pkg is
                               item      : out t_item_handle;
                               name      : in string;
                               atleast   : in natural;
-                              exclude   : in boolean;
                               ranges    : in t_item_range_array) is
     begin
         -- Foreign subprogram

--- a/lib/nvc/cover_pkg-body.vhd
+++ b/lib/nvc/cover_pkg-body.vhd
@@ -22,15 +22,26 @@ package body cover_pkg is
         -- Foreign subprogram
     end procedure;
 
-    procedure add_cover_item (scope : inout t_scope_handle;
-                              item  : out t_item_handle;
-                              name  : in string) is
+    procedure add_cover_item (scope     : inout t_scope_handle;
+                              item      : out t_item_handle;
+                              name      : in string;
+                              source    : in integer;
+                              atleast   : in integer;
+                              flags     : in integer;
+                              n_ranges  : in integer;
+                              ranges    : in t_item_range_array) is
     begin
         -- Foreign subprogram
     end procedure;
 
     procedure increment_cover_item (scope : inout t_scope_handle;
                                     item  : in t_item_handle) is
+    begin
+        -- Foreign subprogram
+    end procedure;
+
+    procedure set_cover_scope_name(scope : inout t_scope_handle;
+                                   name  : in string) is
     begin
         -- Foreign subprogram
     end procedure;

--- a/lib/nvc/cover_pkg-body.vhd
+++ b/lib/nvc/cover_pkg-body.vhd
@@ -22,26 +22,26 @@ package body cover_pkg is
         -- Foreign subprogram
     end procedure;
 
-    procedure add_cover_item (scope     : inout t_scope_handle;
-                              item      : out t_item_handle;
-                              name      : in string;
-                              source    : in integer;
-                              atleast   : in integer;
-                              flags     : in integer;
-                              n_ranges  : in integer;
-                              ranges    : in t_item_range_array) is
+    procedure add_cover_item (variable scope     : inout t_scope_handle;
+                                       item      : out t_item_handle;
+                                       name      : in string;
+                                       source    : in integer;
+                                       atleast   : in integer;
+                                       flags     : in integer;
+                                       n_ranges  : in integer;
+                                       ranges    : in t_item_range_array) is
     begin
         -- Foreign subprogram
     end procedure;
 
-    procedure increment_cover_item (scope : inout t_scope_handle;
-                                    item  : in t_item_handle) is
+    procedure increment_cover_item (variable scope : inout t_scope_handle;
+                                             item  : in t_item_handle) is
     begin
         -- Foreign subprogram
     end procedure;
 
-    procedure set_cover_scope_name(scope : inout t_scope_handle;
-                                   name  : in string) is
+    procedure set_cover_scope_name(variable scope : inout t_scope_handle;
+                                            name  : in string) is
     begin
         -- Foreign subprogram
     end procedure;

--- a/lib/nvc/cover_pkg-body.vhd
+++ b/lib/nvc/cover_pkg-body.vhd
@@ -22,26 +22,24 @@ package body cover_pkg is
         -- Foreign subprogram
     end procedure;
 
-    procedure add_cover_item (variable scope     : inout t_scope_handle;
-                                       item      : out t_item_handle;
-                                       name      : in string;
-                                       source    : in integer;
-                                       atleast   : in integer;
-                                       flags     : in integer;
-                                       n_ranges  : in integer;
-                                       ranges    : in t_item_range_array) is
+    procedure add_cover_item (scope     : inout t_scope_handle;
+                              item      : out t_item_handle;
+                              name      : in string;
+                              atleast   : in integer;
+                              n_ranges  : in integer;
+                              ranges    : in t_item_range_array) is
     begin
         -- Foreign subprogram
     end procedure;
 
-    procedure increment_cover_item (variable scope : inout t_scope_handle;
-                                             item  : in t_item_handle) is
+    procedure increment_cover_item (scope : inout t_scope_handle;
+                                    item  : in t_item_handle) is
     begin
         -- Foreign subprogram
     end procedure;
 
-    procedure set_cover_scope_name(variable scope : inout t_scope_handle;
-                                            name  : in string) is
+    procedure set_cover_scope_name(scope : inout t_scope_handle;
+                                   name  : in string) is
     begin
         -- Foreign subprogram
     end procedure;

--- a/lib/nvc/cover_pkg-body.vhd
+++ b/lib/nvc/cover_pkg-body.vhd
@@ -25,7 +25,8 @@ package body cover_pkg is
     procedure add_cover_item (scope     : inout t_scope_handle;
                               item      : out t_item_handle;
                               name      : in string;
-                              atleast   : in positive;
+                              atleast   : in natural;
+                              exclude   : in boolean;
                               ranges    : in t_item_range_array) is
     begin
         -- Foreign subprogram

--- a/lib/nvc/cover_pkg.vhd
+++ b/lib/nvc/cover_pkg.vhd
@@ -39,21 +39,21 @@ package cover_pkg is
     procedure create_cover_scope (scope : out t_scope_handle;
                                   name  : in string);
 
-    procedure set_cover_scope_name(scope : inout t_scope_handle;
-                                   name  : in string);
+    procedure set_cover_scope_name(variable scope : inout t_scope_handle;
+                                            name  : in string);
 
-    procedure add_cover_item (scope     : inout t_scope_handle;
-                              item      : out t_item_handle;
-                              name      : in string;
-                              source    : in integer;
-                              atleast   : in integer;
-                              flags     : in integer;
-                              n_ranges  : in integer;
-                              ranges    : in t_item_range_array
+    procedure add_cover_item (variable scope     : inout t_scope_handle;
+                                       item      : out t_item_handle;
+                                       name      : in string;
+                                       source    : in integer;
+                                       atleast   : in integer;
+                                       flags     : in integer;
+                                       n_ranges  : in integer;
+                                       ranges    : in t_item_range_array
                               );
 
-    procedure increment_cover_item (scope : inout t_scope_handle;
-                                    item  : in t_item_handle);
+    procedure increment_cover_item (variable scope : inout t_scope_handle;
+                                             item  : in t_item_handle);
 
     attribute foreign of create_cover_scope : procedure
         is "INTERNAL _nvc_create_cover_scope";

--- a/lib/nvc/cover_pkg.vhd
+++ b/lib/nvc/cover_pkg.vhd
@@ -27,20 +27,39 @@ package cover_pkg is
 
     type t_item_handle is range -1 to 2147483647;
 
+    type t_item_range is record
+        min: integer;
+        max: integer;
+    end record;
+
+    type t_item_range_array is array ( integer range <> ) of t_item_range;
+
     constant INVALID_ITEM : t_item_handle := t_item_handle'left;
 
     procedure create_cover_scope (scope : out t_scope_handle;
                                   name  : in string);
 
-    procedure add_cover_item (scope : inout t_scope_handle;
-                              item  : out t_item_handle;
-                              name  : in string);
+    procedure set_cover_scope_name(scope : inout t_scope_handle;
+                                   name  : in string);
+
+    procedure add_cover_item (scope     : inout t_scope_handle;
+                              item      : out t_item_handle;
+                              name      : in string;
+                              source    : in integer;
+                              atleast   : in integer;
+                              flags     : in integer;
+                              n_ranges  : in integer;
+                              ranges    : in t_item_range_array
+                              );
 
     procedure increment_cover_item (scope : inout t_scope_handle;
                                     item  : in t_item_handle);
 
     attribute foreign of create_cover_scope : procedure
         is "INTERNAL _nvc_create_cover_scope";
+
+    attribute foreign of set_cover_scope_name : procedure
+        is "INTERNAL _nvc_set_cover_scope_name";
 
     attribute foreign of add_cover_item : procedure
         is "INTERNAL _nvc_add_cover_item";

--- a/lib/nvc/cover_pkg.vhd
+++ b/lib/nvc/cover_pkg.vhd
@@ -47,7 +47,8 @@ package cover_pkg is
     procedure add_cover_item (scope     : inout t_scope_handle;
                               item      : out t_item_handle;
                               name      : in string;
-                              atleast   : in positive;
+                              atleast   : in natural;
+                              exclude   : in boolean;
                               ranges    : in t_item_range_array
                               );
 

--- a/lib/nvc/cover_pkg.vhd
+++ b/lib/nvc/cover_pkg.vhd
@@ -47,7 +47,7 @@ package cover_pkg is
     procedure add_cover_item (scope     : inout t_scope_handle;
                               item      : out t_item_handle;
                               name      : in string;
-                              atleast   : in integer;
+                              atleast   : in positive;
                               ranges    : in t_item_range_array
                               );
 

--- a/lib/nvc/cover_pkg.vhd
+++ b/lib/nvc/cover_pkg.vhd
@@ -48,7 +48,6 @@ package cover_pkg is
                               item      : out t_item_handle;
                               name      : in string;
                               atleast   : in integer;
-                              n_ranges  : in integer;
                               ranges    : in t_item_range_array
                               );
 

--- a/lib/nvc/cover_pkg.vhd
+++ b/lib/nvc/cover_pkg.vhd
@@ -48,7 +48,6 @@ package cover_pkg is
                               item      : out t_item_handle;
                               name      : in string;
                               atleast   : in natural;
-                              exclude   : in boolean;
                               ranges    : in t_item_range_array
                               );
 

--- a/lib/nvc/cover_pkg.vhd
+++ b/lib/nvc/cover_pkg.vhd
@@ -27,9 +27,11 @@ package cover_pkg is
 
     type t_item_handle is range -1 to 2147483647;
 
+    type t_item_range_value is range 0 to 2147483647;
+
     type t_item_range is record
-        min: integer;
-        max: integer;
+        min: t_item_range_value;
+        max: t_item_range_value;
     end record;
 
     type t_item_range_array is array ( integer range <> ) of t_item_range;
@@ -39,21 +41,19 @@ package cover_pkg is
     procedure create_cover_scope (scope : out t_scope_handle;
                                   name  : in string);
 
-    procedure set_cover_scope_name(variable scope : inout t_scope_handle;
-                                            name  : in string);
+    procedure set_cover_scope_name(scope : inout t_scope_handle;
+                                   name  : in string);
 
-    procedure add_cover_item (variable scope     : inout t_scope_handle;
-                                       item      : out t_item_handle;
-                                       name      : in string;
-                                       source    : in integer;
-                                       atleast   : in integer;
-                                       flags     : in integer;
-                                       n_ranges  : in integer;
-                                       ranges    : in t_item_range_array
+    procedure add_cover_item (scope     : inout t_scope_handle;
+                              item      : out t_item_handle;
+                              name      : in string;
+                              atleast   : in integer;
+                              n_ranges  : in integer;
+                              ranges    : in t_item_range_array
                               );
 
-    procedure increment_cover_item (variable scope : inout t_scope_handle;
-                                             item  : in t_item_handle);
+    procedure increment_cover_item (scope : inout t_scope_handle;
+                                    item  : in t_item_handle);
 
     attribute foreign of create_cover_scope : procedure
         is "INTERNAL _nvc_create_cover_scope";

--- a/nvc.1
+++ b/nvc.1
@@ -667,14 +667,30 @@ a coverage bin for each state of an FSM. NVC considers internal signals of
 all user-defined enum types as FSMs. NVC does not consider port signals or
 variables as an FSM. When a signal recognized as FSM changes its value,
 coverage bin for new state value is incremented.
+
 .It
 .Cm functional
-- NVC creates a coverage bin for each PSL
+- NVC creates a coverage bin for each:
+.Bl -bullet
+.It
+PSL
 .Ql cover
-directive. When a cover sequence completes, coverage bin is incremented.
+directive. When a PSL sequence in the cover directive completes, coverage bin is incremented.
+.It
+OSVVM functional coverage bin. A call to
+.Ql AddBins
+or
+.Ql AddCross
+OSVVM functions creates such NVC functional coverage bins.
+A threshold for OSVVM coverage bin to be reported as covered is given by
+.Ql AtLeast
+argument of
+.Ql AddBins
+OSVVM call.
+.El
 .El
 .Pp
-Collection for each coverage type can be enabled separately at elaboration time:
+Collection of each coverage kind can be enabled separately at elaboration time:
 .Bd -literal -offset indent
 $ nvc -e --cover=statement,branch,toggle,expression <top>
 .Ed
@@ -692,8 +708,6 @@ $ nvc --cover-merge -o merged.covdb first.covdb second.covdb third.covdb ...
 .Pp
 During code coverage merging, NVC sums together coverage bins with equal
 hierarchical paths in the elaborated design.
-When a coverage bin is non-zero, NVC displays such bin as covered in the
-code coverage report.
 .Pp
 NVC creates union of all coverage bins from all input coverage databases
 in the merged code coverage database. This allows merging code coverage from
@@ -708,7 +722,14 @@ $ nvc --cover-report -o report_dir merged.covdb
 The command above will generate a code coverage report in the
 .Pa report_dir
 directory.
-NVC supports two different kinds of code coverage reports:
+Code coverage report shows whether a coverage bin is covered or uncovered.
+A bin is covered when its counter is equal to, or higher than threshold
+given by
+.Cm --threshold-<value>
+option of
+.Cm --cover
+elabortion switch.
+NVC supports two kinds of code coverage reports:
 .Bl -bullet
 .It
 .Cm hierarchy report -
@@ -798,6 +819,12 @@ Toggle coverage on instance ports driven by constant value.
 as FSMs. With this option, NVC can be forced to recognize FSMs only via
 .Ql fsm-type
 directive in coverage specification file.
+.El
+.Bl -bullet
+.It
+.Cm threshold-<value>
+- A minimal value of coverage bin counter for coverage bin to be reported as
+  covered. Default is 1.
 .El
 .Pp
 All additional coverage options are passed comma separated to

--- a/nvc.1
+++ b/nvc.1
@@ -677,17 +677,7 @@ PSL
 .Ql cover
 directive. When a PSL sequence in the cover directive completes, coverage bin is incremented.
 .It
-OSVVM functional coverage bin. A call to
-.Ql AddBins
-or
-.Ql AddCross
-OSVVM functions creates such NVC functional coverage bins.
-A threshold for OSVVM coverage bin to be reported as covered is given by
-.Ql AtLeast
-argument of
-.Ql AddBins
-OSVVM call.
-.El
+Functional coverage bin from third party libraries (e.g. OSVVM)
 .El
 .Pp
 Collection of each coverage kind can be enabled separately at elaboration time:

--- a/src/cov/cov-api.h
+++ b/src/cov/cov-api.h
@@ -89,8 +89,8 @@ typedef enum {
 } cover_src_t;
 
 typedef struct {
-   int64_t  min;
-   int64_t  max;
+   uint32_t  min;
+   uint32_t  max;
 } cover_range_t;
 
 typedef struct _cover_item {

--- a/src/cov/cov-api.h
+++ b/src/cov/cov-api.h
@@ -84,7 +84,7 @@ typedef enum {
    COV_SRC_CONDITION,
    COV_SRC_STATEMENT,
    COV_SRC_PSL_COVER,
-   COV_SRC_OSVVM_COVER,
+   COV_SRC_USER_COVER,
    COV_SRC_UNKNOWN,
 } cover_src_t;
 
@@ -163,7 +163,7 @@ typedef enum {
    COV_FLAG_10             = (1 << 5),
    COV_FLAG_11             = (1 << 6),
    COV_FLAG_STATE          = (1 << 7),
-   COV_FLAG_OSVVM          = (1 << 8),
+   COV_FLAG_USER_DEFINED   = (1 << 8),
    COV_FLAG_TOGGLE_TO_0    = (1 << 15),
    COV_FLAG_TOGGLE_TO_1    = (1 << 16),
    COV_FLAG_TOGGLE_SIGNAL  = (1 << 17),

--- a/src/cov/cov-api.h
+++ b/src/cov/cov-api.h
@@ -84,8 +84,14 @@ typedef enum {
    COV_SRC_CONDITION,
    COV_SRC_STATEMENT,
    COV_SRC_PSL_COVER,
+   COV_SRC_OSVVM_COVER,
    COV_SRC_UNKNOWN,
 } cover_src_t;
+
+typedef struct {
+   int64_t  min;
+   int64_t  max;
+} cover_range_t;
 
 typedef struct _cover_item {
    // Type of coverage
@@ -114,7 +120,10 @@ typedef struct _cover_item {
    // Hierarchy path of the covered object
    ident_t           hier;
 
-   // Name of the function for expression coverage
+   // Additional name for cover item:
+   //    COV_ITEM_EXPRESSION     Name of expression (e.g. OR, AND, XOR)
+   //    COV_ITEM_STATE          Name of FSM state
+   //    COV_ITEM_FUNCTIONAL     Name of user-defined functional over point
    ident_t           func_name;
 
    // Type of source statement or expression
@@ -132,10 +141,17 @@ typedef struct _cover_item {
    //    COV_ITEM_FUNCTIONAL     Always 1
    int               consecutive;
 
+   // Threshold for being covered
+   int               atleast;
+
    // Secondary numeric data:
    //    COV_ITEM_TOGGLE - Start position of signal name
    //    COV_ITEM_STATE  - Value of low-index of enum sub-type
    int64_t           metadata;
+
+   // Ranges for functional coverage bins
+   int               n_ranges;
+   cover_range_t    *ranges;
 } cover_item_t;
 
 typedef enum {
@@ -147,6 +163,7 @@ typedef enum {
    COV_FLAG_10             = (1 << 5),
    COV_FLAG_11             = (1 << 6),
    COV_FLAG_STATE          = (1 << 7),
+   COV_FLAG_OSVVM          = (1 << 8),
    COV_FLAG_TOGGLE_TO_0    = (1 << 15),
    COV_FLAG_TOGGLE_TO_1    = (1 << 16),
    COV_FLAG_TOGGLE_SIGNAL  = (1 << 17),

--- a/src/cov/cov-api.h
+++ b/src/cov/cov-api.h
@@ -170,6 +170,7 @@ typedef enum {
    COV_FLAG_TOGGLE_PORT    = (1 << 18),
    COV_FLAG_EXPR_STD_LOGIC = (1 << 24),
    COV_FLAG_EXCLUDED       = (1 << 25),
+   COV_FLAG_EXCLUDED_USER  = (1 << 26),
 
    // This needs to stay at highest bit of int32_t.
    // Used in run-time data of COV_ITEM_TOGGLE to mark unreachability.

--- a/src/cov/cov-api.h
+++ b/src/cov/cov-api.h
@@ -214,7 +214,7 @@ typedef enum {
                         | COVER_MASK_TOGGLE | COVER_MASK_EXPRESSION     \
                         | COVER_MASK_STATE | COVER_MASK_FUNCTIONAL)
 
-cover_data_t *cover_data_init(cover_mask_t mask, int array_limit);
+cover_data_t *cover_data_init(cover_mask_t mask, int array_limit, int threshold);
 bool cover_enabled(cover_data_t *data, cover_mask_t mask);
 
 unsigned cover_count_items(cover_data_t *data);

--- a/src/cov/cov-data.c
+++ b/src/cov/cov-data.c
@@ -195,12 +195,14 @@ static int32_t cover_add_item(cover_data_t *data, cover_scope_t *cs,
    if (kind == COV_ITEM_TOGGLE)
       metadata = cs->sig_pos;
 
+   loc_t loc = get_cover_loc(kind, obj);
+
    cover_item_t new = {
       .kind          = kind,
       .tag           = data->next_tag++,
       .data          = 0,
       .flags         = flags,
-      .loc           = get_cover_loc(kind, obj),
+      .loc           = loc,
       .loc_lhs       = loc_lhs,
       .loc_rhs       = loc_rhs,
       .hier          = hier,
@@ -217,10 +219,10 @@ static int32_t cover_add_item(cover_data_t *data, cover_scope_t *cs,
    printf("    Consecutive:   %d\n", consecutive);
    printf("    Metadata:      %d\n", metadata);
    printf("    Function name: %s\n", istr(func_name));
-   printf("    First line:    %d\n", loc->first_line);
-   printf("    First column:  %d\n", loc->first_column);
-   printf("    Line delta:    %d\n", loc->line_delta);
-   printf("    Column delta:  %d\n", loc->column_delta);
+   printf("    First line:    %d\n", loc.first_line);
+   printf("    First column:  %d\n", loc.first_column);
+   printf("    Line delta:    %d\n", loc.line_delta);
+   printf("    Column delta:  %d\n", loc.column_delta);
    printf("\n\n");
 #endif
 
@@ -888,7 +890,7 @@ static bool cover_should_emit_scope(cover_data_t *data, cover_scope_t *cs,
          if (ident_glob(ename, AGET(spc->block_exclude, i), -1)) {
 #ifdef COVER_DEBUG_EMIT
             printf("Cover emit: False, block (Block: %s, Pattern: %s)\n",
-                   istr(ts->block_name), AGET(spc->block_exclude, i));
+                   istr(cs->block_name), AGET(spc->block_exclude, i));
 #endif
             return false;
          }
@@ -897,7 +899,7 @@ static bool cover_should_emit_scope(cover_data_t *data, cover_scope_t *cs,
          if (ident_glob(ename, AGET(spc->block_include, i), -1)) {
 #ifdef COVER_DEBUG_EMIT
             printf("Cover emit: True, block (Block: %s, Pattern: %s)\n",
-                   istr(ts->block_name), AGET(spc->block_include, i));
+                   istr(cs->block_name), AGET(spc->block_include, i));
 #endif
             return true;
          }
@@ -908,7 +910,7 @@ static bool cover_should_emit_scope(cover_data_t *data, cover_scope_t *cs,
       if (ident_glob(cs->hier, AGET(spc->hier_exclude, i), -1)) {
 #ifdef COVER_DEBUG_EMIT
          printf("Cover emit: False, hierarchy (Hierarchy: %s, Pattern: %s)\n",
-                istr(ts->hier), AGET(spc->hier_exclude, i));
+                istr(cs->hier), AGET(spc->hier_exclude, i));
 #endif
          return false;
       }
@@ -917,7 +919,7 @@ static bool cover_should_emit_scope(cover_data_t *data, cover_scope_t *cs,
       if (ident_glob(cs->hier, AGET(spc->hier_include, i), -1)) {
 #ifdef COVER_DEBUG_EMIT
          printf("Cover emit: True, hierarchy (Hierarchy: %s, Pattern: %s)\n",
-                istr(ts->hier), AGET(spc->hier_include, i));
+                istr(cs->hier), AGET(spc->hier_include, i));
 #endif
          return true;
       }

--- a/src/cov/cov-data.c
+++ b/src/cov/cov-data.c
@@ -208,7 +208,7 @@ static int32_t cover_add_item(cover_data_t *data, cover_scope_t *cs,
       .hier          = hier,
       .func_name     = func_name,
       .consecutive   = consecutive,
-      .atleast       = 1,
+      .atleast       = data->threshold,
       .metadata      = metadata,
       .n_ranges      = 0,
       .ranges        = NULL,
@@ -872,11 +872,12 @@ void cover_dump_items(cover_data_t *data, fbuf_t *f, cover_dump_t dt,
    ident_write_end(ident_ctx);
 }
 
-cover_data_t *cover_data_init(cover_mask_t mask, int array_limit)
+cover_data_t *cover_data_init(cover_mask_t mask, int array_limit, int threshold)
 {
    cover_data_t *data = xcalloc(sizeof(cover_data_t));
    data->mask = mask;
    data->array_limit = array_limit;
+   data->threshold = threshold;
 
    return data;
 }

--- a/src/cov/cov-data.c
+++ b/src/cov/cov-data.c
@@ -61,7 +61,7 @@ static const struct {
 };
 
 #define COVER_FILE_MAGIC   0x6e636462   // ASCII "ncdb"
-#define COVER_FILE_VERSION 1
+#define COVER_FILE_VERSION 2
 
 static bool cover_is_branch(tree_t branch)
 {

--- a/src/cov/cov-data.h
+++ b/src/cov/cov-data.h
@@ -69,6 +69,7 @@ struct _cover_data {
    int               array_limit;
    int               array_depth;
    int               report_item_limit;
+   int               threshold;
    cover_rpt_buf_t  *rpt_buf;
    cover_spec_t     *spec;
    cover_ef_t       *ef;

--- a/src/cov/cov-exclude.c
+++ b/src/cov/cov-exclude.c
@@ -56,7 +56,7 @@ static void cover_exclude_scope(cover_data_t *data, cover_scope_t *s)
          if (ident_glob(hier, excl_hier, strlen(excl_hier))) {
             excl->found = true;
 
-            if (item->data > 0) {
+            if (item->data >= item->atleast) {
                warn_at(&excl->loc, "%s: '%s' is already covered, "
                                    "it will be reported as covered.",
                                    kind_str, istr(hier));

--- a/src/cov/cov-report.c
+++ b/src/cov/cov-report.c
@@ -605,8 +605,10 @@ static void cover_print_bin(FILE *f, cover_pair_t *pair, uint32_t flag,
          cover_print_get_exclude_button(f, pair->item, flag, true);
 
       if (pkind == PAIR_EXCLUDED) {
-         const char *er = (pair->item->flags & COV_FLAG_UNREACHABLE) ?
-            "Unreachable" : "Exclude file";
+         cover_flags_t flags = pair->item->flags;
+         const char *er = (flags & COV_FLAG_UNREACHABLE)   ? "Unreachable" :
+                          (flags & COV_FLAG_EXCLUDED_USER) ? "User exclude" :
+                                                             "Exclude file";
          fprintf(f, "<td>%s</td>", er);
       }
 
@@ -1125,7 +1127,7 @@ static int cover_append_item_to_chain(cover_data_t *data, cover_chain_group_t *c
       (*flat_total)++;
       (*nested_total)++;
 
-      if (curr_item->data >= curr_item->atleast) {
+      if (curr_item->data >= curr_item->atleast && curr_item->atleast > 0) {
          (*flat_hits)++;
          (*nested_hits)++;
 

--- a/src/cov/cov-report.c
+++ b/src/cov/cov-report.c
@@ -599,6 +599,7 @@ static void cover_print_bin(FILE *f, cover_pair_t *pair, uint32_t flag,
          fprintf(f, "<td>%s</td>", vals[i]);
 
       fprintf(f, "<td>%d</td>", pair->item->data);
+      fprintf(f, "<td>%d</td>", pair->item->atleast);
 
       if (pkind == PAIR_UNCOVERED)
          cover_print_get_exclude_button(f, pair->item, flag, true);
@@ -625,6 +626,7 @@ static void cover_print_bin_header(FILE *f, cov_pair_kind_t pkind, int cols,
    }
 
    fprintf(f, "<th>Count</th>");
+   fprintf(f, "<th>Threshold</th>");
 
    if (pkind == PAIR_UNCOVERED)
       fprintf(f, "<th>Exclude Command</th>");
@@ -761,6 +763,7 @@ static void cover_print_pairs(FILE *f, cover_pair_t *first, cov_pair_kind_t pkin
          cover_print_item_title(f, curr);
          cover_print_code_loc(f, curr);
          fprintf(f, "<br><b>Count:</b> %d", curr->item->data);
+         fprintf(f, "<br><b>Threshold:</b> %d", curr->item->atleast);
          break;
 
       case COV_ITEM_BRANCH:
@@ -840,6 +843,7 @@ static void cover_print_pairs(FILE *f, cover_pair_t *first, cov_pair_kind_t pkin
             cover_print_item_title(f, curr);
             cover_print_code_loc(f, curr);
             fprintf(f, "<br><b>Count:</b> %d", curr->item->data);
+            fprintf(f, "<br><b>Threshold:</b> %d", curr->item->atleast);
          }
          break;
 

--- a/src/cov/cov-report.c
+++ b/src/cov/cov-report.c
@@ -722,9 +722,9 @@ static void cover_print_bins(FILE *f, cover_pair_t *first_pair, cov_pair_kind_t 
          const char *v[item->n_ranges] LOCAL;
          for (int i = 0; i < item->n_ranges; i++)
             if (item->ranges[i].min == item->ranges[i].max)
-               v[i] = xasprintf("%ld", item->ranges[i].min);
+               v[i] = xasprintf("%d", item->ranges[i].min);
             else
-               v[i] = xasprintf("%ld - %ld", item->ranges[i].min, item->ranges[i].max);
+               v[i] = xasprintf("%d - %d", item->ranges[i].min, item->ranges[i].max);
 
          cover_print_bin(f, pair, COV_FLAG_USER_DEFINED, pkind, item->n_ranges, v);
          break;

--- a/src/cov/cov-report.c
+++ b/src/cov/cov-report.c
@@ -494,7 +494,7 @@ static void cover_print_item_title(FILE *f, cover_pair_t *pair)
       [COV_SRC_STATEMENT] = "Sequential statement",
       [COV_SRC_CONDITION] = "Condition",
       [COV_SRC_PSL_COVER] = "PSL cover point",
-      [COV_SRC_OSVVM_COVER] = "OSVVM cover point",
+      [COV_SRC_USER_COVER] = "User cover point",
       [COV_SRC_UNKNOWN] = "",
    };
 
@@ -577,7 +577,7 @@ static void cover_print_get_exclude_button(FILE *f, cover_item_t *item,
    if (item->kind == COV_ITEM_STMT)
       out_of_table = true;
    else if ((item->kind == COV_ITEM_FUNCTIONAL) &&
-            ((item->flags & COV_FLAG_OSVVM) == 0))
+            ((item->flags & COV_FLAG_USER_DEFINED) == 0))
       out_of_table = true;
 
    fprintf(f, "<button onclick=\"GetExclude('exclude %s')\" %s>"
@@ -717,7 +717,7 @@ static void cover_print_bins(FILE *f, cover_pair_t *first_pair, cov_pair_kind_t 
       case COV_ITEM_FUNCTIONAL:
       {
          cover_item_t *item = pair->item;
-         assert (item->source == COV_SRC_OSVVM_COVER);
+         assert (item->source == COV_SRC_USER_COVER);
 
          const char *v[item->n_ranges] LOCAL;
          for (int i = 0; i < item->n_ranges; i++)
@@ -726,7 +726,7 @@ static void cover_print_bins(FILE *f, cover_pair_t *first_pair, cov_pair_kind_t 
             else
                v[i] = xasprintf("%ld - %ld", item->ranges[i].min, item->ranges[i].max);
 
-         cover_print_bin(f, pair, COV_FLAG_OSVVM, pkind, item->n_ranges, v);
+         cover_print_bin(f, pair, COV_FLAG_USER_DEFINED, pkind, item->n_ranges, v);
          break;
       }
 
@@ -825,7 +825,7 @@ static void cover_print_pairs(FILE *f, cover_pair_t *first, cov_pair_kind_t pkin
          break;
 
       case COV_ITEM_FUNCTIONAL:
-         if (curr->item->source == COV_SRC_OSVVM_COVER) {
+         if (curr->item->source == COV_SRC_USER_COVER) {
             cover_print_item_title(f, curr);
             fprintf(f, "<br>%s", istr(curr->item->func_name));
 

--- a/src/nvc.c
+++ b/src/nvc.c
@@ -302,7 +302,7 @@ static void set_top_level(char **argv, int next_cmd)
 }
 
 static void parse_cover_options(const char *str, cover_mask_t *mask,
-                                int *array_limit)
+                                int *array_limit, int *threshold)
 {
    static const struct {
       const char *name;
@@ -326,6 +326,8 @@ static void parse_cover_options(const char *str, cover_mask_t *mask,
       if (*str == ',' || *str == '\0') {
          if (strncmp(start, "ignore-arrays-from-", 19) == 0)
             *array_limit = parse_int(start + 19);
+         else if (strncmp(start, "threshold-", 10) == 0)
+            *threshold = parse_int(start + 10);
          else {
             int pos = 0;
             for (; pos < ARRAY_LEN(options); pos++) {
@@ -384,6 +386,7 @@ static int elaborate(int argc, char **argv, cmd_state_t *state)
    cover_mask_t cover_mask = 0;
    char *cover_spec_file = NULL, *sdf_args = NULL;
    int cover_array_limit = 0;
+   int threshold = 1;
    const int next_cmd = scan_cmd(2, argc, argv);
    int c, index = 0;
    const char *spec = ":Vg:O:j";
@@ -400,7 +403,8 @@ static int elaborate(int argc, char **argv, cmd_state_t *state)
          break;
       case 'c':
          if (optarg)
-            parse_cover_options(optarg, &(cover_mask), &(cover_array_limit));
+            parse_cover_options(optarg, &(cover_mask), &(cover_array_limit),
+                                &(threshold));
          else
             cover_mask = COVER_MASK_ALL;
          break;
@@ -453,7 +457,7 @@ static int elaborate(int argc, char **argv, cmd_state_t *state)
 
    cover_data_t *cover = NULL;
    if (cover_mask != 0) {
-      cover = cover_data_init(cover_mask, cover_array_limit);
+      cover = cover_data_init(cover_mask, cover_array_limit, threshold);
 
       if (cover_spec_file)
          cover_load_spec_file(cover, cover_spec_file);

--- a/src/rt/cover.c
+++ b/src/rt/cover.c
@@ -429,10 +429,10 @@ void _nvc_add_cover_item(jit_scalar_t *args)
    item->source = COV_SRC_USER_COVER;
    item->atleast = args[7].integer;
    item->flags = COV_FLAG_USER_DEFINED;
-   item->n_ranges = ffi_array_length(args[8].integer);
+   item->n_ranges = ffi_array_length(args[10].integer);
    item->ranges = xcalloc_array(item->n_ranges, sizeof(cover_range_t));
 
-   int32_t *ptr = (int32_t *)args[9].pointer;
+   int32_t *ptr = (int32_t *)args[8].pointer;
 
    for (int i = 0; i < item->n_ranges; i++) {
       item->ranges[i].min = *ptr++;

--- a/src/rt/cover.c
+++ b/src/rt/cover.c
@@ -48,7 +48,7 @@ enum std_ulogic {
 //#define COVER_DEBUG_CALLBACK
 
 ///////////////////////////////////////////////////////////////////////////////
-// Runtime handling
+// Toggle coverage
 ///////////////////////////////////////////////////////////////////////////////
 
 static inline void increment_counter(int32_t *ptr)
@@ -235,6 +235,10 @@ void x_cover_setup_toggle_cb(sig_shared_t *ss, int32_t tag)
    model_set_event_cb(m, s, fn, (void *)(uintptr_t)tag, false);
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// FSM state coverage
+///////////////////////////////////////////////////////////////////////////////
+
 #define READ_STATE(type) offset = *((type *)signal_value(s));
 
 static void cover_state_cb(uint64_t now, rt_signal_t *s, rt_watch_t *w, void *user)
@@ -264,6 +268,10 @@ void x_cover_setup_state_cb(sig_shared_t *ss, int64_t low, int32_t tag)
 
    model_set_event_cb(m, s, cover_state_cb, (void *)(uintptr_t)(tag - low), false);
 }
+
+///////////////////////////////////////////////////////////////////////////////
+// Run-time API
+///////////////////////////////////////////////////////////////////////////////
 
 static cover_scope_t *find_cover_scope(cover_data_t *data, rt_model_t *m,
                                        rt_scope_t *inst)
@@ -311,9 +319,6 @@ void _nvc_create_cover_scope(jit_scalar_t *args)
 
    *ptr = NULL;
 
-   if (name_len == 0)
-      jit_msg(NULL, DIAG_FATAL, "coverage scope name cannot be empty");
-
    rt_model_t *m = get_model_or_null();
    if (m == NULL)
       return;
@@ -330,7 +335,10 @@ void _nvc_create_cover_scope(jit_scalar_t *args)
       return;
 
    LOCAL_TEXT_BUF tb = tb_new();
-   sanitise_name(tb, name_bytes, name_len);
+   if (name_len == 0)
+      tb_printf(tb, "__NVC_FUNC_COVER_POINT");
+   else
+      sanitise_name(tb, name_bytes, name_len);
 
    const size_t pfxlen = tb_len(tb);
    for (int i = 0, dup = 0; i < parent->children.count; i++) {
@@ -354,9 +362,6 @@ void _nvc_add_cover_item(jit_scalar_t *args)
 
    *index_ptr = -1;
 
-   if (name_len == 0)
-      jit_msg(NULL, DIAG_FATAL, "coverage item name cannot be empty");
-
    if (s == NULL || !s->emit)
       return;
 
@@ -371,7 +376,11 @@ void _nvc_add_cover_item(jit_scalar_t *args)
    LOCAL_TEXT_BUF tb = tb_new();
    tb_istr(tb, s->hier);
    tb_append(tb, '.');
-   sanitise_name(tb, name_bytes, name_len);
+
+   if (name_len == 0)
+      tb_printf(tb, "__NVC_FUNC_COVER_BIN");
+   else
+      sanitise_name(tb, name_bytes, name_len);
 
    const size_t pfxlen = tb_len(tb);
    for (int i = 0, dup = 0; i < s->items.count; i++) {

--- a/src/rt/cover.c
+++ b/src/rt/cover.c
@@ -430,13 +430,13 @@ void _nvc_add_cover_item(jit_scalar_t *args)
    item->atleast = args[7].integer;
 
    item->flags = COV_FLAG_USER_DEFINED;
-   if (args[8].integer > 0)
+   if (item->atleast == 0)
       item->flags |= (COV_FLAG_EXCLUDED | COV_FLAG_EXCLUDED_USER);
 
-   item->n_ranges = ffi_array_length(args[11].integer);
+   item->n_ranges = ffi_array_length(args[10].integer);
    item->ranges = xcalloc_array(item->n_ranges, sizeof(cover_range_t));
 
-   int32_t *ptr = (int32_t *)args[9].pointer;
+   int32_t *ptr = (int32_t *)args[8].pointer;
 
    for (int i = 0; i < item->n_ranges; i++) {
       item->ranges[i].min = *ptr++;

--- a/src/rt/cover.c
+++ b/src/rt/cover.c
@@ -369,10 +369,8 @@ void _nvc_set_cover_scope_name(jit_scalar_t *args)
    ident_t name_id = ident_new(tb_get(tb));
 
    if (s->items.count > 0)
-      jit_msg(NULL, DIAG_FATAL, "cover point name can't be set to '%s' "
-                                "since the cover point already contains bins. "
-                                "Set the name before adding any bins",
-                                istr(name_id));
+      jit_msg(NULL, DIAG_FATAL, "cannot change name of cover scope after "
+              "items are created");
 
    s->name = name_id;
    s->block_name = name_id;

--- a/src/rt/cover.c
+++ b/src/rt/cover.c
@@ -428,11 +428,15 @@ void _nvc_add_cover_item(jit_scalar_t *args)
 
    item->source = COV_SRC_USER_COVER;
    item->atleast = args[7].integer;
+
    item->flags = COV_FLAG_USER_DEFINED;
-   item->n_ranges = ffi_array_length(args[10].integer);
+   if (args[8].integer > 0)
+      item->flags |= (COV_FLAG_EXCLUDED | COV_FLAG_EXCLUDED_USER);
+
+   item->n_ranges = ffi_array_length(args[11].integer);
    item->ranges = xcalloc_array(item->n_ranges, sizeof(cover_range_t));
 
-   int32_t *ptr = (int32_t *)args[8].pointer;
+   int32_t *ptr = (int32_t *)args[9].pointer;
 
    for (int i = 0; i < item->n_ranges; i++) {
       item->ranges[i].min = *ptr++;

--- a/src/symbols.txt
+++ b/src/symbols.txt
@@ -52,6 +52,7 @@
   _nvc_create_cover_scope;
   _nvc_add_cover_item;
   _nvc_increment_cover_item;
+  _nvc_set_cover_scope_name;
 
   # Exported from src/rt/simpkg.c
   _nvc_current_delta;

--- a/test/regress/cover25.vhd
+++ b/test/regress/cover25.vhd
@@ -13,7 +13,7 @@ begin
         variable item : t_item_handle;
     begin
         create_cover_scope(handle, "sub_scope");
-        add_cover_item(handle, item, "item", 0, (0 => (min => 0, max => 0)));
+        add_cover_item(handle, item, "item", 1, (0 => (min => 0, max => 0)));
         wait for 5 ns;
         for i in 1 to count loop
             increment_cover_item(handle, item);
@@ -47,8 +47,8 @@ begin
         variable item1, item2 : t_item_handle;
     begin
         create_cover_scope(handle, "top_scope");
-        add_cover_item(handle, item1, "item1", 0, (0 => (min => 0, max => 0)));
-        add_cover_item(handle, item2, "item2", 0, (0 => (min => 0, max => 0)));
+        add_cover_item(handle, item1, "item1", 1, (0 => (min => 0, max => 0)));
+        add_cover_item(handle, item2, "item2", 1, (0 => (min => 0, max => 0)));
         wait for 1 ns;
         increment_cover_item(handle, item1);
         increment_cover_item(handle, item2);
@@ -63,9 +63,9 @@ begin
     begin
         create_cover_scope(handle, "top_scope");
         for i in 1 to 3 loop
-            add_cover_item(handle, item1, "dup", 0, (0 => (min => 0, max => 0)));
+            add_cover_item(handle, item1, "dup", 1, (0 => (min => 0, max => 0)));
         end loop;
-        add_cover_item(handle, item2, " **.x~", 0, (0 => (min => 0, max => 0)));
+        add_cover_item(handle, item2, " **.x~", 1, (0 => (min => 0, max => 0)));
         wait;
     end process;
 

--- a/test/regress/cover25.vhd
+++ b/test/regress/cover25.vhd
@@ -13,7 +13,7 @@ begin
         variable item : t_item_handle;
     begin
         create_cover_scope(handle, "sub_scope");
-        add_cover_item(handle, item, "item", 0, 0, 0, 0, (0 => (min => 0, max => 0)));
+        add_cover_item(handle, item, "item", 0, 1, (0 => (min => 0, max => 0)));
         wait for 5 ns;
         for i in 1 to count loop
             increment_cover_item(handle, item);
@@ -47,8 +47,8 @@ begin
         variable item1, item2 : t_item_handle;
     begin
         create_cover_scope(handle, "top_scope");
-        add_cover_item(handle, item1, "item1", 0, 0, 0, 0, (0 => (min => 0, max => 0)));
-        add_cover_item(handle, item2, "item2", 0, 0, 0, 0, (0 => (min => 0, max => 0)));
+        add_cover_item(handle, item1, "item1", 0, 1, (0 => (min => 0, max => 0)));
+        add_cover_item(handle, item2, "item2", 0, 1, (0 => (min => 0, max => 0)));
         wait for 1 ns;
         increment_cover_item(handle, item1);
         increment_cover_item(handle, item2);
@@ -63,9 +63,9 @@ begin
     begin
         create_cover_scope(handle, "top_scope");
         for i in 1 to 3 loop
-            add_cover_item(handle, item1, "dup", 0, 0, 0, 0, (0 => (min => 0, max => 0)));
+            add_cover_item(handle, item1, "dup", 0, 1, (0 => (min => 0, max => 0)));
         end loop;
-        add_cover_item(handle, item2, " **.x~", 0, 0, 0, 0, (0 => (min => 0, max => 0)));
+        add_cover_item(handle, item2, " **.x~", 0, 1, (0 => (min => 0, max => 0)));
         wait;
     end process;
 

--- a/test/regress/cover25.vhd
+++ b/test/regress/cover25.vhd
@@ -13,7 +13,7 @@ begin
         variable item : t_item_handle;
     begin
         create_cover_scope(handle, "sub_scope");
-        add_cover_item(handle, item, "item", 1, false, (0 => (min => 0, max => 0)));
+        add_cover_item(handle, item, "item", 1, (0 => (min => 0, max => 0)));
         wait for 5 ns;
         for i in 1 to count loop
             increment_cover_item(handle, item);
@@ -47,8 +47,8 @@ begin
         variable item1, item2 : t_item_handle;
     begin
         create_cover_scope(handle, "top_scope");
-        add_cover_item(handle, item1, "item1", 1, false, (0 => (min => 0, max => 0)));
-        add_cover_item(handle, item2, "item2", 1, false, (0 => (min => 0, max => 0)));
+        add_cover_item(handle, item1, "item1", 1, (0 => (min => 0, max => 0)));
+        add_cover_item(handle, item2, "item2", 1, (0 => (min => 0, max => 0)));
         wait for 1 ns;
         increment_cover_item(handle, item1);
         increment_cover_item(handle, item2);
@@ -63,9 +63,9 @@ begin
     begin
         create_cover_scope(handle, "top_scope");
         for i in 1 to 3 loop
-            add_cover_item(handle, item1, "dup", 1, false, (0 => (min => 0, max => 0)));
+            add_cover_item(handle, item1, "dup", 1, (0 => (min => 0, max => 0)));
         end loop;
-        add_cover_item(handle, item2, " **.x~", 1, false, (0 => (min => 0, max => 0)));
+        add_cover_item(handle, item2, " **.x~", 1, (0 => (min => 0, max => 0)));
         wait;
     end process;
 

--- a/test/regress/cover25.vhd
+++ b/test/regress/cover25.vhd
@@ -13,7 +13,7 @@ begin
         variable item : t_item_handle;
     begin
         create_cover_scope(handle, "sub_scope");
-        add_cover_item(handle, item, "item");
+        add_cover_item(handle, item, "item", 0, 0, 0, 0, (0 => (min => 0, max => 0)));
         wait for 5 ns;
         for i in 1 to count loop
             increment_cover_item(handle, item);
@@ -47,8 +47,8 @@ begin
         variable item1, item2 : t_item_handle;
     begin
         create_cover_scope(handle, "top_scope");
-        add_cover_item(handle, item1, "item1");
-        add_cover_item(handle, item2, "item2");
+        add_cover_item(handle, item1, "item1", 0, 0, 0, 0, (0 => (min => 0, max => 0)));
+        add_cover_item(handle, item2, "item2", 0, 0, 0, 0, (0 => (min => 0, max => 0)));
         wait for 1 ns;
         increment_cover_item(handle, item1);
         increment_cover_item(handle, item2);
@@ -63,9 +63,9 @@ begin
     begin
         create_cover_scope(handle, "top_scope");
         for i in 1 to 3 loop
-            add_cover_item(handle, item1, "dup");
+            add_cover_item(handle, item1, "dup", 0, 0, 0, 0, (0 => (min => 0, max => 0)));
         end loop;
-        add_cover_item(handle, item2, " **.x~");
+        add_cover_item(handle, item2, " **.x~", 0, 0, 0, 0, (0 => (min => 0, max => 0)));
         wait;
     end process;
 

--- a/test/regress/cover25.vhd
+++ b/test/regress/cover25.vhd
@@ -13,7 +13,7 @@ begin
         variable item : t_item_handle;
     begin
         create_cover_scope(handle, "sub_scope");
-        add_cover_item(handle, item, "item", 1, (0 => (min => 0, max => 0)));
+        add_cover_item(handle, item, "item", 1, false, (0 => (min => 0, max => 0)));
         wait for 5 ns;
         for i in 1 to count loop
             increment_cover_item(handle, item);
@@ -47,8 +47,8 @@ begin
         variable item1, item2 : t_item_handle;
     begin
         create_cover_scope(handle, "top_scope");
-        add_cover_item(handle, item1, "item1", 1, (0 => (min => 0, max => 0)));
-        add_cover_item(handle, item2, "item2", 1, (0 => (min => 0, max => 0)));
+        add_cover_item(handle, item1, "item1", 1, false, (0 => (min => 0, max => 0)));
+        add_cover_item(handle, item2, "item2", 1, false, (0 => (min => 0, max => 0)));
         wait for 1 ns;
         increment_cover_item(handle, item1);
         increment_cover_item(handle, item2);
@@ -63,9 +63,9 @@ begin
     begin
         create_cover_scope(handle, "top_scope");
         for i in 1 to 3 loop
-            add_cover_item(handle, item1, "dup", 1, (0 => (min => 0, max => 0)));
+            add_cover_item(handle, item1, "dup", 1, false, (0 => (min => 0, max => 0)));
         end loop;
-        add_cover_item(handle, item2, " **.x~", 1, (0 => (min => 0, max => 0)));
+        add_cover_item(handle, item2, " **.x~", 1, false, (0 => (min => 0, max => 0)));
         wait;
     end process;
 

--- a/test/regress/cover25.vhd
+++ b/test/regress/cover25.vhd
@@ -13,7 +13,7 @@ begin
         variable item : t_item_handle;
     begin
         create_cover_scope(handle, "sub_scope");
-        add_cover_item(handle, item, "item", 0, 1, (0 => (min => 0, max => 0)));
+        add_cover_item(handle, item, "item", 0, (0 => (min => 0, max => 0)));
         wait for 5 ns;
         for i in 1 to count loop
             increment_cover_item(handle, item);
@@ -47,8 +47,8 @@ begin
         variable item1, item2 : t_item_handle;
     begin
         create_cover_scope(handle, "top_scope");
-        add_cover_item(handle, item1, "item1", 0, 1, (0 => (min => 0, max => 0)));
-        add_cover_item(handle, item2, "item2", 0, 1, (0 => (min => 0, max => 0)));
+        add_cover_item(handle, item1, "item1", 0, (0 => (min => 0, max => 0)));
+        add_cover_item(handle, item2, "item2", 0, (0 => (min => 0, max => 0)));
         wait for 1 ns;
         increment_cover_item(handle, item1);
         increment_cover_item(handle, item2);
@@ -63,9 +63,9 @@ begin
     begin
         create_cover_scope(handle, "top_scope");
         for i in 1 to 3 loop
-            add_cover_item(handle, item1, "dup", 0, 1, (0 => (min => 0, max => 0)));
+            add_cover_item(handle, item1, "dup", 0, (0 => (min => 0, max => 0)));
         end loop;
-        add_cover_item(handle, item2, " **.x~", 0, 1, (0 => (min => 0, max => 0)));
+        add_cover_item(handle, item2, " **.x~", 0, (0 => (min => 0, max => 0)));
         wait;
     end process;
 

--- a/test/test_elab.c
+++ b/test/test_elab.c
@@ -1673,7 +1673,7 @@ START_TEST(test_issue759)
 
    unit_registry_t *ur = get_registry();
    jit_t *jit = jit_new(ur);
-   cover_data_t *cover = cover_data_init(COVER_MASK_ALL, 0);
+   cover_data_t *cover = cover_data_init(COVER_MASK_ALL, 0, 0);
 
    tree_t e = elab(tree_to_object(a), jit, ur, cover, NULL);
    fail_if(e == NULL);
@@ -1999,7 +1999,7 @@ START_TEST(test_issue1012)
 
    unit_registry_t *ur = get_registry();
    jit_t *jit = jit_new(ur);
-   cover_data_t *cover = cover_data_init(COVER_MASK_TOGGLE, 0);
+   cover_data_t *cover = cover_data_init(COVER_MASK_TOGGLE, 0, 0);
 
    tree_t e = elab(tree_to_object(a), jit, ur, cover, NULL);
    fail_unless(e == NULL);

--- a/test/test_lower.c
+++ b/test/test_lower.c
@@ -1936,7 +1936,7 @@ START_TEST(test_cover)
 
    unit_registry_t *ur = get_registry();
    jit_t *jit = jit_new(ur);
-   cover_data_t *data = cover_data_init(COVER_MASK_STMT | COVER_MASK_EXPRESSION | COVER_MASK_BRANCH, 0);
+   cover_data_t *data = cover_data_init(COVER_MASK_STMT | COVER_MASK_EXPRESSION | COVER_MASK_BRANCH, 0, 0);
    elab(tree_to_object(a), jit, ur, data, NULL);
 
    vcode_unit_t v0 = find_unit("WORK.COVER_ENT.P1");
@@ -2496,7 +2496,7 @@ START_TEST(test_choice1)
 
    unit_registry_t *ur = get_registry();
    jit_t *jit = jit_new(ur);
-   cover_data_t *data = cover_data_init(COVER_MASK_BRANCH, 0);
+   cover_data_t *data = cover_data_init(COVER_MASK_BRANCH, 0, 0);
    elab(tree_to_object(a), jit, ur, data, NULL);
 
    vcode_unit_t v0 = find_unit("WORK.CHOICE1.P1");
@@ -5027,7 +5027,7 @@ START_TEST(test_issue582)
 
    unit_registry_t *ur = unit_registry_new();
    jit_t *jit = jit_new(ur);
-   cover_data_t *data = cover_data_init(COVER_MASK_ALL, 0);
+   cover_data_t *data = cover_data_init(COVER_MASK_ALL, 0, 0);
    elab(tree_to_object(a), jit, ur, data, NULL);
 
    jit_free(jit);


### PR DESCRIPTION
Integrates OSVVM functional coverage to NVC functional coverage.
Adds default name for coverage bin if no name is set. This is needed for `CovPType`.
Adds support for changing name on the fly, since OSVVM API has such function,
and user is not forced to first create with name, and only then create cover bins.

Tracks `atleast` as threshold that needs to be reached for bin to be considered as covered.
Range for each bin is tracked. A global `threshold` option is added. Reporting is debugged:

Supports regular and cross bins. E.g.:
```
Cov1 <= NewID("DUMMY NAME") ;
Cov2 := NewID("DUMMY") ;
wait for 0 ns ; -- Update Cov1
AddCross(Cov1, GenBin(0,10000,3), GenBin(0,2), GenBin(0,2));
AddBins(Cov2, "Bin 10 to 12", GenBin(27,10,12,1));
AddBins(Cov2, "Bin 13 to 15", GenBin(13,15));
```
![image](https://github.com/user-attachments/assets/b6e15961-7bbf-4d5d-a4e0-b49683fbc725)
![image](https://github.com/user-attachments/assets/349f6b05-c491-4d27-9866-4efa337d6f7e)

Needs OSVVM:
[OSVVM NVC integration](https://github.com/OSVVM/OSVVM/pull/96/files)

I guess this will wait until this is merged in OSVVM and new release is made.

