### PR TITLE
Fix crash on unexpected psl builtin function in primary

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -570,7 +570,7 @@ BEFORE            ?i:before
 <PSL>{IS}                { TOKEN(tIS); }
 <PSL>"->"                { TOKEN(tIFIMPL); }
 <PSL>"<->"               { TOKEN(tIFFIMPL); }
-<PSL>{NEXT}              { TOKEN(tNEXT); }
+<PSL>{NEXT}              { TOKEN(tPSLNEXT); }
 <PSL>{NEXT}!             { TOKEN(tNEXT1); }
 <PSL>{NEVER}             { TOKEN(tNEVER); }
 <PSL>{EVENTUALLY}!       { TOKEN(tEVENTUALLY); }

--- a/src/parse.c
+++ b/src/parse.c
@@ -4622,7 +4622,7 @@ static tree_t p_primary(tree_t head)
    case tNEW:
       return p_allocator();
 
-   case tNEXT:
+   case tPSLNEXT:
    case tPREV:
    case tSTABLE:
    case tROSE:
@@ -11484,7 +11484,7 @@ static tree_t p_psl_builtin_function_call(void)
 
    BEGIN("PSL Built-in Function call");
 
-   token_t tok = one_of(tNEXT, tPREV, tSTABLE, tROSE, tFELL, tENDED,
+   token_t tok = one_of(tPSLNEXT, tPREV, tSTABLE, tROSE, tFELL, tENDED,
                         tNONDET, tNONDETV);
 
    psl_node_t p = psl_new(P_BUILTIN_FUNC);
@@ -11493,7 +11493,7 @@ static tree_t p_psl_builtin_function_call(void)
    consume(tLPAREN);
 
    switch (tok) {
-   case tNEXT:
+   case tPSLNEXT:
    case tPREV:
    case tSTABLE:
    case tROSE:
@@ -11503,7 +11503,7 @@ static tree_t p_psl_builtin_function_call(void)
       // TODO: Enfore "bit" for "rose" and "fell"
       psl_add_operand(p, p1);
 
-      if (tok == tNEXT)
+      if (tok == tPSLNEXT)
          break;
 
       if (tok == tPREV && optional(tCOMMA)) {
@@ -11549,7 +11549,7 @@ static tree_t p_psl_builtin_function_call(void)
    unsigned kind = 0;
    type_t rvt = type_new(T_NONE);
    switch (tok) {
-   case tNEXT:
+   case tPSLNEXT:
       kind = PSL_BUILTIN_NEXT;
       break;
    case tPREV:
@@ -12176,7 +12176,7 @@ static psl_node_t p_psl_fl_property(void)
       }
       break;
 
-   case tNEXT:
+   case tPSLNEXT:
    case tNEXT1:
       {
          consume(tok);

--- a/src/scan.c
+++ b/src/scan.c
@@ -245,7 +245,7 @@ const char *token_str(token_t tok)
          "absolute", "~&", "~|", "~^", "struct", "packed", "void", "byte",
          "shortint", "longint", "int", "integer", "time", "typedef", "logic",
          "enum", "tagged", "abort", "sync_abort", "async_abort", "before",
-         "before!", "before_", "before!_", "|->", "|=>",
+         "before!", "before_", "before!_", "|->", "|=>", "next",
       };
 
       if (tok >= 200 && tok - 200 < ARRAY_LEN(token_strs))

--- a/src/scan.h
+++ b/src/scan.h
@@ -402,5 +402,6 @@ bool is_scanned_as_psl(void);
 #define tBEFORE1_      502
 #define tSUFFIXOVR     503
 #define tSUFFIXNON     504
+#define tPSLNEXT       505
 
 #endif  // _SCAN_H

--- a/test/parse/issue1038.vhd
+++ b/test/parse/issue1038.vhd
@@ -13,3 +13,15 @@ end package body foo_pkg;
 package foo is
   alias TO_OCTAL_STRING is ns;
 end package foo;
+
+ENTITY psl_func_in_primary IS
+END psl_func_in_primary;
+
+ARCHITECTURE arch OF psl_func_in_primary IS
+  TYPE integer_array IS ARRAY (NATURAL RANGE <>) OF INTEGER;
+  FUNCTION func1(ia: integer_array := (1,2,3,next)) RETURN BOOLEAN IS
+  BEGIN
+    RETURN false;
+  END FUNCTION func1;
+BEGIN
+END ARCHITECTURE arch;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -6919,11 +6919,17 @@ START_TEST(test_issue1038)
 
    input_from_file(TESTDIR "/parse/issue1038.vhd");
 
-   parse_and_check(T_PACKAGE, T_PACK_BODY, T_PACKAGE);
+   const error_t expect[] = {
+      { 22, "unexpected next while parsing primary, expecting one of ??, (, integer, real, null, identifier, string, bit string or new" },
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   parse_and_check(T_PACKAGE, T_PACK_BODY, T_PACKAGE, T_ENTITY, T_ARCH);
 
    fail_unless(parse() == NULL);
 
-   fail_if_errors();
+   check_expected_errors();
 }
 END_TEST
 


### PR DESCRIPTION
Continuation of the fuzzing crashes found by @avelure.
See https://github.com/nickg/nvc/issues/1038#issuecomment-2452959299.

While parsing an unexpected PSL builtin function in a primary nvc does crash on an assertion. I relaxed the assertion to an if check. If the check fails, then the switch falls-through to the already existing error message.

Cheers