### PR TITLE
[Fuzz] Fix crash with missing choices in aggregate.

### DIFF
--- a/test/bounds/issue1091.vhd
+++ b/test/bounds/issue1091.vhd
@@ -1,0 +1,17 @@
+package pkg is
+    type vec is array(0 to 3) of integer;
+end pkg;
+
+use work.pkg.all;
+
+entity ent is
+    port (
+        p0 : boolean := vec'(0=>0, 1=>0) = vec'(3=>0);
+        p1 : boolean := vec'(0=>0, 1=>1, 1 to 2=>1) = vec'(others=>0);
+        p2 : boolean := vec'(0=>0, 1=>1, 2 to 3=>1) = vec'(others=>0)
+    );
+end ent;
+
+architecture arch of ent is
+begin
+end architecture arch;

--- a/test/test_bounds.c
+++ b/test/test_bounds.c
@@ -860,6 +860,27 @@ START_TEST(test_issue1021)
 }
 END_TEST
 
+START_TEST(test_issue1091)
+{
+   input_from_file(TESTDIR "/bounds/issue1091.vhd");
+
+   const error_t expect[] = {
+      {  9, "missing choices for elements 2 to 3 of VEC" },
+      {  9, "missing choices for elements 0 to 2 of VEC" },
+      { 10, "value 1 is already covered" },
+      { 10, "missing choice for element 3 of VEC" },
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   parse_check_and_simplify(T_PACKAGE, T_ENTITY, T_ARCH);
+
+   fail_unless(parse() == NULL);
+
+   check_expected_errors();
+}
+END_TEST
+
 Suite *get_bounds_tests(void)
 {
    Suite *s = suite_create("bounds");
@@ -905,6 +926,7 @@ Suite *get_bounds_tests(void)
    tcase_add_test(tc_core, test_issue975);
    tcase_add_test(tc_core, test_issue1040);
    tcase_add_test(tc_core, test_issue1021);
+   tcase_add_test(tc_core, test_issue1091);
    suite_add_tcase(s, tc_core);
 
    return s;


### PR DESCRIPTION
Based on crashing fuzzer input `da346642705230c6f2c89b7c0a522d1078c44b3d0dfd5fe52e2859212edd2784` from issue #1091.

The crash happens because `simplify_local` cannot find the missing choice in the aggregate. Bounds checking reports an error for it, but the check is only done afterwards. This adds a check for missing aggregate choices in `eval_possible` and forbids the early evaluation of such erroneous constructs.

Alternatively one could also do the bounds check before the local simplify and only if there were no errors, but I think that would change the code flow in a lot of places and tests.

Cheers