### PR TITLE
Add NULL check before calling type_eq.

### DIFF
--- a/src/names.c
+++ b/src/names.c
@@ -890,7 +890,7 @@ static symbol_t *make_visible(scope_t *s, ident_t name, tree_t decl,
          // homographs if they denote different named entities
          return sym;
       }
-      else if (overload && kind == DIRECT
+      else if (overload && kind == DIRECT && type != NULL
                && type_eq(type, tree_type(dd->tree))) {
          if (dd->origin != s) {
             // LRM 93 section 10.3 on visibility specifies that if two

--- a/src/sem.c
+++ b/src/sem.c
@@ -5711,6 +5711,7 @@ static bool sem_static_name(tree_t t, static_fn_t check_fn)
          case T_PARAM_DECL:
          case T_CONCURRENT:
          case T_VIEW_DECL:
+         case T_UNIT_DECL:
             return true;
          case T_ALIAS:
             return sem_static_name(tree_value(decl), check_fn);

--- a/test/parse/issue1038.vhd
+++ b/test/parse/issue1038.vhd
@@ -9,3 +9,7 @@ package body foo_pkg is
   package body bar_pkg is
   end package body bar_pkg;
 end package body foo_pkg;
+
+package foo is
+  alias TO_OCTAL_STRING is ns;
+end package foo;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -6919,7 +6919,7 @@ START_TEST(test_issue1038)
 
    input_from_file(TESTDIR "/parse/issue1038.vhd");
 
-   parse_and_check(T_PACKAGE, T_PACK_BODY);
+   parse_and_check(T_PACKAGE, T_PACK_BODY, T_PACKAGE);
 
    fail_unless(parse() == NULL);
 


### PR DESCRIPTION
Continuation of the fuzzing crashes found by @avelure.
See https://github.com/nickg/nvc/issues/1038#issuecomment-2452911050.

This one happened when `type_eq` was called on a `kind` that is actually `NULL`. I added a simple check. The tests with `make check` are passing and seem to indicate that nothing else was impacted. Lets see what CI thinks of it.

I preliminary merged #1048 to build upon the same test case. I'll rebase once that is in master.

Cheers