### PR TITLE
Handle invalid use of attribute as range

### DIFF
--- a/src/sem.c
+++ b/src/sem.c
@@ -140,6 +140,10 @@ static bool sem_check_range(tree_t r, type_t expect, nametab_t *tab)
          if (tree_kind(expr) != T_ATTR_REF)
             sem_error(expr, "invalid expression in range constraint");
 
+         const attr_kind_t kind = tree_subkind(expr);
+         if (kind != ATTR_RANGE && kind != ATTR_REVERSE_RANGE)
+            sem_error(expr, "cannot use attribute %s as range", istr(tree_ident(expr)));
+
          if (!sem_check_attr_ref(expr, true, tab))
             return false;
 

--- a/test/sem/issue1038.vhd
+++ b/test/sem/issue1038.vhd
@@ -1,0 +1,6 @@
+package timing_pkg is
+  type type1 is range real'high;       -- error
+  type type2 is range real'base'low;   -- error
+  type type3 is range real'base'range; -- ok
+  type type4 is range natural'range;   -- ok
+end package;

--- a/test/test_sem.c
+++ b/test/test_sem.c
@@ -3860,6 +3860,25 @@ START_TEST(test_issue1024)
 }
 END_TEST
 
+START_TEST(test_issue1038)
+{
+   set_standard(STD_08);
+
+   input_from_file(TESTDIR "/sem/issue1038.vhd");
+
+   const error_t expect[] = {
+      { 2, "cannot use attribute HIGH as range" },
+      { 3, "cannot use attribute LOW as range" },
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   parse_and_check(T_PACKAGE);
+
+   check_expected_errors();
+}
+END_TEST
+
 START_TEST(test_issue1057)
 {
    set_standard(STD_08);
@@ -4056,6 +4075,7 @@ Suite *get_sem_tests(void)
    tcase_add_test(tc_core, test_issue1020);
    tcase_add_test(tc_core, test_missingwait);
    tcase_add_test(tc_core, test_issue1024);
+   tcase_add_test(tc_core, test_issue1038);
    tcase_add_test(tc_core, test_issue1057);
    suite_add_tcase(s, tc_core);
 


### PR DESCRIPTION
Continuation of the fuzzing crashes found by @avelure.
See https://github.com/nickg/nvc/issues/1038#issuecomment-2452978464.

Parsing of the illegal range expression is successful but crashes later on. I added a simple semantic check. I don't quite like that the check function now has two boolean flags `allow_range` and `require_range`.  Maybe this could be consolidated into a single flag? Let me know your thoughts about this.

Cheers

