### PR TITLE
[Fuzz] Fix crash with duplicate aliases in name resolution.

### DIFF
--- a/src/names.c
+++ b/src/names.c
@@ -1611,6 +1611,9 @@ static void hint_for_typo(scope_t *top_scope, diag_t *d, ident_t name,
 
 static type_t get_result_type(nametab_t *tab, tree_t decl)
 {
+   if (tree_kind(decl) == T_ALIAS && !tree_has_type(decl))
+      return tree_type(tree_value(decl));
+
    type_t type = tree_type(decl);
    if (type_kind(type) != T_SIGNATURE || !type_has_result(type))
       return type;

--- a/test/parse/alias5.vhd
+++ b/test/parse/alias5.vhd
@@ -1,0 +1,5 @@
+package test_pkg is
+  alias alias_t is type_t;
+  alias alias_t is type_t;
+  constant c : alias_t;
+end package;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -7089,6 +7089,24 @@ START_TEST(test_issue1096)
 }
 END_TEST
 
+START_TEST(test_alias5)
+{
+   input_from_file(TESTDIR "/parse/alias5.vhd");
+
+   const error_t expect[] = {
+      {  2, "no visible declaration for TYPE_T" },
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   parse_and_check(T_PACKAGE);
+
+   fail_unless(parse() == NULL);
+
+   check_expected_errors();
+}
+END_TEST
+
 Suite *get_parse_tests(void)
 {
    Suite *s = suite_create("parse");
@@ -7261,6 +7279,7 @@ Suite *get_parse_tests(void)
    tcase_add_test(tc_core, test_issue1090);
    tcase_add_test(tc_core, test_issue1091);
    tcase_add_test(tc_core, test_issue1096);
+   tcase_add_test(tc_core, test_alias5);
    suite_add_tcase(s, tc_core);
 
    return s;


### PR DESCRIPTION
When we have more than one alias of the same name but both with no valid type, then we crash in `get_result_type` that gets called from `try_resolve_name`.

I'm not sure what the implications for this change are. All tests pass though.
Alternatively I did come up with another (less elegant) fix that would at least set the type to `T_NONE` for both the invalid aliases:
```diff
diff --git a/src/parse.c b/src/parse.c
index 8a0ed211..ce115359 100644
--- a/src/parse.c
+++ b/src/parse.c
@@ -7471,18 +7471,17 @@ static void p_alias_declaration(tree_t parent)
       }
       tree_set_type(t, type);
    }
-   else if (value_kind == T_REF && tree_has_ref(value)) {
+   else if (value_kind == T_REF && tree_has_ref(value)
+            && is_design_unit(tree_ref(value))) {
       // A nonobject alias may be a design unit which does not have a type
-      tree_t decl = tree_ref(value);
-      if (is_design_unit(decl)) {
-         tree_set_flag(t, TREE_F_NONOBJECT_ALIAS);
-         nonobject_alias = true;
-      }
-      else
-         solve_types(nametab, value, NULL);
+      tree_set_flag(t, TREE_F_NONOBJECT_ALIAS);
+      nonobject_alias = true;
+   }
+   else {
+      type_t type = solve_types(nametab, value, NULL);
+      if (type_is_none(type))
+         tree_set_type(t, type);
    }
-   else
-      solve_types(nametab, value, NULL);
 
    if (value_kind == T_REF && tree_has_ref(value)) {
       tree_t decl = tree_ref(value);
```

Cheers!