### PR TITLE
Warn on missing wait

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 - OSVVM functional coverage is reported as part of functional coverage
 - Add `threshold-<value>` option for coverage to set minimal coun a
   coverage bin must reach to be reported as covered
+- Added a warning for potential infinite loops in processes without
+  sensitivity and lacking any wait statements (from @NikLeberg).
 
 ## Version 1.14.0 - 2024-09-22
 - Waiting on implicit `'stable` and `'quiet` signals now works

--- a/src/option.c
+++ b/src/option.c
@@ -174,4 +174,5 @@ void set_default_options(void)
    opt_set_int(OPT_SERVER_PORT, 8888);
    opt_set_int(OPT_STDERR_LEVEL, DIAG_DEBUG);
    opt_set_int(OPT_CHECK_SYNTHESIS, 0);
+   opt_set_int(OPT_MISSING_WAIT, 1);
 }

--- a/src/option.h
+++ b/src/option.h
@@ -69,6 +69,7 @@ typedef enum {
    OPT_SERVER_PORT,
    OPT_STDERR_LEVEL,
    OPT_CHECK_SYNTHESIS,
+   OPT_MISSING_WAIT,
 
    OPT_LAST_NAME
 } opt_name_t;

--- a/test/sem/missingwait.vhd
+++ b/test/sem/missingwait.vhd
@@ -1,0 +1,114 @@
+entity foo is end entity;
+
+architecture arch of foo is
+  signal a : bit;
+
+  procedure does_wait is
+  begin
+    wait for 10 ns;
+  end procedure;
+
+  procedure does_not_wait is
+  begin
+    report "not waiting";
+  end procedure;
+
+  procedure does_indirectly_wait is
+  begin
+    does_wait;
+  end procedure;
+begin
+
+  -- Warning, contains no wait.
+  process is
+  begin
+    report "no wait";
+  end process;
+
+  -- Ok, contains wait.
+  process is
+  begin
+    wait for 10 ns;
+  end process;
+
+  -- Ok, has sensitivity.
+  process (a) is
+  begin
+    report "a changed";
+  end process;
+
+  -- Ok, has sensitivity.
+  process (ALL) is
+  begin
+    report "something changed";
+  end process;
+
+  -- Ok, calls procedure with wait.
+  process is
+  begin
+    does_wait;
+  end process;
+
+  -- Warning, calls procedure without wait.
+  process is
+  begin
+    does_not_wait;
+  end process;
+
+  -- Ok, calls procedure with indirect wait.
+  process is
+  begin
+    does_indirectly_wait;
+  end process;
+
+  -- Ok, wait in if block.
+  process is
+  begin
+    if now < 100 ns then
+      wait for 1 ns;
+    else
+      wait;
+    end if;
+  end process;
+
+  -- Ok, pcall with wait in if block.
+  process is
+  begin
+    if now < 100 ns then
+      does_wait;
+    end if;
+  end process;
+
+  -- Ok, wait in case block.
+  process is
+  begin
+    case a is
+      when '0' =>
+        wait for 1 ns;
+      when '1' =>
+        wait for 10 ns;
+      when others =>
+        wait on a;
+    end case;
+  end process;
+
+  -- Ok, pcall with wait in case block.
+  process is
+  begin
+    case a is
+      when '0' =>
+        does_wait;
+      when '1' =>
+        does_not_wait;
+      when others =>
+        null;
+    end case;
+  end process;
+
+  -- Ok, calls procedure with indirect wait.
+  process is
+  begin
+    does_indirectly_wait;
+  end process;
+
+end architecture;

--- a/test/test_sem.c
+++ b/test/test_sem.c
@@ -3821,6 +3821,27 @@ START_TEST(test_issue1020)
 }
 END_TEST
 
+START_TEST(test_missingwait)
+{
+   opt_set_int(OPT_MISSING_WAIT, 1);
+   set_standard(STD_08);
+   input_from_file(TESTDIR "/sem/missingwait.vhd");
+
+   const error_t expect[] = {
+      { 23, "potential infinite loop in process with no sensitivity list and"
+        " no wait statements" },
+      { 53, "potential infinite loop in process with no sensitivity list and"
+        " no wait statements" },
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   parse_and_check(T_ENTITY, T_ARCH);
+
+   check_expected_errors();
+}
+END_TEST
+
 Suite *get_sem_tests(void)
 {
    Suite *s = suite_create("sem");
@@ -3997,6 +4018,7 @@ Suite *get_sem_tests(void)
    tcase_add_test(tc_core, test_issue1010);
    tcase_add_test(tc_core, test_issue1025);
    tcase_add_test(tc_core, test_issue1020);
+   tcase_add_test(tc_core, test_missingwait);
    suite_add_tcase(s, tc_core);
 
    return s;

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -86,6 +86,7 @@ int main(int argc, char **argv)
    opt_set_str(OPT_GC_VERBOSE, getenv("NVC_GC_VERBOSE"));
    opt_set_size(OPT_HEAP_SIZE, 128 * 1024);
    opt_set_int(OPT_GC_STRESS, getenv("NVC_GC_STRESS") != 0);
+   opt_set_int(OPT_MISSING_WAIT, 0);
 
    if (getenv("NVC_LIBPATH") == NULL)
       setenv("NVC_LIBPATH", "./lib", 1);


### PR DESCRIPTION
Hi there!

I did (as sadly common) something stupid and my testbench did ... nothing. I recompiled with questa which gave me an nice warning that one of the processes without sensitivitiy list did not contain any wait statements. Aha! - Found the culprit.

So I thought maybe nvc would profit from a similar warning.

Currenty, this breaks some regression checks as they also trigger this warning. Should this be put behind a flag?
Let me know of any comments or nitpicks. I'm happy to change the pr in any way required.

Cheers.