### PR TITLE
[Fuzz] Fix crash with invalid aggregate field name

### DIFF
--- a/src/names.c
+++ b/src/names.c
@@ -4433,9 +4433,9 @@ static type_t solve_record_aggregate(nametab_t *tab, tree_t agg, type_t type)
          {
             push_scope_for_fields(tab, type);
             tree_t name = tree_name(a);
-            solve_types(tab, name, NULL);
+            type_t ntype = solve_types(tab, name, NULL);
             pop_scope(tab);
-            if (tree_has_ref(name)) {
+            if (!type_is_none(ntype) && tree_has_ref(name)) {
                tree_t field = tree_ref(name);
                type_set_add(tab, solve_field_subtype(type, field), field);
                if (tree_kind(field) == T_FIELD_DECL) {

--- a/test/parse/aggregate2.vhd
+++ b/test/parse/aggregate2.vhd
@@ -1,0 +1,13 @@
+package tick is
+  type t_data_segment is record end record;
+  constant C_SEGMENT_RECORDS : t_data_segment := (
+    data'last => (others => '0')  -- Error
+  );
+end package;
+
+package brack is
+  type t_data_segment is record end record;
+  constant C_SEGMENT_RECORDS : t_data_segment := (
+    data[word => (others => '0')  -- Error
+  );
+end package;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -7130,6 +7130,30 @@ START_TEST(test_gensub)
 }
 END_TEST
 
+START_TEST(test_aggregate2)
+{
+   set_standard(STD_19);
+
+   input_from_file(TESTDIR "/parse/aggregate2.vhd");
+
+   const error_t expect[] = {
+      {  4, "no visible declaration for DATA" },
+      {  4, "association choice must be a field name" },
+      { 11, "no visible declaration for WORD" },
+      { 11, "unexpected => while parsing signature" },
+      { 11, "association choice must be a field name" },
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   parse_and_check(T_PACKAGE, T_PACKAGE);
+
+   fail_unless(parse() == NULL);
+
+   check_expected_errors();
+}
+END_TEST
+
 Suite *get_parse_tests(void)
 {
    Suite *s = suite_create("parse");
@@ -7304,6 +7328,7 @@ Suite *get_parse_tests(void)
    tcase_add_test(tc_core, test_issue1096);
    tcase_add_test(tc_core, test_alias5);
    tcase_add_test(tc_core, test_gensub);
+   tcase_add_test(tc_core, test_aggregate2);
    suite_add_tcase(s, tc_core);
 
    return s;


### PR DESCRIPTION
If an aggregate field name happened to be parsed into an attribute, then solving the type for `others` crashed.

```vhd
package tick is
  type t_data_segment is record end record;
  constant C_SEGMENT_RECORDS : t_data_segment := (
    data'last => (others => '0')
  );
end package;
```

```
root@nvc:/workspaces/nvc/fuzz# nvc --std=19 -a --relaxed ../test/parse/aggregate2.vhd 
** Error: no visible declaration for DATA
   > ../test/parse/aggregate2.vhd:6
   |
 6 |     data'last => (others => '0')
   |     ^^^^
** Fatal: tree kind T_ATTR_REF does not have item I_REF
   > ../test/parse/aggregate2.vhd:6
   |
 6 |     data'last => (others => '0')
   |     ^^^^^^^^^
[0x55666c453ea9] ../src/object.c:255 object_lookup_failed
       diag_emit(d);
-->    show_stacktrace();
       fatal_exit(EXIT_FAILURE);
[0x55666c40bc32] ../src/tree.c:1004 tree_has_ref
    {
-->    return lookup_item(&tree_object, t, I_REF)->object != NULL;
    }
[0x55666c4ab76e] ../src/names.c:4438 solve_record_aggregate
                pop_scope(tab);
-->             if (tree_has_ref(name)) {
                   tree_t field = tree_ref(name);
[0x55666c4ac11d] ../src/names.c:4632 try_solve_aggregate
       if (type_is_record(type))
-->       return solve_record_aggregate(tab, agg, type);
       else
[0x55666c4ac173] ../src/names.c:4639 solve_aggregate
    {
-->    type_t type = try_solve_aggregate(tab, agg);
       if (type != NULL)
[0x55666c4ace0a] ../src/names.c:4915 _solve_types
       case T_AGGREGATE:
-->       return solve_aggregate(tab, expr);
       case T_ARRAY_REF:
[0x55666c4ad0ac] ../src/names.c:4975 solve_known_subtype
-->    type_t type = _solve_types(tab, expr);
[0x55666c3e2b6a] ../src/parse.c:6972 p_constant_declaration
          else
-->          solve_known_subtype(nametab, init, type);
       }
[0x55666c3e8435] ../src/parse.c:8760 p_package_declarative_item
       case tCONSTANT:
-->       p_constant_declaration(pack);
          break;
[0x55666c3e86b1] ../src/parse.c:8821 p_package_declarative_part
       while (not_at_token(tEND))
-->       p_package_declarative_item(pack);
    }
[0x55666c3e8a14] ../src/parse.c:8887 p_package_declaration
-->    p_package_declarative_part(pack);
[0x55666c3eaa25] ../src/parse.c:9469 p_primary_unit
          else
-->          p_package_declaration(unit);
          break;
[0x55666c3f73b2] ../src/parse.c:13573 p_library_unit
          else
-->          p_primary_unit(unit);
          break;
[0x55666c3f7722] ../src/parse.c:13629 p_design_unit
       p_context_clause(unit);
-->    p_library_unit(unit);
[0x55666c3f7942] ../src/parse.c:13682 parse
-->    tree_t unit = p_design_unit();
[0x55666c4481f7] ../src/common.c:2485 analyse_file
             tree_t unit;
-->          while (base_errors = error_count(), (unit = parse())) {
                if (error_count() == base_errors) {
[0x55666c3bb3ce] ../src/nvc.c:267 analyse
          else
-->          analyse_file(argv[i], jit, state->registry);
       }
[0x55666c3bfe0f] ../src/nvc.c:2208 process_command
       case 'a':
-->       return analyse(argc, argv, state);
       case 'e':
[0x55666c3c0352] ../src/nvc.c:2370 main
-->    const int ret = process_command(argc, argv, &state);
```

Cheers