### PR TITLE
Fix crash on type mark error for protected func.

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -549,11 +549,13 @@ class_t class_of(tree_t t)
    case T_FUNC_BODY:
    case T_FUNC_INST:
    case T_FCALL:
+   case T_PROT_FCALL:
       return C_FUNCTION;
    case T_PROC_DECL:
    case T_PROC_BODY:
    case T_PROC_INST:
    case T_PCALL:
+   case T_PROT_PCALL:
       return C_PROCEDURE;
    case T_ENTITY:
       return C_ENTITY;

--- a/test/parse/protected3.vhd
+++ b/test/parse/protected3.vhd
@@ -1,0 +1,6 @@
+package fred4 is
+  type fred4_t is protected
+    impure function is_empty return boolean;
+    impure function hi_there return is_empty; -- error
+  end protected;
+end package fred4;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -6960,6 +6960,27 @@ START_TEST(test_hang)
 }
 END_TEST
 
+START_TEST(test_protected3)
+{
+   opt_set_int(OPT_RELAXED, 1);
+   set_standard(STD_08);
+
+   input_from_file(TESTDIR "/parse/protected3.vhd");
+
+   const error_t expect[] = {
+      {  4, "type mark does not denote a type or a subtype" },
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   parse_and_check(T_PACKAGE);
+
+   fail_unless(parse() == NULL);
+
+   check_expected_errors();
+}
+END_TEST
+
 Suite *get_parse_tests(void)
 {
    Suite *s = suite_create("parse");
@@ -7127,6 +7148,7 @@ Suite *get_parse_tests(void)
    tcase_add_test(tc_core, test_issue1038);
    tcase_add_test(tc_core, test_issue1055);
    tcase_add_test(tc_core, test_hang);
+   tcase_add_test(tc_core, test_protected3);
    suite_add_tcase(s, tc_core);
 
    return s;


### PR DESCRIPTION
Another crash, another fix.

In generating the hint for the type mark error, nvc crashed as `class_of` did not handle protected function calls. I tried to fix it by adding `T_PROT_FCALL` and preemptively also adding `T_PROT_PCALL`. At various places in the codebase `T_PROT_FCALL` and `T_FCALL` are treated the same. So I thought that could be done here as well.

Cheers