### PR TITLE
Psl seq implication

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -593,6 +593,8 @@ CCOND             ?i:CCOND
 <PSL>{UNTIL}!            { TOKEN(tUNTIL1); }
 <PSL>{UNTIL}_            { TOKEN(tUNTIL_); }
 <PSL>{UNTIL}_!           { TOKEN(tUNTIL_1); }
+<PSL>"|->"               { TOKEN(tSEQIMPLOVR); }
+<PSL>"|=>"               { TOKEN(tSEQIMPLNOVR); }
 
 <VLOG>"module"           { return tMODULE; }
 <VLOG>"endmodule"        { return tENDMODULE; }

--- a/src/parse.c
+++ b/src/parse.c
@@ -12252,6 +12252,20 @@ static psl_node_t p_psl_fl_property(void)
          return impl;
       }
 
+   case tSEQIMPLOVR:
+   case tSEQIMPLNOVR:
+      {
+         consume(infix);
+
+         psl_node_t impl = psl_new(P_SEQ_IMPLICATION);
+         psl_set_subkind(impl, infix == tSEQIMPLOVR ? PSL_SEQ_IMPL_OVER : PSL_SEQ_IMPL_NOVER);
+         psl_add_operand(impl, p);
+         psl_add_operand(impl, p_psl_fl_property());
+         psl_set_loc(impl, CURRENT_LOC);
+
+         return impl;
+      }
+
    case tUNTIL:
    case tUNTIL_:
    case tUNTIL1:

--- a/src/psl/Makemodule.am
+++ b/src/psl/Makemodule.am
@@ -6,4 +6,6 @@ lib_libnvc_a_SOURCES += \
 	src/psl/psl-lower.c \
 	src/psl/psl-dump.c \
 	src/psl/psl-fsm.h \
-	src/psl/psl-fsm.c
+	src/psl/psl-fsm.c \
+	src/psl/psl-util.h \
+	src/psl/psl-util.c

--- a/src/psl/psl-dump.c
+++ b/src/psl/psl-dump.c
@@ -162,6 +162,16 @@ static void psl_dump_sere(psl_node_t p)
    }
 }
 
