### PR TITLE
Fix crash on duplicated protected body.

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -7841,6 +7841,11 @@ static tree_t p_protected_type_body(ident_t id)
    if (decl != NULL) {
       switch (tree_kind(decl)) {
       case T_PROT_BODY:   // Duplicate body will trigger an error later
+         if (!tree_has_primary(decl)) {
+            assert(error_count() > 0); // Fallout from previous error, ignore
+            decl = NULL;
+            break;
+         }
          decl = tree_primary(decl);
          // Fall-through
       case T_PROT_DECL:

--- a/test/parse/protected3.vhd
+++ b/test/parse/protected3.vhd
@@ -4,3 +4,11 @@ package fred4 is
     impure function hi_there return is_empty; -- error
   end protected;
 end package fred4;
+
+--------------------------------------------------------------------------------
+
+package pkg is
+  type SharedCounter is protected body -- first body, but incomplete
+  type SharedCounter is protected body -- duplicated body
+  end protected body;
+end package;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -6979,11 +6979,14 @@ START_TEST(test_protected3)
 
    const error_t expect[] = {
       {  4, "type mark does not denote a type or a subtype" },
+      { 11, "no visible declaration for SHAREDCOUNTER" },
+      { 14, "unexpected package while parsing protected type body, "
+            "expecting protected" },
       { -1, NULL }
    };
    expect_errors(expect);
 
-   parse_and_check(T_PACKAGE);
+   parse_and_check(T_PACKAGE, T_PACKAGE);
 
    fail_unless(parse() == NULL);
 


### PR DESCRIPTION
We crash, we fix.

If a duplicated protected body is parsed while the first body failed to parse correctly, then we crash when trying to get the primary with `tree_primary`. As this is a fallout from previous error(s) I simply added a check.

I'm not sure if you like the use of `assert(error_count() > 0);` (as found multiple times in `sem.c` and `names.c`) also inside `parser.c`, as that would be the first use of it there. 

Thanks.

Ps. Please let me know if I'm creating too many PRs of maybe too-little-value. I definitely don't want to tax your limited spare time.