### PR TITLE
Fix parser hang for integers in scientific notation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 - Fixed a crash when a process sensitivity list contains an external
   name and the process is elaborated before the object referenced by the
   name (#1062).
+- Fixed parser hang for integers in scientific notation (from @NikLeberg).
 - Several other minor bugs were resolved (#1038, #1055, #1057).
 
 ## Version 1.14.1 - 2024-10-26

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -910,10 +910,14 @@ static int parse_decimal_literal(const char *str)
 
       long long int e = (exp ? atoll(exp) : 0);
 
-      if (e >= 0) {  // Minus sign forbidden for an integer literal
+      if (yylval.i64 == 0)
+         tok = tINT;
+      else if (e >= 0) {  // Minus sign forbidden for an integer literal
          for (; e > 0; e--) {
-            if (__builtin_mul_overflow(yylval.i64, INT64_C(10), &yylval.i64))
+            if (__builtin_mul_overflow(yylval.i64, INT64_C(10), &yylval.i64)) {
                overflow = true;
+               break;
+            }
          }
          tok = (sign == NULL) ? tINT : tERROR;
       }

--- a/test/parse/hang.vhd
+++ b/test/parse/hang.vhd
@@ -1,0 +1,7 @@
+entity ent is begin
+end entity ent;
+
+architecture arch of ent is
+    constant i : integer := 0e100000000000; -- used to hang here
+begin
+end architecture arch;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -6948,6 +6948,18 @@ START_TEST(test_issue1055)
 }
 END_TEST
 
+START_TEST(test_hang)
+{
+   input_from_file(TESTDIR "/parse/hang.vhd");
+
+   parse_and_check(T_ENTITY, T_ARCH);
+
+   fail_unless(parse() == NULL);
+
+   fail_if_errors();
+}
+END_TEST
+
 Suite *get_parse_tests(void)
 {
    Suite *s = suite_create("parse");
@@ -7114,6 +7126,7 @@ Suite *get_parse_tests(void)
    tcase_add_test(tc_core, test_issue991);
    tcase_add_test(tc_core, test_issue1038);
    tcase_add_test(tc_core, test_issue1055);
+   tcase_add_test(tc_core, test_hang);
    suite_add_tcase(s, tc_core);
 
    return s;


### PR DESCRIPTION
My own instance of an fuzzer found an hang while parsing integers in scientific notation if the factor is zero.

Cheers