### PR TITLE
[Fuzz] Fix crash in overload check of invalid alias declarations

### DIFF
--- a/src/names.c
+++ b/src/names.c
@@ -891,6 +891,7 @@ static symbol_t *make_visible(scope_t *s, ident_t name, tree_t decl,
          return sym;
       }
       else if (overload && kind == DIRECT && type != NULL
+               && tree_has_type(dd->tree)
                && type_eq(type, tree_type(dd->tree))) {
          if (dd->origin != s) {
             // LRM 93 section 10.3 on visibility specifies that if two

--- a/test/parse/alias5.vhd
+++ b/test/parse/alias5.vhd
@@ -3,3 +3,9 @@ package test_pkg is
   alias alias_t is type_t;
   constant c : alias_t;
 end package;
+
+package pack is
+  procedure proc;
+  alias proc_alias is x;
+  alias proc_alias is proc [integer];
+end package;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -7096,11 +7096,13 @@ START_TEST(test_alias5)
 
    const error_t expect[] = {
       {  2, "no visible declaration for TYPE_T" },
+      {  9, "no visible declaration for X" },
+      { 10, "no visible subprogram PROC matches signature [INTEGER]" },
       { -1, NULL }
    };
    expect_errors(expect);
 
-   parse_and_check(T_PACKAGE);
+   parse_and_check(T_PACKAGE, T_PACKAGE);
 
    fail_unless(parse() == NULL);
 


### PR DESCRIPTION
Very similar to #1106. When we have two aliases that overload each other/are a duplicate but have both an invalid type (it is actually not set at all), then we crash.

Alternatively to this suggested changes, the fix described in the pr comment in #1106 would also prevent the crash happening.

Cheers.