### PR TITLE
Cover fix long report names

### DIFF
--- a/test/regress/cover26.sh
+++ b/test/regress/cover26.sh
@@ -7,7 +7,7 @@ nvc -a $TESTDIR/regress/cover26.vhd -e --cover cover26 -r
 
 # Report per-file
 # This used to crash before
-nvc --cover-report -o html  work/_WORK.COVER26.elab.covdb 2>&1 | tee out.txt
+nvc --cover-report -o html cover26.ncdb 2>&1 | tee out.txt
 
 # Adjust output to be work directory relative
 sed -i -e "s/[^ ]*regress\/data\//data\//g" out.txt

--- a/test/regress/cover26.sh
+++ b/test/regress/cover26.sh
@@ -1,0 +1,15 @@
+set -xe
+
+pwd
+which nvc
+
+nvc -a $TESTDIR/regress/cover26.vhd -e --cover cover26 -r
+
+# Report per-file
+# This used to crash before
+nvc --cover-report -o html  work/_WORK.COVER26.elab.covdb 2>&1 | tee out.txt
+
+# Adjust output to be work directory relative
+sed -i -e "s/[^ ]*regress\/data\//data\//g" out.txt
+
+diff -u $TESTDIR/regress/gold/cover26.txt out.txt

--- a/test/regress/cover26.vhd
+++ b/test/regress/cover26.vhd
@@ -1,0 +1,43 @@
+entity sub is
+    generic ( nest : natural );
+end entity;
+
+architecture test of sub is
+begin
+
+    sub_hier_gen : if (nest > 0) generate
+
+        sub_inst_long_path : entity work.sub
+        generic map (
+            nest => nest - 1
+        );
+
+    end generate;
+
+    leaf_hier_gen : if (nest = 0) generate
+
+        process
+        begin
+            wait for 1 ns;
+            report "I am at leaf level";
+            wait for 1 ns;
+            wait;
+        end process;
+
+    end generate;
+
+end architecture;
+
+
+entity cover26 is
+end entity;
+
+architecture test of cover26 is
+begin
+
+    sub_inst_long_path : entity work.sub
+    generic map (
+        nest => 16
+    );
+
+end architecture;

--- a/test/regress/gold/cover26.txt
+++ b/test/regress/gold/cover26.txt
@@ -1,0 +1,9 @@
+** Note: Code coverage report folder: html.
+** Note: Code coverage report contains: covered, uncovered, excluded coverage details.
+** Note: code coverage results for: WORK.COVER26
+** Note:      statement:     100.0 % (4/4)
+** Note:      branch:        N.A.
+** Note:      toggle:        N.A.
+** Note:      expression:    N.A.
+** Note:      FSM state:     N.A.
+** Note:      functional:    N.A.

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -1096,3 +1096,4 @@ issue1137       normal
 tcl3            tcl,fail,gold
 psl18           fail,gold,2008
 psl19           gold,psl
+cover26         shell


### PR DESCRIPTION
Brought-up the previous branch with fixes of cover report hierarchy exceeding 256 characters.
Sub-hierarchy path is hashed to create unique hierarchy report name.