### PR TITLE
[Fuzz] Show fuzzy-stack-hash for crashes in debug build.

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -61,6 +61,7 @@ debug_info_t *debug_capture(void);
 void debug_free(debug_info_t *di);
 unsigned debug_count_frames(debug_info_t *di);
 const debug_frame_t *debug_get_frame(debug_info_t *di, unsigned n);
+uint32_t debug_hash(debug_info_t *di);
 
 void debug_add_unwinder(void *start, size_t len, debug_unwind_fn_t fn,
                         void *context);

--- a/src/ident.c
+++ b/src/ident.c
@@ -29,9 +29,6 @@
 #include <ctype.h>
 #include <limits.h>
 
-#define HASH_INIT 5381;
-typedef uint32_t hash_state_t;
-
 #define INITIAL_SIZE  1024
 #define REPROBE_LIMIT 20
 #define MOVED_TAG     1
@@ -67,20 +64,6 @@ typedef struct {
 
 static ident_tab_t *table = NULL;
 static ident_tab_t *resizing = NULL;
-
-static inline int hash_update(hash_state_t *state, const char *key, int nchars)
-{
-   // DJB2 hash function from here:
-   //   http://www.cse.yorku.ca/~oz/hash.html
-
-   hash_state_t hash = *state;
-   const char *p = key;
-   for (; p < key + nchars && *p; p++)
-      hash = ((hash << 5) + hash) + *p;
-
-   *state = hash;
-   return p - key;
-}
 
 static ident_t ident_alloc(size_t len, hash_state_t hash)
 {

--- a/src/util.c
+++ b/src/util.c
@@ -713,6 +713,10 @@ void show_stacktrace(void)
 
    }
 
+#ifdef DEBUG
+   color_fprintf(stderr, "\n$!red$Crash hash: %08x$$\n", debug_hash(di));
+#endif
+
    debug_free(di);
 
 #if defined __linux__ && !defined HAVE_LIBDW && !defined HAVE_LIBDWARF

--- a/src/util.h
+++ b/src/util.h
@@ -514,4 +514,21 @@ void list_clear(ptr_list_t *l);
          __tmp;                                         \
       })
 
+#define HASH_INIT 5381;
+typedef uint32_t hash_state_t;
+
+static inline int hash_update(hash_state_t *state, const char *key, int nchars)
+{
+   // DJB2 hash function from here:
+   //   http://www.cse.yorku.ca/~oz/hash.html
+
+   hash_state_t hash = *state;
+   const char *p = key;
+   for (; p < key + nchars && *p; p++)
+      hash = ((hash << 5) + hash) + *p;
+
+   *state = hash;
+   return p - key;
+}
+
 #endif // _UTIL_H


### PR DESCRIPTION
Hi there,

this is something that helped me to quickly see if different reproducers result in the same crash. Source of the idea is: https://argp.github.io/2014/12/29/fuzzy-stack-hash/

Basically the symbol names of the N last stack frames of the backtrace are hashed. Usually for crashes the text _Please report this bug_ is shown. For debug builds this text is omitted. This PR would add the output of a crash hash in the following form for debug builds:
```
<other stack frames>
[0x565027925c4a] ../src/nvc.c:2193 process_command
       case 'a':
-->       return analyse(argc, argv, state);
       case 'e':
[0x56502792618d] ../src/nvc.c:2355 main
-->    const int ret = process_command(argc, argv, &state);

Crash hash: 79505df7
```

Please feel no obligation to merge this. I simply wanted to offer it. If you deem it useful, you are of course more than welcome to merge it.

Cheers