### PR TITLE
Add support for `'*_name` attributes of generate block label

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,8 @@
 - `vhpi_assert` now behaves the same as VHDL `assert` for the purposes
   of determining the simulation exit code and early termination (#1060).
 - The `'driving_value` attribute now works correctly with record types.
+- Added basic support for `'instance_name`, `'path_name` and `'simple_name`
+  attributes of generate block labels (from @NikLeberg) (#1125).
 - Several other minor bugs were resolved (#1038, #1057, #1067).
 
 ## Version 1.14.2 - 2024-11-23

--- a/src/common.c
+++ b/src/common.c
@@ -574,6 +574,9 @@ class_t class_of(tree_t t)
    case T_CONCURRENT:
    case T_ELAB:
    case T_PSL:
+   case T_FOR_GENERATE:
+   case T_IF_GENERATE:
+   case T_CASE_GENERATE:
       return C_LABEL;
    case T_COMPONENT:
       return C_COMPONENT;
@@ -1990,6 +1993,7 @@ type_t get_type_or_null(tree_t t)
    case T_GROUP:
    case T_FOR_GENERATE:
    case T_IF_GENERATE:
+   case T_CASE_GENERATE:
    case T_USE:
    case T_CONTEXT:
    case T_PSL:

--- a/src/lower.c
+++ b/src/lower.c
@@ -1496,6 +1496,9 @@ static vcode_reg_t lower_name_attr(lower_unit_t *lu, tree_t decl,
    case T_ARCH:
    case T_PROT_DECL:
    case T_PROT_BODY:
+   case T_FOR_GENERATE:
+   case T_IF_GENERATE:
+   case T_CASE_GENERATE:
       tb_append(tb, ':');
       break;
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -11163,12 +11163,14 @@ static tree_t p_for_generate_statement(ident_t label)
 
    consume(tFOR);
 
-   push_scope(nametab);
-   scope_set_prefix(nametab, label);
-
    tree_t g = tree_new(T_FOR_GENERATE);
    tree_set_ident(g, label);
 
+   if (label != NULL)
+      insert_name(nametab, g, NULL);
+
+   push_scope(nametab);
+   scope_set_prefix(nametab, label);
    scope_set_container(nametab, g);
 
    p_parameter_specification(g, T_GENERIC_DECL);
@@ -11206,6 +11208,9 @@ static tree_t p_if_generate_statement(ident_t label)
 
    tree_t g = tree_new(T_IF_GENERATE);
    tree_set_ident(g, label);
+
+   if (label != NULL)
+      insert_name(nametab, g, NULL);
 
    ident_t alt_label = NULL;
    if (peek() == tID && peek_nth(2) == tCOLON) {
@@ -11341,6 +11346,9 @@ static tree_t p_case_generate_statement(ident_t label)
 
    tree_t g = tree_new(T_CASE_GENERATE);
    tree_set_ident(g, label);
+
+   if (label != NULL)
+      insert_name(nametab, g, NULL);
 
    tree_t value = p_expression();
    tree_set_value(g, value);

--- a/src/sem.c
+++ b/src/sem.c
@@ -4417,14 +4417,15 @@ static bool sem_is_named_entity(tree_t t)
    tree_t decl = tree_ref(t);
 
    switch (tree_kind(decl)) {
-   case T_SIGNAL_DECL:  case T_VAR_DECL:     case T_PORT_DECL:
-   case T_ALIAS:        case T_ENTITY:       case T_ARCH:
-   case T_PACKAGE:      case T_PACK_BODY:    case T_BLOCK:
-   case T_FILE_DECL:    case T_CONST_DECL:   case T_FUNC_DECL:
-   case T_FUNC_BODY:    case T_PROC_DECL:    case T_PROC_BODY:
-   case T_PROCESS:      case T_GENERIC_DECL: case T_PARAM_DECL:
-   case T_INSTANCE:     case T_PROT_DECL:    case T_PROT_BODY:
-   case T_TYPE_DECL:    case T_SUBTYPE_DECL:
+   case T_SIGNAL_DECL:  case T_VAR_DECL:       case T_PORT_DECL:
+   case T_ALIAS:        case T_ENTITY:         case T_ARCH:
+   case T_PACKAGE:      case T_PACK_BODY:      case T_BLOCK:
+   case T_FILE_DECL:    case T_CONST_DECL:     case T_FUNC_DECL:
+   case T_FUNC_BODY:    case T_PROC_DECL:      case T_PROC_BODY:
+   case T_PROCESS:      case T_GENERIC_DECL:   case T_PARAM_DECL:
+   case T_INSTANCE:     case T_PROT_DECL:      case T_PROT_BODY:
+   case T_TYPE_DECL:    case T_SUBTYPE_DECL:   case T_FOR_GENERATE:
+   case T_IF_GENERATE:  case T_CASE_GENERATE:
       return true;
    case T_IMPLICIT_SIGNAL:
       return tree_subkind(decl) == IMPLICIT_GUARD;   // See LRM 93 section 4.3

--- a/test/regress/issue1125.vhd
+++ b/test/regress/issue1125.vhd
@@ -1,0 +1,70 @@
+ENTITY issue1125 IS END ENTITY;
+
+ARCHITECTURE arch OF issue1125 IS
+BEGIN
+
+    gen_if : IF true GENERATE
+        ASSERT gen_if'simple_name = "gen_if";
+        ASSERT gen_if'path_name = ":issue1125:gen_if:";
+    END GENERATE;
+
+    -- *_name attributes in if generate with alternative labels not supported:
+    -- f : FOR i IN 0 TO 2 GENERATE
+    --     gen_if : IF gen_if_0 : i = 0 GENERATE
+    --         ASSERT gen_if'simple_name = "gen_if";
+    --         ASSERT gen_if'path_name = ":issue1125:f(0):gen_if:";
+    --
+    --         ASSERT gen_if_0'simple_name = "gen_if_0";
+    --         ASSERT gen_if_0'path_name = ":issue1125:f(0):gen_if_0:";
+    --
+    --     ELSIF gen_if_1 : i = 1 GENERATE
+    --         ASSERT gen_if'simple_name = "gen_if";
+    --         ASSERT gen_if'path_name = ":issue1125:f(1):gen_if:";
+    --
+    --         ASSERT gen_if_1'simple_name = "gen_if_1";
+    --         ASSERT gen_if_1'path_name = ":issue1125:f(1):gen_if_1:";
+    --
+    --     ELSE GENERATE
+    --         ASSERT gen_if'simple_name = "gen_if";
+    --         ASSERT gen_if'path_name = ":issue1125:f(2):gen_if:";
+    --     END GENERATE;
+    --
+    --     ASSERT gen_if'simple_name = "gen_if";
+    --     ASSERT gen_if'path_name = ":issue1125:f(" & INTEGER'image(i) & "):gen_if:";
+    -- END GENERATE;
+
+    ASSERT gen_if'simple_name = "gen_if";
+    -- Error, currently resolves to ":issue1125:"
+    -- ASSERT gen_if'path_name   = ":issue1125:gen_if:";
+
+    gen_for : FOR i IN 0 TO 1 GENERATE
+        ASSERT gen_for'simple_name = "gen_for";
+        ASSERT gen_for'path_name = ":issue1125:gen_for(" & INTEGER'image(i) & "):";
+    END GENERATE;
+
+    ASSERT gen_for'simple_name = "gen_for";
+    -- Error, currently resolves to ":issue1125:"
+    -- ASSERT gen_for'path_name   = ":issue1125:gen_for:";
+
+    gen_case : CASE true GENERATE
+        WHEN true =>
+            ASSERT gen_case'simple_name = "gen_case";
+            ASSERT gen_case'path_name   = ":issue1125:gen_case:";
+        WHEN false =>
+    END GENERATE;
+
+    ASSERT gen_case'simple_name = "gen_case";
+    -- Error, currently resolves to ":issue1125:"
+    -- ASSERT gen_case'path_name   = ":issue1125:gen_case:";
+
+    -- *_name attributes in case generate with alternative labels not supported:
+    -- gen_case : CASE true GENERATE
+    --     WHEN gen_case_true : true =>
+    --         ASSERT gen_case'simple_name = "gen_case";
+    --         ASSERT gen_case'path_name   = ":issue1125:gen_case:";
+    --
+    --         ASSERT gen_case_true'simple_name = "gen_case_true";
+    --         ASSERT gen_case_true'path_name   = ":issue1125:gen_case_true:";
+    --     WHEN false =>
+    -- END GENERATE;
+END ARCHITECTURE;

--- a/test/regress/issue430.vhd
+++ b/test/regress/issue430.vhd
@@ -94,14 +94,14 @@ architecture MODEL of CHANNEL_PLAYER is
         read_val(signals.AR.ADDR(ADDR_WIDTH-1 downto 0));
     end procedure;
 begin
-    CHANNEL_M: if (CHANNEL = CHANNEL_M) generate
+    gCHANNEL_M: if (CHANNEL = CHANNEL_M) generate
         PROCESS_M: process
         begin
             FINISH <= '1';
             wait;
         end process;
     end generate;
-    CHANNEL_A:if (CHANNEL = CHANNEL_AW or CHANNEL = CHANNEL_AR) generate
+    gCHANNEL_A:if (CHANNEL = CHANNEL_AW or CHANNEL = CHANNEL_AR) generate
         PROCESS_A: process
             procedure execute_output is
             begin
@@ -125,7 +125,7 @@ begin
             wait;
         end process;
     end generate;
-    CHANNEL_D:if (CHANNEL = CHANNEL_DW  or CHANNEL = CHANNEL_DR) generate
+    gCHANNEL_D:if (CHANNEL = CHANNEL_DW  or CHANNEL = CHANNEL_DR) generate
         PROCESS_D: process
             procedure execute_output is
             begin

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -1091,3 +1091,4 @@ conv18          normal
 ename17         fail,gold,2008
 cmdline13       shell
 issue1117       normal,psl,2008
+issue1125       normal,2008


### PR DESCRIPTION
I had a bit of fun trying to fix issue #1125 as it seemed rather simple.

The basic stuff works. But some other does not:
 - [ ] does not support alternative labels for if/case generate blocks
   - I had trouble supporting both, the normal label and the alternative label at the same time. Because the current code overwrites the ident of the generate block if an alternative label was found. In such a case `gen_case` and `gen_case_true` would both resolve to `gen_case_true`.
 - [ ] if the `'path_name` is accessed from outside the generate block, instead of returning e.g. `:issue1125:gen_case:` it returns only `:issue1125:`
   - Interesting to think about what we would even return for the `gen_for` label if we are outside the loop. Inside we have `gen_for(0)`, `gen_for(1)`, etc. But outside? Only `gen_for`?
   - I tested this with modelsim and it returns whatever it wants.... sometimes `gen_for(1)` and sometimes `gen_for`. So it does not seem very important.

Let me know if you see another way of implementing it. Please feel also absolutely free to discard everything and implement your own fix.

Cheers

Fixes #1125