+static void psl_dump_seq_implication(psl_node_t p)
+{
+   psl_dump(psl_operand(p, 0));
+   if (psl_subkind(p) == PSL_SEQ_IMPL_NOVER)
+      print_syntax(" |-> ");
+   else
+      print_syntax(" |=> ");
+   psl_dump(psl_operand(p, 1));
+}
+
 static void psl_dump_clock_decl(psl_node_t p)
 {
    print_syntax("#default #clock #is ");
@@ -215,6 +225,9 @@ void psl_dump(psl_node_t p)
       break;
    case P_SERE:
       psl_dump_sere(p);
+      break;
+   case P_SEQ_IMPLICATION:
+      psl_dump_seq_implication(p);
       break;
    default:
       print_syntax("\n");

--- a/src/psl/psl-fsm.c
+++ b/src/psl/psl-fsm.c
@@ -360,16 +360,28 @@ void psl_fsm_dump(psl_fsm_t *fsm, const char *fname)
    fprintf(f, "digraph psl {\n");
 
    for (fsm_state_t *s = fsm->states; s; s = s->next) {
+      fprintf(f, "%d", s->id);
+      fprintf(f, "[label=\"%d", s->id);
+      if (s->accept || s->strong || s->initial)
+         fprintf(f, "\n");
       if (s->accept)
-         fprintf(f, "%d [peripheries=2];\n", s->id);
+         fprintf(f, " A");
+      if (s->initial)
+         fprintf(f, " I");
+      if (s->strong)
+         fprintf(f, " S");
+      fprintf(f, "\"];\n");
 
-      for (fsm_edge_t *e = s->edges; e; e = e->next) {
+      int n = 0;
+      for (fsm_edge_t *e = s->edges; e; e = e->next, n++) {
          fprintf(f, "%d -> %d [", s->id, e->dest->id);
+         fprintf(f, "label=\"");
+         fprintf(f, "  %d", n);
          if (e->guard != NULL) {
-            fprintf(f, "label=\"");
+            fprintf(f, "\n");
             psl_dump_label(f, e->guard);
-            fputs("\",", f);
          }
+         fputs("\",", f);
          if (e->kind == EDGE_EPSILON)
             fputs("style=dashed,", f);
          fprintf(f, "];\n");

--- a/src/psl/psl-fsm.h
+++ b/src/psl/psl-fsm.h
@@ -57,6 +57,10 @@ typedef struct {
 
 psl_fsm_t *psl_fsm_new(psl_node_t p);
 void psl_fsm_free(psl_fsm_t *fsm);
+
+void psl_fsm_append(psl_fsm_t *to, psl_fsm_t *from);
+fsm_state_t *psl_fsm_get_accept(psl_fsm_t *fsm);
+
 void psl_fsm_dump(psl_fsm_t *fsm, const char *fname);
 bool psl_fsm_repeating(psl_fsm_t *fsm);
 

--- a/src/psl/psl-node.c
+++ b/src/psl/psl-node.c
@@ -97,6 +97,9 @@ static const imask_t has_map[P_LAST_PSL_KIND] = {
 
    // P_UNTIL
    (I_PARAMS | I_CLOCK | I_FLAGS),
+
+   // P_SEQ_IMPLICATION
+   (I_SUBKIND | I_PARAMS | I_CLOCK)
 };
 
 static const char *kind_text_map[P_LAST_PSL_KIND] = {
@@ -105,6 +108,7 @@ static const char *kind_text_map[P_LAST_PSL_KIND] = {
    "P_NEVER", "P_EVENTUALLY", "P_NEXT_A", "P_NEXT_E", "P_NEXT_EVENT",
    "P_SERE", "P_IMPLICATION", "P_REPEAT", "P_PROPERTY_INST", "P_SEQUENCE_INST",
    "P_UNION", "P_BUILTIN_FUNC", "P_VALUE_SET", "P_PARAM", "P_UNTIL",
+   "P_SEQ_IMPLICATION"
 };
 
 static const change_allowed_t change_allowed[] = {

--- a/src/psl/psl-node.h
+++ b/src/psl/psl-node.h
@@ -47,14 +47,20 @@ typedef enum {
    P_VALUE_SET,
    P_PARAM,
    P_UNTIL,
+   P_SEQ_IMPLICATION,
 
    P_LAST_PSL_KIND
 } psl_kind_t;
 
 typedef enum {
    PSL_IMPL_IF,
-   PSL_IMPL_IFF,
+   PSL_IMPL_IFF
 } psl_impl_kind_t;
+
+typedef enum {
+   PSL_SEQ_IMPL_OVER,
+   PSL_SEQ_IMPL_NOVER
+} psl_seq_impl_kind_t;
 
 typedef enum {
    PSL_TYPE_HDLTYPE,

--- a/src/psl/psl-sem.c
+++ b/src/psl/psl-sem.c
@@ -180,13 +180,22 @@ static void psl_check_sequence_inst(psl_node_t p)
 {
 
 }
-
 static void psl_check_sere(psl_node_t p, nametab_t *tab)
 {
    const int nops = psl_operands(p);
    for (int i = 0; i < nops; i++)
       psl_check(psl_operand(p, i), tab);
 }
+
+static void psl_check_seq_implication(psl_node_t p, nametab_t *tab)
+{
+   psl_node_t lhs = psl_operand(p, 0);
+   psl_node_t rhs = psl_operand(p, 1);
+
+   psl_check(lhs, tab);
+   psl_check(rhs, tab);
+}
+
 
 static void psl_check_implication(psl_node_t p, nametab_t *tab)
 {
@@ -307,6 +316,9 @@ void psl_check(psl_node_t p, nametab_t *tab)
       break;
    case P_UNTIL:
       psl_check_until(p, tab);
+      break;
+   case P_SEQ_IMPLICATION:
+      psl_check_seq_implication(p, tab);
       break;
    default:
       fatal_trace("cannot check PSL kind %s", psl_kind_str(psl_kind(p)));

--- a/src/psl/psl-util.c
+++ b/src/psl/psl-util.c
@@ -1,0 +1,29 @@
+//
+//  Copyright (C) 2022-2024  Nick Gasson
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "psl/psl-node.h"
+
+bool psl_is_directive(psl_node_t p)
+{
+   psl_kind_t kind = psl_kind(p);
+
+   if (kind == P_ASSERT || kind == P_ASSUME ||
+       kind == P_NEVER || kind == P_COVER)
+      return true;
+
+   return false;
+}

--- a/src/psl/psl-util.h
+++ b/src/psl/psl-util.h
@@ -1,0 +1,20 @@
+//
+//  Copyright (C) 2022-2024  Nick Gasson
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "psl/psl-node.h"
+
+bool psl_is_directive(psl_node_t p);

--- a/src/scan.c
+++ b/src/scan.c
@@ -244,7 +244,8 @@ const char *token_str(token_t tok)
          "name", "arrival", "departure", "slack", "waveform", "increment",
          "absolute", "~&", "~|", "~^", "struct", "packed", "void", "byte",
          "shortint", "longint", "int", "integer", "time", "typedef", "logic",
-         "enum", "tagged",
+         "enum", "tagged", "overlap sequence implication",
+         "non-overlap sequence implication"
       };
 
       if (tok >= 200 && tok - 200 < ARRAY_LEN(token_strs))

--- a/src/scan.h
+++ b/src/scan.h
@@ -393,5 +393,7 @@ bool is_scanned_as_psl(void);
 #define tLOGIC         493
 #define tENUM          494
 #define tTAGGED        495
+#define tSEQIMPLOVR    496
+#define tSEQIMPLNOVR   497
 
 #endif  // _SCAN_H

--- a/test/regress/gold/psl12.txt
+++ b/test/regress/gold/psl12.txt
@@ -1,0 +1,4 @@
+2ns+1: PSL assertion failed
+3ns+1: PSL assertion failed
+5ns+1: PSL assertion failed
+7ns+1: PSL assertion failed

--- a/test/regress/psl12.vhd
+++ b/test/regress/psl12.vhd
@@ -1,0 +1,34 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity psl12 is
+end entity;
+
+architecture tb of psl12 is
+
+    signal clk : natural;
+    signal a,b,c,d : std_logic;
+
+    constant seq_a : std_logic_vector := "0100" & "1000";
+    constant seq_b : std_logic_vector := "0010" & "0100";
+    constant seq_c : std_logic_vector := "0000" & "0010";
+    constant seq_d : std_logic_vector := "0001" & "0000";
+
+begin
+
+    clkgen: clk <= clk + 1 after 1 ns when clk < 7;
+
+    agen: a <= seq_a(clk);
+    bgen: b <= seq_b(clk);
+    cgen: c <= seq_c(clk);
+    dgen: d <= seq_d(clk);
+
+    -- psl default clock is clk'event;
+
+    -- Should fail at: 3 ns and 7 ns
+    -- psl asrt_1 : assert always {a;b} |=> {c;d};
+
+    -- Should fail at 2 ns and 5 ns
+    -- psl asrt_2 : assert always {a;b} |-> c;
+
+end architecture;

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -1060,3 +1060,4 @@ vlog12          verilog
 conv15          normal
 cover25         cover=functional
 issue1035       normal,vhpi,2008
+psl12           psl,fail,gold


### PR DESCRIPTION
Adds simple support for PSL sequence implication. FSMs for LHS and RHS are
created separately and merged. A default transition is added from each state of
LHS FSM into `accept` state of the RHS FSM.

I have added `P_SEQ_IMPLICATION` instead of encoding it into the `P_IMPLICATION`,
it seemed better to separate it.