### PR TITLE
[Fuzz] Fix crash with type interface in function parameters. Issue #1108

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -5533,7 +5533,8 @@ static void p_interface_type_declaration(tree_t parent, tree_kind_t kind)
    // immediately following the interface type declaration in the
    // enclosing interface list
 
-   declare_generic_ops(parent, type);
+   if (kind == T_GENERIC_DECL)
+      declare_generic_ops(parent, type);
 }
 
 static void p_formal_parameter_list(tree_t decl, type_t type)

--- a/test/parse/vhdl2008.vhd
+++ b/test/parse/vhdl2008.vhd
@@ -289,4 +289,13 @@ begin
     begin
         proc(x => inertial x);          -- Error
     end block;
+
+    b12: block is
+        function fact generic (
+            function foo( type t ) return natural  -- Error
+        ) return natural is
+        begin
+        end function;
+    begin
+    end block;
 end architecture;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -3626,7 +3626,8 @@ START_TEST(test_vhdl2008)
       { 264, "signed bit string literal cannot be an empty string" },
       { 282, "the reserved word INERTIAL can only be used in port map " },
       { 290, "the reserved word INERTIAL can only be used in port map " },
-      { -1, NULL }
+      { 295, "parameter interface list cannot contain type interface " },
+      {  -1, NULL }
    };
    expect_errors(expect);
 


### PR DESCRIPTION
As discussed in #1108, this adds your suggested check for `kind == T_GENERIC_DECL`.