### PR TITLE
Fix crash on warning of hidden declaration. Issue #1038

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 - Added a warning for potential infinite loops in processes without
   sensitivity and lacking any wait statements (from @NikLeberg).
 - Fixed a crash when `'last_value` is used with record types (#1043).
+- Several other minor bugs were resolved (#1038).
 
 ## Version 1.14.1 - 2024-10-26
 - Fixed an error when using the `work` library alias and the working

--- a/src/names.c
+++ b/src/names.c
@@ -787,7 +787,7 @@ static void warn_hidden_decl(scope_t *s, decl_t *outer, tree_t inner)
    // to avoid false-positives and cases that may be intentional
 
    for (scope_t *it = s; it && it != outer->origin; it = it->parent) {
-      if (s->container == NULL)
+      if (it->container == NULL)
          return;   // Ignore ports in component, etc.
       else if (is_subprogram(it->container))
          return;   // Do not warn when subprogram parameters hide ports

--- a/test/parse/issue1038.vhd
+++ b/test/parse/issue1038.vhd
@@ -1,0 +1,11 @@
+package foo_pkg is
+  signal sig: integer;
+end foo_pkg;
+
+package body foo_pkg is
+  package bar_pkg is
+    signal sig: integer;
+  end bar_pkg;
+  package body bar_pkg is
+  end package body bar_pkg;
+end package body foo_pkg;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -6912,6 +6912,21 @@ START_TEST(test_issue991)
 }
 END_TEST
 
+START_TEST(test_issue1038)
+{
+   opt_set_int(OPT_RELAXED, 1);
+   set_standard(STD_08);
+
+   input_from_file(TESTDIR "/parse/issue1038.vhd");
+
+   parse_and_check(T_PACKAGE, T_PACK_BODY);
+
+   fail_unless(parse() == NULL);
+
+   fail_if_errors();
+}
+END_TEST
+
 Suite *get_parse_tests(void)
 {
    Suite *s = suite_create("parse");
@@ -7076,6 +7091,7 @@ Suite *get_parse_tests(void)
    tcase_add_test(tc_core, test_issue961);
    tcase_add_test(tc_core, test_issue977);
    tcase_add_test(tc_core, test_issue991);
+   tcase_add_test(tc_core, test_issue1038);
    suite_add_tcase(s, tc_core);
 
    return s;


### PR DESCRIPTION
The fuzzing done by @avelure produced various interesting errors.

The one I try to fix here seems to stem from a simple typo in the implementation of `warn_hidden_decl`.

I added a testcase but it produces another error `../test/test_util.c:199:F:Core:test_issue1038:0: Assertion 'parse() == NULL' failed` But I don't know exactly why. I do not fully understand the test framework though and could be doing something stupid. 

Cheers