### PR TITLE
PSL SERE repetition

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -278,6 +278,7 @@ ENDED         ?i:ended
 NONDET        ?i:nondet
 NONDET_V      ?i:nondet_vector
 UNION         ?i:union
+INF           ?i:inf
 
 INTERCONNECT      ?i:interconnect
 DELAYFILE         ?i:delayfile
@@ -582,8 +583,8 @@ BEFORE            ?i:before
 <PSL>{NEXT_EVENT}!       { TOKEN(tNEXTEVENT1); }
 <PSL>"[*"                { TOKEN(tTIMESRPT); }
 <PSL>"[+]"               { TOKEN(tPLUSRPT); }
-<PSL>"[="                { TOKEN(tGOTORPT); }
-<PSL>"[->"               { TOKEN(tARROWRPT); }
+<PSL>"[="                { TOKEN(tEQRPT); }
+<PSL>"[->"               { TOKEN(tGOTORPT); }
 <PSL>"&&"                { TOKEN(tDBLAMP); }
 <PSL>{WITHIN}            { TOKEN(tWITHIN); }
 <PSL>{PREV}              { TOKEN(tPREV); }
@@ -606,6 +607,7 @@ BEFORE            ?i:before
 <PSL>{BEFORE}!_          { TOKEN(tBEFORE1_); }
 <PSL>"|->"               { TOKEN(tSUFFIXOVR); }
 <PSL>"|=>"               { TOKEN(tSUFFIXNON); }
+<PSL>{INF}               { TOKEN(tINF); }
 
 <VLOG>"module"           { return tMODULE; }
 <VLOG>"endmodule"        { return tENDMODULE; }
@@ -691,8 +693,8 @@ BEFORE            ?i:before
 "<->"                    { TOKEN(tIFFIMPL); }
 "[*"                     { TOKEN(tTIMESRPT); }
 "[+]"                    { TOKEN(tPLUSRPT); }
-"[="                     { TOKEN(tGOTORPT); }
-"[->"                    { TOKEN(tARROWRPT); }
+"[="                     { TOKEN(tEQRPT); }
+"[->"                    { TOKEN(tGOTORPT); }
 {UNTIL}!                 { TOKEN(tUNTIL1); }
 {UNTIL}_                 { TOKEN(tUNTIL_); }
 {UNTIL}!_                { TOKEN(tUNTIL1_); }

