### PR TITLE
Coverage minor fixes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,10 @@
   statements (#1156).
 - Fixed a crash when packages are passed through multiple layers of
   generics.
+- Toggle coverage count is displayed correctly for unreachable constant
+  driven toggle bins.
+- Transitions from `X` are counted (instead of just `U`)
+  with `--count-from-undefined`.
 
 ## Version 1.15.1 - 2025-01-22
 - Fixed a crash when a subprogram is called with too many named arguments

--- a/nvc.1
+++ b/nvc.1
@@ -770,21 +770,25 @@ NVC supports the following additional options to control coverage collection:
 .Bl -bullet
 .It
 .Cm count-from-undefined
-- When set, NVC also counts toggles
+- When set, NVC also counts toggles from
 .Cm U
-->
+/
+.Cm X
+to
 .Cm 1
 as
 .Cm 0
-->
+to
 .Cm 1
-and toggles
+and toggles from
 .Cm U
-->
+/
+.Cm X
+to
 .Cm 0
 as
 .Cm 1
-->
+/
 .Cm 0
 during toggle coverage collection.
 .It

--- a/nvc.1
+++ b/nvc.1
@@ -819,6 +819,18 @@ unreachable coverage items:
 .Bl -bullet
 .It
 Toggle coverage on instance ports driven by constant value.
+.It
+Expression coverage bins where right side of the expression is not evaluated
+due to left side value being sufficient to determine expression result.
+This applies to following cases:
+.Bl -bullet
+.It
+.Ql or
+expression bin with LHS=True, RHS=False
+.It
+.Ql and
+expression bin with LHS=False, RHS=True.
+.El
 .El
 .It
 .Cm fsm-no-default-enums

--- a/src/cov/cov-report.c
+++ b/src/cov/cov-report.c
@@ -602,7 +602,9 @@ static void cover_print_bin(FILE *f, cover_pair_t *pair, uint32_t flag,
       for (int i = 0; i < cols; i++)
          fprintf(f, "<td>%s</td>", vals[i]);
 
-      fprintf(f, "<td>%d</td>", pair->item->data);
+      // Toggle flags hold unreachability in highest bit of runtime data
+      // Must be masked out to print properly
+      fprintf(f, "<td>%d</td>", (pair->item->data) & ~COV_FLAG_UNREACHABLE);
       fprintf(f, "<td>%d</td>", pair->item->atleast);
 
       if (pkind == PAIR_UNCOVERED)

--- a/src/rt/cover.c
+++ b/src/rt/cover.c
@@ -73,9 +73,9 @@ static inline void cover_toggle_check_0_1_u(uint8_t old, uint8_t new,
    else if (old == _1 && new == _0)
       increment_counter(toggle_10);
 
-   else if (old == _U && new == _1)
+   else if ((old == _U || old == _X) && new == _1)
       increment_counter(toggle_01);
-   else if (old == _U && new == _0)
+   else if ((old == _U || old == _X) && new == _0)
       increment_counter(toggle_10);
 }
 
@@ -106,9 +106,9 @@ static inline void cover_toggle_check_0_1_u_z(uint8_t old, uint8_t new,
    else if (old == _1 && new == _0)
       increment_counter(toggle_10);
 
-   else if (old == _U && new == _1)
+   else if ((old == _U || old == _X) && new == _1)
       increment_counter(toggle_01);
-   else if (old == _U && new == _0)
+   else if ((old == _U || old == _X) && new == _0)
       increment_counter(toggle_10);
 
    else if (old == _0 && new == _Z)


### PR DESCRIPTION
1. Fixes toggle coverage data being displayed as negative in the coverage report. When driven by constant, highest bit of data holds the unreachability flag, needs to be masked out otherwise value shown in the report is INT32_MIN.
2. Extend manual with explanation of other source of unreachability -> Was missing second source
3. For `--count-from-undefined` allows `X` as undefined value -> Usefull when bus is driven to a valid value only around
    the clock edge when it shall be sampled and driven to X otherwise. For such BFM, the toggle coverage will never be
    reached since all transitions are from / to X