### PR TITLE
feat,test(psl): add SERE fusion support.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,7 @@
 - Partial association of ports with interface views now works correctly
   (#1074).
 - Several other minor bugs were resolved (#1038, #1055, #1057, #1067).
+- Add PSL SERE fusion support
 
 ## Version 1.14.1 - 2024-10-26
 - Fixed an error when using the `work` library alias and the working

--- a/src/psl/psl-fsm.c
+++ b/src/psl/psl-fsm.c
@@ -217,13 +217,17 @@ static fsm_state_t *build_sere(psl_fsm_t *fsm, fsm_state_t *state, psl_node_t p)
 
    for (int i = 0; i < nops; i++) {
       psl_node_t rhs = psl_operand(p, i);
+      edge_kind_t ekind = EDGE_NEXT;
+
       switch (psl_subkind(p)) {
+      case PSL_SERE_FUSION:
+         ekind = EDGE_EPSILON;
       case PSL_SERE_CONCAT:
          if (i + 1 < nops) {
             fsm_state_t *lhs = build_node(fsm, state, rhs);
             if (lhs != state) {
                state = add_state(fsm, p);
-               add_edge(lhs, state, EDGE_NEXT, NULL);
+               add_edge(lhs, state, ekind, NULL);
             }
          }
          else

--- a/test/regress/gold/psl16.txt
+++ b/test/regress/gold/psl16.txt
@@ -1,0 +1,3 @@
+2ns+0: cov_1 hit
+8ns+0: cov_2_hit
+12ns+0: cov_3_hit

--- a/test/regress/psl16.vhd
+++ b/test/regress/psl16.vhd
@@ -1,0 +1,41 @@
+entity psl16 is
+end entity;
+
+architecture tb of psl16 is
+
+    signal clk : natural;
+    signal a,b,c,d,e,f : bit;
+
+    --    Parts                       A        B            C
+    constant seq_a : bit_vector := "011" & "10000" & "10000";
+    constant seq_b : bit_vector := "011" & "01000" & "01000";
+    constant seq_c : bit_vector := "110" & "00100" & "01000";
+
+    constant seq_d : bit_vector := "100" & "00100" & "00100";
+    constant seq_e : bit_vector := "010" & "00010" & "00100";
+    constant seq_f : bit_vector := "001" & "00001" & "00010";
+
+begin
+
+    clkgen: clk <= clk + 1 after 1 ns when clk < 12;
+
+    agen: a <= seq_a(clk);
+    bgen: b <= seq_b(clk);
+    cgen: c <= seq_c(clk);
+    dgen: d <= seq_d(clk);
+    egen: e <= seq_e(clk);
+    fgen: f <= seq_f(clk);
+
+    -- psl default clock is clk'event;
+
+    -- Should be covered at 2ns since a,b,c are high at the same time.
+    -- Should not be covered at 1ns or 3 ns.
+    -- psl cov_1 : cover {a:b:c} report "cov_1 hit";
+
+    -- Should be covered at 8 ns.
+    -- psl cov_2 : cover {{a;b;c}:{d;e;f}} report "cov_2_hit";
+
+    -- Should be covered at 12 ns.
+    -- psl cov_3 : cover {a;b:c;d:e;f} report "cov_3_hit";
+
+end architecture;

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -1072,3 +1072,4 @@ issue1062       normal,2008
 cmdline12       shell
 psl14           gold,psl
 issue1074       normal,2019
+psl16           gold,psl


### PR DESCRIPTION
Implement SERE fusion, upon SERE build use `EDGE_EPSILON` instead of `EDGE_NEXT`
to get boolean expression matching in single cycle.