--- a/src/psl/psl-node.h
+++ b/src/psl/psl-node.h
@@ -86,7 +86,7 @@ typedef enum {
    PSL_PLUS_REPEAT,
    PSL_TIMES_REPEAT,
    PSL_GOTO_REPEAT,
-   PSL_ARROW_REPEAT
+   PSL_EQUAL_REPEAT
 } psl_repeat_t;
 
 typedef enum {

--- a/src/scan.h
+++ b/src/scan.h
@@ -277,7 +277,7 @@ bool is_scanned_as_psl(void);
 #define tTIMESRPT      377
 #define tPLUSRPT       378
 #define tGOTORPT       379
-#define tARROWRPT      380
+#define tEQRPT         380
 #define tDBLAMP        381
 #define tWITHIN        382
 #define tSYSTASK       383
@@ -403,5 +403,6 @@ bool is_scanned_as_psl(void);
 #define tSUFFIXOVR     503
 #define tSUFFIXNON     504
 #define tPSLNEXT       505
+#define tINF           506
 
 #endif  // _SCAN_H

--- a/test/regress/gold/psl14.txt
+++ b/test/regress/gold/psl14.txt
@@ -1,0 +1,9 @@
+6ns+0: cov_1 hit
+8ns+0: cov_1 hit
+8ns+0: cov_1 hit
+10ns+0: cov_2 hit
+11ns+0: cov_2 hit
+12ns+0: cov_3 hit
+13ns+0: cov_5 hit
+14ns+0: cov_5 hit
+15ns+0: cov_5 hit

--- a/test/regress/psl14.vhd
+++ b/test/regress/psl14.vhd
@@ -1,0 +1,48 @@
+entity psl14 is
+end entity;
+
+architecture tb of psl14 is
+
+    signal clk : natural;
+    signal a,b,c,d,e : bit;
+
+    constant seq_a : bit_vector := "1010101000000000";
+    constant seq_b : bit_vector := "0101010100000000";
+    constant seq_c : bit_vector := "0000000011100000";
+    constant seq_d : bit_vector := "0000011111110000";
+    constant seq_e : bit_vector := "0000000011111110";
+
+begin
+
+    clkgen: clk <= clk + 1 after 1 ns when clk < 15;
+
+    agen: a <= seq_a(clk);
+    bgen: b <= seq_b(clk);
+    cgen: c <= seq_c(clk);
+    dgen: d <= seq_d(clk);
+    egen: e <= seq_e(clk);
+
+    -- psl default clock is clk'event;
+
+    -- Should be hit at:
+    --  6 ns - 3 repetitions (started at 0 ns)
+    --  8 ns - 4 repetitions (started at 0 ns)
+    --  8 ns - 3 repetitions (started at 2 ns)
+    -- psl cov_1 : cover {a;b}[*3 to 4] report "cov_1 hit";
+
+    -- Should be hit at:
+    --  10 ns - First two ones from "111" in seq_c
+    --  11 ns - Last two ones from "111" in seq_c
+    -- psl cov_2 : cover {c;c}[+] report "cov_2 hit";
+
+    -- Should be hit at:
+    --  12 ns - Sequence of "1111111" from seq_d
+    -- psl cov_3 : cover {d}[*7] report "cov_3 hit";
+
+    -- Should be hit at:
+    --  13 ns - After 5 repetitions
+    --  14 ns - After 6 repetitions
+    --  15 ns - After 7 repetitions
+    -- psl cov_5 : cover {e}[*5 to inf] report "cov_5 hit";
+
+end architecture;

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -1070,3 +1070,4 @@ issue1036       normal
 issue1057       normal,vhpi,2008
 issue1062       normal,2008
 cmdline12       shell
+psl14           gold,psl


### PR DESCRIPTION
Hi,

this is a WIP of sequence repetition, not yet ready to be merged.

I would like to discuss how to proceed with the FSM generation. Consider the example below:
```
-- psl cov_1 : cover {a;b}[*2 to 3] report "COVER HIT!";
```
The current code leads to FSM like so:
![image](https://github.com/user-attachments/assets/449515d7-ccba-4cff-8398-c26908b29dd3)

State 1 serves as skip condition when minimal required number of repetitions were already met.
In state 8, I would need to:
- Move to 1 via epsilon edge since two repetitions were hit
- Move to 9 since I would like to track third repetition from next cycle on.

Both of these are un-guarded. I create 8 -> 9 edge during "repeat" part, so it is not guarded since
checking of "third" repetition is by guard on epsilon 9 -> 10.

The `psl_lower_state` fires an assert, since I have two "default" edges, one `EDGE_NEXT`
and one `EDGE_EPSILON`.

I need to activate both 1 and 9 from 8, so "branch" the FSM traverse.
AFAICT, the `psl_lower_state` generates code in `if-elsif-else` manner, making sure only one transition
is activated.

I think the behavior could be:
- All `EDGE_NEXT` edges that have guard are activated if the guard is 1 (instead of the first one matching)
- If `EDGE_NEXT` has no guard, it is always activated.
- `EDGE_EPSILON` will behave as till now (activated in `if-else-if` manner, there can be only one default `EDGE_EPSILON`).

I think the branching behavior will be needed also for some of the other SERE logic (`within` or `&&`).

Maybe some of the PSL syntax will require also multiple activated `EDGE_EPSILON`. But since this is
done with `emit_jump`, it would require more complex logic (some sort of call). Anyway, this is now not
needed, only the points above.

Let me know what do you think. Btw. thanks for all the effort in the recent weeks.