### PR TITLE
[Fuzz] Raise error when entity aspect is missing in configuration specification.

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -9076,7 +9076,11 @@ static void p_configuration_specification(tree_t parent)
 
    push_scope(nametab);
 
+   bool is_open = (peek() == tUSE && peek_nth(2) == tOPEN);
    tree_t bind = p_binding_indication(comp);
+   if (!is_open && bind == NULL)
+      parse_error(CURRENT_LOC, "a binding indication in an explicit "
+                  "configuration specification must contain an entity aspect");
    consume(tSEMI);
 
    if (ids != NULL) {

--- a/test/parse/config.vhd
+++ b/test/parse/config.vhd
@@ -74,3 +74,15 @@ configuration use_pack_ent of ent is
         end for;
     end for;
 end configuration;
+
+entity b is
+end entity b;
+
+architecture rtl of b is 
+  component ent
+  end component;
+
+  for ent0 : ent; -- Error
+begin
+  ent0: ent;
+end architecture rtl;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -2900,6 +2900,8 @@ START_TEST(test_config)
       { 45, "cannot find architecture BAD of entity WORK.ENT" },
       { 52, "P is not a block that can be configured" },
       { 55, "instance P not found" },
+      { 85, "a binding indication in an explicit configuration "
+            "specification must contain an entity aspect" },
       { -1, NULL }
    };
    expect_errors(expect);
@@ -2978,6 +2980,16 @@ START_TEST(test_config)
    fail_if(c == NULL);
    fail_unless(tree_kind(c) == T_CONFIGURATION);
    lib_put(lib_work(), c);
+
+   e = parse();
+   fail_if(e == NULL);
+   fail_unless(tree_kind(e) == T_ENTITY);
+   lib_put(lib_work(), e);
+
+   e = parse();
+   fail_if(e == NULL);
+   fail_unless(tree_kind(e) == T_ARCH);
+   lib_put(lib_work(), e);
 
    c = parse();
    fail_unless(c == NULL);


### PR DESCRIPTION
Based on crashing fuzzer input `0c1d01dd6f3aea51f8b086c4c788132486f2bfe6079eb33e89f4e69d39945bc7` from issue #1091.

Previously nvc allowed entity aspect to be non existent even though for such explicit cases I think even the standard requires it to be existent.

> LRM 19 section 7.3.2.1: When a binding indication is used in an explicit configuration specification, it is an error if the entity aspect is absent.