### PR TITLE
[Fuzz] Fix crash with call with too many named arguments. Issue #1091

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 ## Unreleased changes
+- Fixed a crash when a subprogram is called with too many named arguments
+  (from @NikLeberg) (#1091).
 
 ## Version 1.15.0 - 2025-01-11
 - `--load` is now a global option and should be placed before the `-r`

--- a/src/sem.c
+++ b/src/sem.c
@@ -3322,7 +3322,16 @@ static bool sem_check_call_args(tree_t t, tree_t decl, nametab_t *tab)
                }
             }
 
-            if (index == -1 || !tree_has_ref(ref)) {
+            if (index == -1) {
+               diag_t *d = diag_new(DIAG_ERROR, tree_loc(param));
+               diag_printf(d, "subprogram %s has no parameter named %s",
+                           type_pp(tree_type(decl)), istr(id));
+               diag_hint(d, tree_loc(decl), "subprogram defined here");
+               diag_emit(d);
+               return false;
+            }
+
+            if (!tree_has_ref(ref)) {
                // Should have generated an error during overload
                // resolution
                assert(error_count() > 0);

--- a/test/parse/issue1091b.vhd
+++ b/test/parse/issue1091b.vhd
@@ -1,0 +1,21 @@
+PACKAGE Vital_Memory IS END Vital_Memory;
+
+PACKAGE BODY Vital_Memory IS
+    PROCEDURE MemoryTableCorruptMask (
+        VARIABLE CorruptMask : OUT INTEGER
+    ) IS
+    BEGIN
+    END;
+
+    PROCEDURE MemoryTableLookUp (
+        VARIABLE DataCorruptMask : OUT INTEGER;
+        CONSTANT EnableIndex     : IN INTEGER
+    ) IS
+    BEGIN
+        MemoryTableCorruptMask (
+            CorruptMask => DataCorruptMask,
+            EnableIndex => EnableIndex
+        );
+    END;
+
+END PACKAGE BODY Vital_Memory;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -7071,6 +7071,25 @@ START_TEST(test_issue1091)
 }
 END_TEST
 
+START_TEST(test_issue1091b)
+{
+   input_from_file(TESTDIR "/parse/issue1091b.vhd");
+
+   const error_t expect[] = {
+      { 17, "subprogram MEMORYTABLECORRUPTMASK [INTEGER] "
+            "has no parameter named ENABLEINDEX" },
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   parse_and_check(T_PACKAGE, T_PACK_BODY);
+
+   fail_unless(parse() == NULL);
+
+   check_expected_errors();
+}
+END_TEST
+
 START_TEST(test_issue1096)
 {
    input_from_file(TESTDIR "/parse/issue1096.vhd");
@@ -7356,6 +7375,7 @@ Suite *get_parse_tests(void)
    tcase_add_test(tc_core, test_pkgindecl);
    tcase_add_test(tc_core, test_issue1090);
    tcase_add_test(tc_core, test_issue1091);
+   tcase_add_test(tc_core, test_issue1091b);
    tcase_add_test(tc_core, test_issue1096);
    tcase_add_test(tc_core, test_alias5);
    tcase_add_test(tc_core, test_gensub);


### PR DESCRIPTION
Based on crashing fuzzer input `a04900efaed84ebf347d7c8325e5bf9fd96b67deb31508d4149b17b558e703c0_standalone` from issue #1091.

If a procedure (or function) is called with too many named arguments, then `sem_check_call_args` asserts that an error in overload resolution must have been reported. But that may not always be the case.

The output of the new error is as follows:
```
# nvc --std=08 -a ../test/parse/issue1091b.vhd 
** Error: subprogram MEMORYTABLECORRUPTMASK [INTEGER] has no parameter named ENABLEINDEX
    > ../test/parse/issue1091b.vhd:17
    |
  4 |     PROCEDURE MemoryTableCorruptMask (
    |     ^ subprogram defined here
 ...
 17 |             EnableIndex => EnableIndex
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ error occurred here
```

Note: As the crash is depending on `error_count()` returning 0, I put it into a standalone test.

Cheers