### PR TITLE
Replace redundant copy of libraryName with missing copy of modelName

### DIFF
--- a/src/vhpi/vhpi-model.c
+++ b/src/vhpi/vhpi-model.c
@@ -3564,7 +3564,7 @@ vhpiHandleT vhpi_register_foreignf(vhpiForeignDataT *foreignDatap)
 
          // Make a defensive copy of the passed-in strings
          f->data.libraryName = (char *)new_string(foreignDatap->libraryName);
-         f->data.libraryName = (char *)new_string(foreignDatap->libraryName);
+         f->data.modelName = (char *)new_string(foreignDatap->modelName);
 
          vhpi_context_t *c = vhpi_context();
          APUSH(c->foreignfs, &(f->object));


### PR DESCRIPTION
I stumbled over this earlier, figured it must be a mistake?