### PR TITLE
[Fuzz] Fix crash with invalid range type for aggregate

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -2648,6 +2648,9 @@ bool calculate_aggregate_bounds(tree_t expr, range_kind_t *kind,
 
    type_t type = tree_type(expr);
    type_t index_type = index_type_of(type, 0);
+   if (index_type == NULL || type_is_none(index_type))
+      return false;
+
    tree_t index_r = range_of(index_type, 0), base_r = index_r;
 
    int64_t low, high;

--- a/test/parse/aggregate2.vhd
+++ b/test/parse/aggregate2.vhd
@@ -11,3 +11,10 @@ package brack is
     data[word => (others => '0')  -- Error
   );
 end package;
+
+--------------------------------------------------------------------------------
+
+package pkg is
+  type narr is array (t_direction range <>) of natural;  -- Error
+  constant C : narr := (others => 0);                    -- Error
+end package;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -7142,11 +7142,14 @@ START_TEST(test_aggregate2)
       { 11, "no visible declaration for WORD" },
       { 11, "unexpected => while parsing signature" },
       { 11, "association choice must be a field name" },
+      { 18, "no visible declaration for T_DIRECTION" },
+      { 19, "index range of array aggregate with others choice cannot be "
+            "determined from the context" },
       { -1, NULL }
    };
    expect_errors(expect);
 
-   parse_and_check(T_PACKAGE, T_PACKAGE);
+   parse_and_check(T_PACKAGE, T_PACKAGE, T_PACKAGE);
 
    fail_unless(parse() == NULL);
 


### PR DESCRIPTION
If we try to resolve the bounds of an array aggregate where the index/range type is invalid, we crash. This adds a small check to prevent the crash.

```vhd
package pkg is
  type narr is array (t_direction range <>) of natural;
  constant C : narr := (others => 0);
end package;
```

```
root@nvc:/workspaces/nvc/fuzz# nvc --std=08 -a --relaxed range.vhd 
** Error: no visible declaration for T_DIRECTION
   > range.vhd:2
   |
 2 |   type narr is array (t_direction range <>) of natural;
   |                       ^^^^^^^^^^^
** Fatal: invalid type kind T_NONE in range_of
[0x5636fb65386a] ../src/diag.c:1053 diag_femit
          if (d->stacktrace)
-->          show_stacktrace();
       }
[0x5636fb653a51] ../src/diag.c:1078 diag_emit
       const diag_level_t stderr_level = opt_get_int(OPT_STDERR_LEVEL);
-->    diag_femit(d, d->level >= stderr_level ? stderr : stdout);
    }
[0x5636fb564f5d] ../src/util.c:610 fatal_trace
       diag_set_consumer(NULL, NULL);
-->    diag_emit(d);
       fatal_exit(EXIT_FAILURE);
[0x5636fb5e3b59] ../src/common.c:989 range_of
       default:
-->       fatal_trace("invalid type kind %s in range_of",
                      type_kind_str(type_kind(type)));
[0x5636fb5e8940] ../src/common.c:2651 calculate_aggregate_bounds
       type_t index_type = index_type_of(type, 0);
-->    tree_t index_r = range_of(index_type, 0), base_r = index_r;
[0x5636fb5e8f73] ../src/common.c:2788 calculate_aggregate_subtype
       int64_t ileft, iright;
-->    if (!calculate_aggregate_bounds(expr, &dir, &ileft, &iright))
          return NULL;
[0x5636fb64bfa5] ../src/names.c:4595 solve_array_aggregate
-->    type_t sub = calculate_aggregate_subtype(agg);
       if (sub == NULL) {
[0x5636fb64c14a] ../src/names.c:4634 try_solve_aggregate
       else
-->       return solve_array_aggregate(tab, agg, type);
    }
[0x5636fb64c187] ../src/names.c:4639 solve_aggregate
    {
-->    type_t type = try_solve_aggregate(tab, agg);
       if (type != NULL)
[0x5636fb64ce1e] ../src/names.c:4915 _solve_types
       case T_AGGREGATE:
-->       return solve_aggregate(tab, expr);
       case T_ARRAY_REF:
[0x5636fb64d020] ../src/names.c:4961 solve_types
       type_set_add(tab, constraint, NULL);
-->    type_t type = _solve_types(tab, expr);
       type_set_pop(tab);
[0x5636fb582b4e] ../src/parse.c:6970 p_constant_declaration
          if (standard() < STD_19 || type_is_unconstrained(type))
-->          solve_types(nametab, init, type);
          else
[0x5636fb588435] ../src/parse.c:8760 p_package_declarative_item
       case tCONSTANT:
-->       p_constant_declaration(pack);
          break;
[0x5636fb5886b1] ../src/parse.c:8821 p_package_declarative_part
       while (not_at_token(tEND))
-->       p_package_declarative_item(pack);
    }
[0x5636fb588a14] ../src/parse.c:8887 p_package_declaration
-->    p_package_declarative_part(pack);
[0x5636fb58aa25] ../src/parse.c:9469 p_primary_unit
          else
-->          p_package_declaration(unit);
          break;
[0x5636fb5973b2] ../src/parse.c:13573 p_library_unit
          else
-->          p_primary_unit(unit);
          break;
[0x5636fb597722] ../src/parse.c:13629 p_design_unit
       p_context_clause(unit);
-->    p_library_unit(unit);
[0x5636fb597942] ../src/parse.c:13682 parse
-->    tree_t unit = p_design_unit();
[0x5636fb5e81f7] ../src/common.c:2485 analyse_file
             tree_t unit;
-->          while (base_errors = error_count(), (unit = parse())) {
                if (error_count() == base_errors) {
[0x5636fb55b3ce] ../src/nvc.c:267 analyse
          else
-->          analyse_file(argv[i], jit, state->registry);
       }
[0x5636fb55fe0f] ../src/nvc.c:2208 process_command
       case 'a':
-->       return analyse(argc, argv, state);
       case 'e':
[0x5636fb560352] ../src/nvc.c:2370 main
-->    const int ret = process_command(argc, argv, &state);
```

Note: This also contains the changes from #1121 i.e. depends on it, because the tests are written with the same fileset.

Cheers