### PR TITLE
[Fuzz] Raise error when formal part is illegal.

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -3123,8 +3123,15 @@ static tree_t p_formal_part(type_t *signature)
       }
       break;
 
-   default:
+   case T_RECORD_REF:
+   case T_ARRAY_REF:
+   case T_ARRAY_SLICE:
+   case T_TYPE_CONV:
       break;
+
+   default:
+      parse_error(CURRENT_LOC, "illegal formal designator");
+      return error_expr();
    }
 
    return name;

--- a/src/parse.c
+++ b/src/parse.c
@@ -3109,6 +3109,12 @@ static tree_t p_formal_part(type_t *signature)
    tree_t name = p_name(0);
 
    switch (tree_kind(name)) {
+   case T_RECORD_REF:
+   case T_ARRAY_REF:
+   case T_ARRAY_SLICE:
+   case T_TYPE_CONV:
+      break;
+
    case T_FCALL:
       if (tree_params(name) == 1)
          tree_set_flag(name, TREE_F_CONVERSION);
@@ -3121,13 +3127,9 @@ static tree_t p_formal_part(type_t *signature)
          *signature = p_signature();
          tree_set_loc(name, CURRENT_LOC);
       }
-      break;
-
-   case T_RECORD_REF:
-   case T_ARRAY_REF:
-   case T_ARRAY_SLICE:
-   case T_TYPE_CONV:
-      break;
+      if (!(tree_has_type(name) && type_is_none(tree_type(name))))
+         break;
+      // Fall-through
 
    default:
       parse_error(CURRENT_LOC, "illegal formal designator");

--- a/test/parse/issue1091.vhd
+++ b/test/parse/issue1091.vhd
@@ -9,3 +9,20 @@ architecture struct_adderN of adderN is
 begin
     u: adder port map(addend'last_value => addend);
 end;
+
+--------------------------------------------------------------------------------
+
+LIBRARY IEEE;
+USE IEEE.std_logic_1164.ALL;
+
+PACKAGE Vital_Memory IS END PACKAGE Vital_Memory;
+PACKAGE BODY Vital_Memory IS
+    PROCEDURE InternalTimingCheck (CONSTANT SetupHigh : IN TIME := 0 ns) IS
+    BEGIN
+    END InternalTimingCheck;
+
+    PROCEDURE VitalMemorySetupHoldCheck (SIGNAL TestSignal : IN time) IS
+    BEGIN
+        InternalTimingCheck (IEEE.SetupHigh => TestSignal);
+    END VitalMemorySetupHoldCheck;
+END PACKAGE BODY Vital_Memory;

--- a/test/parse/issue1091.vhd
+++ b/test/parse/issue1091.vhd
@@ -1,0 +1,11 @@
+entity adderN is
+    port(addend: in boolean);
+end;
+
+architecture struct_adderN of adderN is
+    component adder is
+        port(addend: in boolean);
+    end component;
+begin
+    u: adder port map(addend'last_value => addend);
+end;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -7041,11 +7041,12 @@ START_TEST(test_issue1091)
 
    const error_t expect[] = {
       { 10, "illegal formal designator" },
+      { 26, "illegal formal designator" },
       { -1, NULL }
    };
    expect_errors(expect);
 
-   parse_and_check(T_ENTITY, T_ARCH);
+   parse_and_check(T_ENTITY, T_ARCH, T_PACKAGE, T_PACK_BODY);
 
    fail_unless(parse() == NULL);
 

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -7035,6 +7035,24 @@ START_TEST(test_issue1090)
 }
 END_TEST
 
+START_TEST(test_issue1091)
+{
+   input_from_file(TESTDIR "/parse/issue1091.vhd");
+
+   const error_t expect[] = {
+      { 10, "illegal formal designator" },
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   parse_and_check(T_ENTITY, T_ARCH);
+
+   fail_unless(parse() == NULL);
+
+   check_expected_errors();
+}
+END_TEST
+
 Suite *get_parse_tests(void)
 {
    Suite *s = suite_create("parse");
@@ -7205,6 +7223,7 @@ Suite *get_parse_tests(void)
    tcase_add_test(tc_core, test_protected3);
    tcase_add_test(tc_core, test_pkgindecl);
    tcase_add_test(tc_core, test_issue1090);
+   tcase_add_test(tc_core, test_issue1091);
    suite_add_tcase(s, tc_core);
 
    return s;


### PR DESCRIPTION
Based on crashing fuzzer input `51c4a1798e1f1aeff3711fc660cc9fa9a06c8ab38777c4fb40e79b23e5682add_standalone` from issue #1091.

The added check ensures that only _legal_ formal parts are parsed / present in the tree. Otherwise attribute references could end up in there.

I don't know what really constitutes as _legal_ formal part. I simply ran the testsuite and added all occurring (and seemingly valid) kinds to the switch case block. All others trigger a new error.
```c
   case T_RECORD_REF:
   case T_ARRAY_REF:
   case T_ARRAY_SLICE:
   case T_TYPE_CONV:
      break;
```
Please let me know if I forgot something.