### PR TITLE
Optimize toggle coverage performance

### DIFF
--- a/src/rt/cover.c
+++ b/src/rt/cover.c
@@ -124,8 +124,8 @@ static inline void cover_toggle_check_0_1_u_z(uint8_t old, uint8_t new,
 #ifdef COVER_DEBUG_CALLBACK
 #define COVER_TGL_CB_MSG(signal)                                              \
    do {                                                                       \
-      printf("Time: %lu Callback on signal: %s\n",                            \
-              now, istr(tree_ident(signal->where)));                          \
+      printf("Time: %lu Callback on signal: %s with size: %d \n",             \
+              now, istr(tree_ident(signal->where)), s->shared.size);          \
    } while (0);
 
 #define COVER_TGL_SIGNAL_DETAILS(signal, size)                                \
@@ -145,25 +145,68 @@ static inline void cover_toggle_check_0_1_u_z(uint8_t old, uint8_t new,
 #define COVER_TGL_SIGNAL_DETAILS(signal, size)
 #endif
 
-// TODO: Could multi-bit signals be optimized with vector instructions ?
-#define DEFINE_COVER_TOGGLE_CB(name, check_fnc)                               \
-   static void name(uint64_t now, rt_signal_t *s, rt_watch_t *w, void *user)  \
-   {                                                                          \
-      uint32_t s_size = s->shared.size;                                       \
-      rt_model_t *m = get_model();                                            \
-      const int32_t tag = (uintptr_t)user;                                    \
-      int32_t *toggle_01 = get_cover_counter(m, tag);                         \
-      int32_t *toggle_10 = toggle_01 + 1;                                     \
-      COVER_TGL_CB_MSG(s)                                                     \
-      for (int i = 0; i < s_size; i++) {                                      \
-         uint8_t new = ((uint8_t*)signal_value(s))[i];                        \
-         uint8_t old = ((uint8_t*)signal_last_value(s))[i];                   \
-         check_fnc(old, new, toggle_01, toggle_10);                           \
-         toggle_01 += 2;                                                      \
-         toggle_10 += 2;                                                      \
-      }                                                                       \
-      COVER_TGL_SIGNAL_DETAILS(s, s_size)                                     \
-   }                                                                          \
+// Set to match word size of common PC and optimize for int64_t comparison
+#define TOGGLE_BATCH_SIZE 8
+
+// Signal size threshold to enable optimization.
+// Signals larger than this size are considered to be less likely to have
+// many change at one callback
+#define TOGGLE_OPT_TH 128
+
+// Callback is optimized for performance
+// Check only group of 8 bytes that do have change of signal value
+#define DEFINE_COVER_TOGGLE_CB(name, check_fnc)                                     \
+   static void name(uint64_t now, rt_signal_t *s, rt_watch_t *w, void *user)        \
+   {                                                                                \
+      uint32_t s_size = s->shared.size;                                             \
+      rt_model_t *m = get_model();                                                  \
+      const int32_t tag = (uintptr_t)user;                                          \
+      COVER_TGL_CB_MSG(s)                                                           \
+      /* For small sized signals, always iterate and assume most bits change */     \
+      if (s_size <= TOGGLE_OPT_TH) {                                                \
+         int32_t *toggle_01 = get_cover_counter(m, tag);                            \
+         int32_t *toggle_10 = toggle_01 + 1;                                        \
+         for (int i = 0; i < s_size; i++) {                                         \
+            uint8_t new = ((uint8_t*)signal_value(s))[i];                           \
+            uint8_t old = ((uint8_t*)signal_last_value(s))[i];                      \
+            check_fnc(old, new, toggle_01, toggle_10);                              \
+            toggle_01 += 2;                                                         \
+            toggle_10 += 2;                                                         \
+         }                                                                          \
+         return;                                                                    \
+      }                                                                             \
+      /* Optimize for assumption that most bits don't change in large signals */    \
+      uint32_t batches = ((s_size - 1) / TOGGLE_BATCH_SIZE) + 1;                    \
+      for (int i = 0; i < batches; i++) {                                           \
+         bool walk = false;                                                         \
+         int batch_size = TOGGLE_BATCH_SIZE;                                        \
+         if (i < batches - 1) {                                                     \
+            const void *batch_new = signal_value(s) + i * TOGGLE_BATCH_SIZE;        \
+            const void *batch_old = signal_last_value(s) + i * TOGGLE_BATCH_SIZE;   \
+            if (*((int64_t*)batch_new) != *((int64_t*)batch_old))                   \
+               walk = true;                                                         \
+         }                                                                          \
+         else {                                                                     \
+            batch_size = ((s_size - 1) % TOGGLE_BATCH_SIZE) + 1;                    \
+            walk = true;                                                            \
+         }                                                                          \
+         if (walk) {                                                                \
+            int32_t low = i * TOGGLE_BATCH_SIZE;                                    \
+            int32_t high = low + batch_size;                                        \
+            int32_t *toggle_01 = get_cover_counter(m, tag) + low * 2;               \
+            int32_t *toggle_10 = toggle_01 + 1;                                     \
+            for (int j = low; j < high; j++) {                                      \
+               uint8_t new = ((uint8_t*)signal_value(s))[j];                        \
+               uint8_t old = ((uint8_t*)signal_last_value(s))[j];                   \
+               if (new != old)                                                      \
+                  check_fnc(old, new, toggle_01, toggle_10);                        \
+               toggle_01 += 2;                                                      \
+               toggle_10 += 2;                                                      \
+            }                                                                       \
+         }                                                                          \
+      }                                                                             \
+      COVER_TGL_SIGNAL_DETAILS(s, s_size)                                           \
+   }                                                                                \
 
 DEFINE_COVER_TOGGLE_CB(cover_toggle_cb_0_1,     cover_toggle_check_0_1)
 DEFINE_COVER_TOGGLE_CB(cover_toggle_cb_0_1_u,   cover_toggle_check_0_1_u)


### PR DESCRIPTION
Optimizes toggle coverage performance.

On large signals (e.g. with `--include-mems`), a loop + check through each byte is
performance bottleneck. The optimization can use the fact that it is likely that not all
signals of a vector change at one time.

Instead, signal bits are split into batches of 8 bytes. An iteration through bytes of batch
is done only when a change occurred in the batch. A change detection is fast since
batch size matches word size. Further, each call to `check_fnc` is done only when
`old_val` and `new_val` differ to prevent falling through all the `if/else` statements if
nothing has changed.

For smaller sized signals the optimization is disabled since these are likely to change
all in a single callback (e.g. address / data bus, etc...).

On common simulation there is almost no visible effect (since optimization is disabled).
E.g. on:
```
library ieee;
use IEEE.std_logic_1164.all;

entity cover26 is
end entity;

architecture test of cover26 is

    type t_mem is array (32767 downto 0) of std_logic_vector(31 downto 0);

    signal mem : t_mem := (others => (others => '0'));

begin

    process
    begin
        for i in 0 to 32767 loop
            mem(i)(0) <= '1';
            wait for 1 ns;
        end loop;
        wait;
     end process;

end architecture;
```
when running with `include-mems` there is 50 % performance improvement.

