### PR TITLE
Fix parser hang for bit string literals.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@
 - Nested arrays more than two levels deep can now be dumped in FST
   format (#1071).
 - Added support for package external names (#1072).
+- Fixed parser hang for bit string literals (from @NikLeberg).
 - Several other minor bugs were resolved (#1038, #1057, #1067).
 
 ## Version 1.14.2 - 2024-11-23

--- a/src/parse.c
+++ b/src/parse.c
@@ -596,7 +596,13 @@ static tree_t bit_string_to_literal(const char *str, const loc_t *loc)
 
    if (isdigit_iso88591(*p)) {
       require_std(STD_08, "bit string literals with length specifier");
-      length = strtoul(p, (char **)&p, 10);
+      unsigned long slength = strtoul(p, (char **)&p, 10);
+      if (slength > INT32_MAX) {
+         error_at(loc, "sorry, bit strings longer than %d elements are "
+                  "not supported", INT32_MAX);
+         return t;
+      }
+      length = slength;
    }
 
    enum { UNSIGNED, SIGNED } mode = UNSIGNED;

--- a/test/parse/hang.vhd
+++ b/test/parse/hang.vhd
@@ -5,3 +5,14 @@ architecture arch of ent is
     constant i : integer := 0e100000000000; -- used to hang here
 begin
 end architecture arch;
+
+--------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+package hang is
+    constant c0 : std_logic_vector (31 downto 0) := 32sb"1"; -- ok
+    -- used to hang on line below
+    constant c1 : std_logic_vector (31 downto 0) := 32222222222sb"1";
+end package;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -6950,13 +6950,22 @@ END_TEST
 
 START_TEST(test_hang)
 {
+   set_standard(STD_08);
+
    input_from_file(TESTDIR "/parse/hang.vhd");
 
-   parse_and_check(T_ENTITY, T_ARCH);
+   const error_t expect[] = {
+      { 17, "sorry, bit strings longer than 2147483647 elements "
+            "are not supported" },
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   parse_and_check(T_ENTITY, T_ARCH, T_PACKAGE);
 
    fail_unless(parse() == NULL);
 
-   fail_if_errors();
+   check_expected_errors();
 }
 END_TEST
 


### PR DESCRIPTION
As discussed in https://github.com/nickg/nvc/issues/1038#issuecomment-2509724739, this now generates the error you suggested. I added the check at the place where we call `strtoul`, because it may return `ULONG_MAX` which was previously simply truncated into an `int` (I guess `-1`) and silently ignored.

Cheers