### PR TITLE
implement rose, fell and stable PSL built-in functions.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## Unreleased changes
-- Added support for PSL `prev()` built-in function (#1135).
+- Added support for PSL `prev()`, `stable()`, `rose()` and `fell()`
+  built-in functions (#1135).
 
 ## Version 1.15.1 - 2025-01-22
 - Fixed a crash when a subprogram is called with too many named arguments

--- a/src/parse.c
+++ b/src/parse.c
@@ -4652,6 +4652,7 @@ static tree_t p_primary(tree_t head)
    case tROSE:
    case tFELL:
    case tENDED:
+   case tSTABLE:
       {
          psl_node_t p = p_psl_builtin_function_call();
          psl_check(p, nametab);

--- a/src/psl/psl-lower.c
+++ b/src/psl/psl-lower.c
@@ -367,6 +367,13 @@ vcode_reg_t psl_lower_fcall(lower_unit_t *lu, psl_node_t p)
       return emit_and(prev, expr_n);
    }
 
+   case PSL_BUILTIN_STABLE:
+   {
+      vcode_reg_t prev = psl_lower_prev_shift_reg(lu, loc, expr, 1);
+      vcode_reg_t rhs = lower_rvalue(lu, expr);
+      return emit_cmp(VCODE_CMP_EQ, prev, rhs);
+   }
+
    default:
       fatal_at(psl_loc(p), "sorry, this built-in function is not supported");
    }

--- a/test/regress/gold/psl20.txt
+++ b/test/regress/gold/psl20.txt
@@ -1,4 +1,6 @@
 ** Note: 2ns+1: ROSE
+** Note: 3ns+1: STABLE
+** Note: 4ns+1: STABLE
 ** Note: 5ns+1: FELL
 ** Note: 6ns+1: ROSE
 ** Note: 7ns+1: FELL

--- a/test/regress/gold/psl20.txt
+++ b/test/regress/gold/psl20.txt
@@ -1,0 +1,4 @@
+** Note: 2ns+1: ROSE
+** Note: 5ns+1: FELL
+** Note: 6ns+1: ROSE
+** Note: 7ns+1: FELL

--- a/test/regress/psl20.vhd
+++ b/test/regress/psl20.vhd
@@ -1,0 +1,25 @@
+entity psl20 is
+end entity;
+
+architecture tb of psl20 is
+
+    signal clk : natural;
+    signal a : bit;
+
+    constant seq_a : bit_vector := "00111010";
+
+begin
+
+    clkgen: clk <= clk + 1 after 1 ns when clk < 7;
+
+    agen: a <= seq_a(clk);
+
+    -- psl default clock is clk'delayed(0 ns)'event;
+
+    -- Covered at 2 ns and 6 ns
+    -- psl one: cover {rose(a)} report "ROSE";
+
+    -- Covered at 5 ns and 7 ns
+    -- psl two: cover {fell(a)} report "FELL";
+
+end architecture;

--- a/test/regress/psl20.vhd
+++ b/test/regress/psl20.vhd
@@ -22,4 +22,8 @@ begin
     -- Covered at 5 ns and 7 ns
     -- psl two: cover {fell(a)} report "FELL";
 
+    -- Covered at 3 ns and 4 ns
+    -- TODO: should be covered at 1 ns too! Why isn't it ?
+    -- psl three: cover {stable(a)} report "STABLE";
+
 end architecture;

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -1096,3 +1096,4 @@ issue1137       normal
 tcl3            tcl,fail,gold
 psl18           fail,gold,2008
 psl19           gold,psl
+psl20           gold,psl

--- a/www/features.html.in
+++ b/www/features.html.in
@@ -478,7 +478,7 @@ table below.
   <tr>
     <td>5.2.3.1</td>
     <td>prev()</td>
-    <td class="feature-partial"></td>
+    <td class="feature-partial">master</td>
   </tr>
   <tr>
     <td>5.2.3.2</td>
@@ -488,17 +488,17 @@ table below.
   <tr>
     <td>5.2.3.3</td>
     <td>stable()</td>
-    <td class="feature-missing"></td>
+    <td class="feature-partial">master</td>
   </tr>
   <tr>
     <td>5.2.3.4</td>
     <td>rose()</td>
-    <td class="feature-partial"></td>
+    <td class="feature-partial">master</td>
   </tr>
   <tr>
     <td>5.2.3.5</td>
     <td>fell()</td>
-    <td class="feature-partial"></td>
+    <td class="feature-partial">master</td>
   </tr>
   <tr>
     <td>5.2.3.6</td>

--- a/www/features.html.in
+++ b/www/features.html.in
@@ -493,12 +493,12 @@ table below.
   <tr>
     <td>5.2.3.4</td>
     <td>rose()</td>
-    <td class="feature-missing"></td>
+    <td class="feature-partial"></td>
   </tr>
   <tr>
     <td>5.2.3.5</td>
     <td>fell()</td>
-    <td class="feature-missing"></td>
+    <td class="feature-partial"></td>
   </tr>
   <tr>
     <td>5.2.3.6</td>


### PR DESCRIPTION
A follow-up to the previous merge-request.

The PSL `prev` logic is abstracted to separate function and used to build logic
for `rose`, `fell` and `stable` as suggested by PSL spec:
```
The function rose() can be expressed in terms of the built-in function prev() as follows: For any bit
expression e and any Boolean c, rose(e,c) is equivalent to the Verilog or SystemVerilog expression
(prev(e,1,c)==1’b0 && e==1’b1), and is equivalent to the VHDL expression (prev(e,1,c)
=’0 and e=’1). The function rose() may be used anywhere a Boolean is required.
```