### PR TITLE
[Fuzz] Fix crash with index constraint on file type

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -949,6 +949,7 @@ unsigned dimension_of(type_t type)
    case T_NONE:
    case T_RECORD:
    case T_INCOMPLETE:
+   case T_FILE:
       return 0;
    case T_INTEGER:
    case T_REAL:

--- a/test/sem/file.vhd
+++ b/test/sem/file.vhd
@@ -57,7 +57,9 @@ package p is
 
     type ft4 is file of t_ok_rec;           -- OK
 
-    function get_ft4 return ft4;        -- Error
+    function get_ft4 return ft4;            -- Error
+
+    signal s : ft(1 downto 0);              -- Error
 
 end package;
 

--- a/test/test_sem.c
+++ b/test/test_sem.c
@@ -875,9 +875,10 @@ START_TEST(test_file)
       { 48, "type T_REC has a subelement with an access type" },
       { 49, "type T_REC2 has a subelement with an access type" },
       { 60, "function result subtype may not denote a file type" },
-      { 76, "no matching subprogram READ [FT, FILE_OPEN_STATUS]" },
-      { 82, "no matching operator \"=\" [FT, FT return BOOLEAN]" },
-      { 83, "no matching operator \"/=\" [FT, FT return BOOLEAN]" },
+      { 62, "index constraint cannot be used with non-array type FT" },
+      { 78, "no matching subprogram READ [FT, FILE_OPEN_STATUS]" },
+      { 84, "no matching operator \"=\" [FT, FT return BOOLEAN]" },
+      { 85, "no matching operator \"/=\" [FT, FT return BOOLEAN]" },
       { -1, NULL }
    };
    expect_errors(expect);


### PR DESCRIPTION
The fuzzer noticed, that if a file type is given an index constraint, then nvc crashes. This fixes that.
Cheers