### PR TITLE
Add parsing of compiler directive `default_nettype

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -635,10 +635,21 @@ BEFORE            ?i:before
 <VLOG>"begin"            { return tBEGIN; }
 <VLOG>"end"              { return tEND; }
 <VLOG>"wire"             { return tWIRE; }
+<VLOG>"tri"              { return tTRI; }
+<VLOG>"tri0"             { return tTRI0; }
+<VLOG>"tri1"             { return tTRI1; }
+<VLOG>"wand"             { return tWAND; }
+<VLOG>"triand"           { return tTRIAND; }
+<VLOG>"wor"              { return tWOR; }
+<VLOG>"trior"            { return tTRIOR; }
+<VLOG>"trireg"           { return tTRIREG; }
+<VLOG>"uwire"            { return tUWIRE; }
+<VLOG>"none"             { return tNONE; }
 <VLOG>"assign"           { return tASSIGN; }
 <VLOG>"if"               { return tIF; }
 <VLOG>"else"             { return tELSE; }
 <VLOG>"`timescale"       { return tTIMESCALE; }
+<VLOG>"`default_nettype" { return tDEFNETTYPE; }
 <VLOG>"`celldefine"      { }
 <VLOG>"`endcelldefine"   { }
 <VLOG>"`begin_keywords"  { return tBEGINKEYWORDS; }

--- a/src/scan.c
+++ b/src/scan.c
@@ -263,7 +263,8 @@ const char *token_str(token_t tok)
          "repeat", "do", "endpoint", "<<", ">>", "<<<", ">>>", "task",
          "endtask", "endfunction", "`begin_keywords", "`end_keywords", "real",
          "shortreal", "realtime", "`__nvc_push", "`__nvc_pop", "++", "--",
-         "var",
+         "var", "`default_nettype", "tri", "tri0", "tri1", "wand", "triand",
+         "wor", "trior", "trireg", "uwire", "none",
       };
 
       if (tok >= 200 && tok - 200 < ARRAY_LEN(token_strs))

--- a/src/scan.h
+++ b/src/scan.h
@@ -425,5 +425,16 @@ void reset_sdf_parser(void);
 #define tPLUSPLUS      524
 #define tMINUSMINUS    525
 #define tVAR           526
+#define tDEFNETTYPE    527
+#define tTRI           528
+#define tTRI0          529
+#define tTRI1          530
+#define tWAND          531
+#define tTRIAND        532
+#define tWOR           533
+#define tTRIOR         534
+#define tTRIREG        535
+#define tUWIRE         536
+#define tNONE          537
 
 #endif  // _SCAN_H

--- a/src/vlog/vlog-parse.c
+++ b/src/vlog/vlog-parse.c
@@ -3888,6 +3888,19 @@ static void p_timescale_compiler_directive(void)
    set_timescale(unit_value, unit_name, prec_value, prec_name, CURRENT_LOC);
 }
 
+static void p_defaultnettype_compiler_directive(void)
+{
+   // `default_nettype wire | tri | tri0 | tri1 | wand | triand | wor | trior | trireg | uwire | none
+
+   BEGIN("default_nettype directive");
+
+   consume(tDEFNETTYPE);
+
+   one_of(tWIRE, tTRI, tTRI0, tTRI1, tWAND, tTRIAND, tWOR, tTRIOR, tTRIREG, tUWIRE, tNONE);
+
+   // TODO: do something with the directive
+}
+
 static void p_keywords_directive(void)
 {
    // `begin_keywords "version_specifier"
@@ -3915,6 +3928,9 @@ static void p_directive_list(void)
 
    for (;;) {
       switch (peek()) {
+      case tDEFNETTYPE:
+         p_defaultnettype_compiler_directive();
+         break;
       case tTIMESCALE:
          p_timescale_compiler_directive();
          break;

--- a/src/vlog/vlog-pp.l
+++ b/src/vlog/vlog-pp.l
@@ -110,6 +110,7 @@ ID    [a-zA-Z_]([a-zA-Z0-9_$])*
 `undef[ \t]+{ID}[ \t]*  { undef_macro(); }
 
 `timescale              |
+`default_nettype        |
 `resetall               |
 `pragma                 |
 `begin_keywords         |

--- a/test/test_vlog.c
+++ b/test/test_vlog.c
@@ -420,6 +420,28 @@ START_TEST(test_timescale1)
 }
 END_TEST
 
+START_TEST(test_defaultnettype)
+{
+   input_from_file(TESTDIR "/vlog/defaultnettype.v");
+
+   const error_t expect[] = {
+      { 12, "unexpected identifier while parsing default_nettype directive, expecting one of wire, tri, tri0, tri1, wand, triand, wor, trior," },
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   vlog_node_t m = vlog_parse();
+   fail_if(m == NULL);
+   fail_unless(vlog_kind(m) == V_MODULE);
+
+   vlog_check(m);
+
+   fail_unless(vlog_parse() == NULL);
+
+   check_expected_errors();
+}
+END_TEST
+
 START_TEST(test_gate1)
 {
    input_from_file(TESTDIR "/vlog/gate1.v");
@@ -699,6 +721,7 @@ Suite *get_vlog_tests(void)
    tcase_add_test(tc, test_pp1);
    tcase_add_test(tc, test_empty1);
    tcase_add_test(tc, test_timescale1);
+   tcase_add_test(tc, test_defaultnettype);
    tcase_add_test(tc, test_gate1);
    tcase_add_test(tc, test_pp2);
    tcase_add_test(tc, test_specify1);

--- a/test/vlog/defaultnettype.v
+++ b/test/vlog/defaultnettype.v
@@ -1,0 +1,15 @@
+`default_nettype wire     // OK
+`default_nettype tri      // OK
+`default_nettype tri0     // OK
+`default_nettype tri1     // OK
+`default_nettype wand     // OK
+`default_nettype triand   // OK
+`default_nettype wor      // OK
+`default_nettype trior    // OK
+`default_nettype trireg   // OK
+`default_nettype uwire    // OK
+`default_nettype none     // OK
+`default_nettype foo      // Error
+
+module foo;
+endmodule // foo


### PR DESCRIPTION
I tried analysing the xpm models provided with vivado just to see how far I could get and the `default_nettype` is the first problem it encounters.

I tried to add just enough logic to parse the directive correctly but I have no idea how to use the parsed information so this is ad far as I can go for the moment.

According to what I found online this is the notation:
```
`default_nettype wire | tri | tri0 | tri1 | wand | triand | wor | trior | trireg | uwire | none
```