### PR TITLE
[Fuzz] Fix crash with instantiation of unexpected kind

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -7259,7 +7259,7 @@ static tree_t p_subprogram_instantiation_declaration(void)
    else {
       // Create a dummy subprogram type to avoid later errors
       type_t type = type_new(T_SIGNATURE);
-      type_set_ident(type, tree_ident(name));
+      type_set_ident(type, error_marker());
       if (kind == T_FUNC_INST)
          type_set_result(type, type_new(T_NONE));
 

--- a/test/parse/gensub.vhd
+++ b/test/parse/gensub.vhd
@@ -1,0 +1,3 @@
+package pack is
+    procedure foo is new bar.all;
+end package;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -7108,6 +7108,26 @@ START_TEST(test_alias5)
 }
 END_TEST
 
+START_TEST(test_gensub)
+{
+   set_standard(STD_08);
+
+   input_from_file(TESTDIR "/parse/gensub.vhd");
+
+   const error_t expect[] = {
+      {  2, "expecting uninstantiated subprogram name" },
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   parse_and_check(T_PACKAGE);
+
+   fail_unless(parse() == NULL);
+
+   check_expected_errors();
+}
+END_TEST
+
 Suite *get_parse_tests(void)
 {
    Suite *s = suite_create("parse");
@@ -7281,6 +7301,7 @@ Suite *get_parse_tests(void)
    tcase_add_test(tc_core, test_issue1091);
    tcase_add_test(tc_core, test_issue1096);
    tcase_add_test(tc_core, test_alias5);
+   tcase_add_test(tc_core, test_gensub);
    suite_add_tcase(s, tc_core);
 
    return s;


### PR DESCRIPTION
This fixes the following crash that happens on a fallout from parsing error. The tree object returned by `p_name` is of kind `T_ALL` which does not have an identifier.

```
nvc --std=08 -a --relaxed look.vhd 
** Error: expecting uninstantiated subprogram name
   > look.vhd:2
   |
 2 |     procedure foo is new bar.all;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
** Fatal: tree kind T_ALL does not have item I_IDENT
   > look.vhd:2
   |
 2 |     procedure foo is new bar.all;
   |                          ^^^^^^^
[0x55c540231eb0] ../src/object.c:255 object_lookup_failed
       diag_emit(d);
-->    show_stacktrace();
       fatal_exit(EXIT_FAILURE);
[0x55c5401e5592] ../src/tree.c:553 tree_ident
    {
-->    item_t *item = lookup_item(&tree_object, t, I_IDENT);
       assert(item->ident != NULL);
[0x55c5401c1876] ../src/parse.c:7262 p_subprogram_instantiation_declaration
          type_t type = type_new(T_SIGNATURE);
-->       type_set_ident(type, tree_ident(name));
          if (kind == T_FUNC_INST)
[0x55c5401c6350] ../src/parse.c:8734 p_package_declarative_item
          if (peek_nth(3) == tIS && peek_nth(4) == tNEW)
-->          tree_add_decl(pack, p_subprogram_instantiation_declaration());
          else {
[0x55c5401c66b8] ../src/parse.c:8821 p_package_declarative_part
       while (not_at_token(tEND))
-->       p_package_declarative_item(pack);
    }
[0x55c5401c6a1b] ../src/parse.c:8887 p_package_declaration
-->    p_package_declarative_part(pack);
[0x55c5401c8a2c] ../src/parse.c:9469 p_primary_unit
          else
-->          p_package_declaration(unit);
          break;
[0x55c5401d53b9] ../src/parse.c:13573 p_library_unit
          else
-->          p_primary_unit(unit);
          break;
[0x55c5401d5729] ../src/parse.c:13629 p_design_unit
       p_context_clause(unit);
-->    p_library_unit(unit);
[0x55c5401d5949] ../src/parse.c:13682 parse
-->    tree_t unit = p_design_unit();
[0x55c5402261fe] ../src/common.c:2485 analyse_file
             tree_t unit;
-->          while (base_errors = error_count(), (unit = parse())) {
                if (error_count() == base_errors) {
[0x55c5401993ce] ../src/nvc.c:267 analyse
          else
-->          analyse_file(argv[i], jit, state->registry);
       }
[0x55c54019de0f] ../src/nvc.c:2208 process_command
       case 'a':
-->       return analyse(argc, argv, state);
       case 'e':
[0x55c54019e352] ../src/nvc.c:2370 main
-->    const int ret = process_command(argc, argv, &state);
```