### PR TITLE
[Fuzz] Fix crash when new instance with generics is created.

### DIFF
--- a/src/inst.c
+++ b/src/inst.c
@@ -170,7 +170,7 @@ static bool instantiate_should_copy_tree(tree_t t, void *__ctx)
       // Make a unique copy of all public declarations in the package
       return decls != NULL && hset_contains(decls, t);
    case T_REF:
-      return tree_kind(tree_ref(t)) == T_GENERIC_DECL;
+      return tree_has_ref(t) && tree_kind(tree_ref(t)) == T_GENERIC_DECL;
    case T_EXTERNAL_NAME:
       return true;    // Relative paths get converted to absolute
    default:


### PR DESCRIPTION
Given some combination of procedure with invalid generics and a later instantiation thereof, nvc would crash.

One possible input that triggered the crash would be:
```vhd
package pack2 is
    procedure generate_clock
    generic (
        package inner is
        end package;
    ) is begin
    end procedure;

    procedure generate_clock2 is new generate_clock;
end package;
```
But I dunno, but for me that looked way too contrived and broken to be worth to put a test for that.

But preventing the crash seemed worthwhile.