### PR TITLE
MacOS LLVM only requires -L for libzstd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -186,9 +186,6 @@ PKG_CHECK_MODULES([zlib], [zlib >= 1.0.0])
 
 AC_DEFINE_UNQUOTED([FST_REMOVE_DUPLICATE_VC], [1], [Enable FST glitch removal])
 
-# LLVM on macOS also needs libzstd
-PKG_CHECK_MODULES([libzstd], [libzstd >= 1.4])
-
 AC_ARG_ENABLE([llvm],
   [AS_HELP_STRING([--enable-llvm], [Build LLVM code generator])],
   [enable_llvm=$enableval],
@@ -212,6 +209,8 @@ PKG_CHECK_MODULES([capstone], [capstone >= 4.0],
                   [true])
 
 PKG_CHECK_MODULES([libffi], [libffi >= 3.0])
+
+PKG_CHECK_MODULES([libzstd], [libzstd >= 1.4])
 
 AC_ARG_ENABLE([gui],
   [AS_HELP_STRING([--enable-gui], [Build browser-based GUI (WIP)])],

--- a/m4/ax_llvm_c.m4
+++ b/m4/ax_llvm_c.m4
@@ -83,6 +83,15 @@ AC_DEFUN([AX_LLVM_C], [
     LLVM_CONFIG_BINDIR="$($ac_llvm_config $ac_llvm_config_flags --bindir | sed 's|\\|\\\\|g')"
     LLVM_LIBDIR="$($ac_llvm_config --libdir | sed 's|\\|\\\\|g')"
 
+    if test "$llvm_ver_num" -ge "160"; then
+      case $host_os in
+      darwin*)
+        # Add LDFLAGS for libzstd in a non-default location for issue #1046
+        AC_REQUIRE([PKG_PROG_PKG_CONFIG])
+        LLVM_LDFLAGS="$LLVM_LDFLAGS $($PKG_CONFIG --libs-only-L libzstd)"
+      esac
+    fi
+
     if test "$llvm_ver_num" -lt "80"; then
       AC_MSG_ERROR([LLVM version 8.0 or later required])
     fi
@@ -144,14 +153,6 @@ AC_DEFUN([AX_LLVM_C], [
     LIBS_SAVED="$LIBS"
     LIBS="$LIBS $LLVM_LIBS"
     export LIBS
-
-    if test "$llvm_ver_num" -ge "160"; then
-      case $host_os in
-      darwin*)
-        # Add LIBS for libzstd in a non-default location for issue #1046
-        LIBS="$LIBS $libzstd_LIBS"
-      esac
-    fi
 
     AC_CACHE_CHECK([for LLVM ([$1])],
                    ax_cv_llvm,


### PR DESCRIPTION
Another attempt at fixing #1043.