### PR TITLE
feat,test(psl): add non-consecutive and goto repetition support.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,8 @@
 - Partial association of ports with interface views now works correctly
   (#1074).
 - Several other minor bugs were resolved (#1038, #1055, #1057, #1067).
+- Add PSL suffix implication support
+- Add PSL SERE repetition support
 
 ## Version 1.14.1 - 2024-10-26
 - Fixed an error when using the `work` library alias and the working

--- a/src/parse.c
+++ b/src/parse.c
@@ -11836,7 +11836,8 @@ static psl_node_t p_psl_repeat_scheme(void)
 
    case tGOTORPT:
       psl_set_subkind(rpt, PSL_GOTO_REPEAT);
-      psl_set_tree(rpt, p_psl_count());
+      if (peek() != tRSQUARE)
+         psl_set_tree(rpt, p_psl_count());
       consume(tRSQUARE);
       break;
 
@@ -12064,6 +12065,8 @@ static psl_node_t p_psl_sequence(void)
 
    case tPLUSRPT:
    case tTIMESRPT:
+   case tGOTORPT:
+   case tEQRPT:
       p = psl_new(P_SERE);
       break;
 

--- a/src/psl/psl-fsm.c
+++ b/src/psl/psl-fsm.c
@@ -237,37 +237,47 @@ static fsm_state_t *build_sere(psl_fsm_t *fsm, fsm_state_t *state, psl_node_t p)
    return state;
 }
 
-static fsm_state_t *build_repeated_sere(psl_fsm_t *fsm, fsm_state_t *state,
-                                        psl_node_t p)
+static void get_repeat_bounds(psl_node_t p, int *low, int *high, bool *infinite,
+                              bool *noncon, bool *goto_rep)
 {
-   assert(psl_has_repeat(p));
-
-   int low = 0, high = 0;
-
    psl_node_t r = psl_repeat(p);
-   psl_repeat_t rpt_kind = psl_subkind(r);
+   psl_repeat_t kind = psl_subkind(r);
 
-   switch (rpt_kind) {
+   *low = 0;
+   *high = 0;
+   *noncon = false;
+   *goto_rep = false;
+   *infinite = false;
+
+   switch (kind) {
    case PSL_PLUS_REPEAT:
-      low = 1;
-      high = INT32_MAX;
+      *low = 1;
+      *high = INT32_MAX;
       break;
+
+   case PSL_GOTO_REPEAT:
+      *goto_rep = true;
+      // fallthrough
+
+   case PSL_EQUAL_REPEAT:
+      *noncon = true;
+      // fallthrough
 
    case PSL_TIMES_REPEAT:
       if (psl_has_tree(r)) {
          tree_t t_r = psl_tree(r);
          if (tree_kind(t_r) == T_RANGE) {
-            low = get_number(tree_left(t_r));
-            high = get_number(tree_right(t_r));
+            *low = get_number(tree_left(t_r));
+            *high = get_number(tree_right(t_r));
          }
          else {
-            low = get_number(t_r);
-            high = low;
+            *low = get_number(t_r);
+            *high = *low;
          }
       }
       else {
-         low = 0;
-         high = INT32_MAX;
+         *low = 0;
+         *high = INT32_MAX;
       }
       break;
 
@@ -275,27 +285,55 @@ static fsm_state_t *build_repeated_sere(psl_fsm_t *fsm, fsm_state_t *state,
       CANNOT_HANDLE(r);
    }
 
-   bool infinite = false;
-   if (high == INT32_MAX) {
-      infinite = true;
-      high = low;
+   if (*high == INT32_MAX) {
+      *infinite = true;
+      *high = *low;
    }
+}
+
+static fsm_state_t *build_repeated_sere(psl_fsm_t *fsm, fsm_state_t *state,
+                                        psl_node_t p)
+{
+   assert(psl_has_repeat(p));
+
+   int low, high;
+   bool infinite, noncon, goto_rep;
+
+   get_repeat_bounds(p, &low, &high, &infinite, &noncon, &goto_rep);
 
    fsm_state_t *skip = (high > low) ? add_state(fsm, p) : NULL;
    fsm_state_t *initial = state;
    fsm_state_t *last_but_one = NULL;
 
    for (int i = 0; i < high; i++) {
+      bool is_last = (i == high - 1) ? true : false;
+
       last_but_one = state;
       state = build_sere(fsm, state, p);
 
-      if (i != high - 1) {
+      if (noncon) {
+         fsm_state_t *wait = add_state(fsm, p);
+         add_edge(last_but_one, wait, EDGE_EPSILON, NULL);
+         add_edge(wait, last_but_one, EDGE_NEXT, NULL);
+      }
+
+      if (!is_last) {
          if (i >= low - 1)
             add_edge(state, skip, EDGE_EPSILON, NULL);
 
          fsm_state_t *curr = state;
          state = add_state(fsm, p);
          add_edge(curr, state, EDGE_NEXT, NULL);
+      }
+      else if (noncon && !goto_rep) {
+         fsm_state_t *aux = add_state(fsm, p);
+         fsm_state_t *dead = add_state(fsm, p);
+         fsm_state_t *wait = add_state(fsm, p);
+         add_edge(state, aux, EDGE_NEXT, NULL);
+         add_edge(aux, dead, EDGE_EPSILON, psl_operand(p, 0));
+         add_edge(aux, wait, EDGE_EPSILON, NULL);
+         add_edge(wait, aux, EDGE_NEXT, NULL);
+         add_edge(wait, state, EDGE_EPSILON, NULL);
       }
    }
 

--- a/src/scan.c
+++ b/src/scan.c
@@ -224,7 +224,7 @@ const char *token_str(token_t tok)
          "initial", "wire", "unsigned", "assume", "assume_guarantee",
          "restrict", "restrict_guarantee", "strong", "fairness", "cover",
          "property", "sequence", "const", "mutable", "hdltype", "boolean",
-         "bit", "bitvector", "numeric", "string", "[*", "[+]", "[=", "[->",
+         "bit", "bitvector", "numeric", "string", "[*", "[+]", "[->", "[=",
          "&&", "within", "system task", "view", "private", "prev", "stable",
          "rose", "fell", "ended", "nondet", "nondetv", "union", "translate on",
          "translate off", "until!", "until_", "until!_", "`timescale",

--- a/test/regress/gold/psl15.txt
+++ b/test/regress/gold/psl15.txt
@@ -1,0 +1,14 @@
+3ns+0: cov_2 hit
+4ns+0: cov_1 hit
+4ns+0: cov_2 hit
+5ns+0: cov_4 hit
+8ns+0: cov_2 hit
+8ns+0: cov_3 hit
+8ns+0: cov_4 hit
+9ns+0: cov_1 hit
+12ns+0: cov_4 hit
+13ns+0: cov_2 hit
+15ns+0: cov_4 hit
+16ns+0: cov_1 hit
+16ns+0: cov_2 hit
+17ns+0: cov_1 hit

--- a/test/regress/psl15.vhd
+++ b/test/regress/psl15.vhd
@@ -1,0 +1,81 @@
+entity psl15 is
+end entity;
+
+architecture tb of psl15 is
+
+    signal clk : natural;
+    signal a,b,c,d,e,f,g,h,i,j,k,l : bit;
+
+    --    Parts                       A        B            C
+    constant seq_a : bit_vector := "1000" & "10000" & "1000000000";
+    constant seq_b : bit_vector := "0110" & "01010" & "0010100100";
+    constant seq_c : bit_vector := "0001" & "00001" & "0000001110";
+
+    --    Parts                       A          B           C
+    constant seq_d : bit_vector := "1000" & "100000000" & "100000";
+    constant seq_e : bit_vector := "0110" & "001000100" & "011100";
+    constant seq_f : bit_vector := "0011" & "000100001" & "001010";
+
+    --    Parts                         A             B
+    constant seq_g : bit_vector := "100000000" & "1000000000";
+    constant seq_h : bit_vector := "001010100" & "0111000000";
+    constant seq_i : bit_vector := "000000010" & "0000010000";
+
+    --    Parts                         A
+    constant seq_j : bit_vector := "1000000000000000000";
+    constant seq_k : bit_vector := "0101001001100100100";
+    constant seq_l : bit_vector := "0010100100010010000";
+
+begin
+
+    clkgen: clk <= clk + 1 after 1 ns when clk < 18;
+
+    agen: a <= seq_a(clk);
+    bgen: b <= seq_b(clk);
+    cgen: c <= seq_c(clk);
+    dgen: d <= seq_d(clk);
+    egen: e <= seq_e(clk);
+    fgen: f <= seq_f(clk);
+    ggen: g <= seq_g(clk);
+    hgen: h <= seq_h(clk);
+    igen: i <= seq_i(clk);
+    jgen: j <= seq_j(clk);
+    kgen: k <= seq_k(clk);
+    lgen: l <= seq_l(clk);
+
+    -- psl default clock is clk'event;
+
+    -- Should be covered at:
+    --  4 ns - Part A - Consecutive repeat
+    --  9 ns - Part B - Empty cycle in the middle
+    -- 16 ns - Part C - Empty cycle in the start and back
+    -- 17 ns - Part C - Same as previous, continuation of c
+    -- Should not be covered at 18 ns, since b occured again at 17 ns.
+    -- psl cov_1 : cover {a;b[=2];c} report "cov_1 hit";
+
+    -- Should be covered at:
+    --  3 ns - Part A - Due to 1 repetition of e and f in next cycle
+    --  4 ns - Part A - Due to 2 repetitions of e and f in next cycle
+    --  8 ns - Part B - Due to 1 repetition of e and f in next cycle
+    -- 13 ns - Part B - Due to 2 repetitions of e and f in next cycle
+    -- 16 ns - Part C - Due to 1 repetition of e and f in next cycle
+    -- Should not be covered later since e was repeated 3 times before
+    -- another f
+    -- psl cov_2 : cover {d;e[=1 to 2];f} report "cov_2 hit";
+
+    -- Should be covered at:
+    --  8 ns - Part A - 3 repetitions of h followed by i in the next cycle
+    --  Should not be covered in part B since there is one cycle gap
+    --  after last h before i is high
+    -- psl cov_3 : cover {g;h[->3];i} report "cov_3 hit";
+
+    -- Should be covered at:
+    --  5 ns - After 2 repetitions of k and l in next cycle
+    --  8 ns - After 3 repetitions of k and l in next cycle
+    -- 12 ns - After 5 repetitions of k and l in next cycle
+    -- 15 ns - After 6 repetitions of k and l in next cycle
+    -- Should not be covered after 4 and 7 repetitions of k since l is
+    -- not active in the next cycle
+    -- psl cov_4 : cover {j;k[->2 to inf];l} report "cov_4 hit";
+
+end architecture;

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -1072,3 +1072,4 @@ issue1062       normal,2008
 cmdline12       shell
 psl14           gold,psl
 issue1074       normal,2019
+psl15           gold,psl


### PR DESCRIPTION
Implement non-consecutive (`[=`) and goto (`[->`) repetition.

Optional wait cycles between each repetition are handled by helper
state where FSM "waits" for next repetition of boolean.

Last repetition in goto is handled by 3 extra states: `aux`, `dead` and `wait`.
The `aux` , `wait` and the last state of the repetition form a loop that keeps the last
repetition state active until another repetition of boolean expression occurs.
Such N + 1 repetition jumps out of the loop into a `dead` state going nowhere.
