### PR TITLE
Parse ANSI parameters declaration

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -139,6 +139,7 @@ UDP_INDICATOR   "("{UDP_LEVEL}{UDP_LEVEL}")"
 SCALAR_ZERO     ('b0|'B0|1'b0|1'B0)
 SCALAR_ONE      ('b1|'B1|1'b1|1'B1)
 PAREN_STAR      "("{SPACE}*"*"{SPACE}*")"
+HASH_LPAREN     #{SPACE}*"("
 
 %x COMMENT C_COMMENT PSL VLOG UDP SDF SDF_EXPR
 
@@ -733,6 +734,7 @@ BEFORE            ?i:before
 <VLOG>{VLOG_NUMBER}      { yylval.str = xstrdup(yytext); return tNUMBER; }
 <VLOG>{VLOG_REAL}        { return parse_verilog_real(yytext); };
 <VLOG>{PAREN_STAR}       { return tPARENSTAR; }
+<VLOG>{HASH_LPAREN}      { return tHASHLPAREN; }
 
 <INITIAL,PSL>{DECIMAL}   { return parse_decimal_literal(yytext); }
 <INITIAL,PSL>{BASED}     { return parse_based_literal(yytext); }

--- a/src/scan.c
+++ b/src/scan.c
@@ -265,7 +265,7 @@ const char *token_str(token_t tok)
          "shortreal", "realtime", "`__nvc_push", "`__nvc_pop", "++", "--",
          "var", "`default_nettype", "tri", "tri0", "tri1", "wand", "triand",
          "wor", "trior", "trireg", "uwire", "none", "localparam", "always_comb",
-         "always_ff", "always_latch", "(*)",
+         "always_ff", "always_latch", "(*)", "#(",
       };
 
       if (tok >= 200 && tok - 200 < ARRAY_LEN(token_strs))

--- a/src/scan.h
+++ b/src/scan.h
@@ -441,5 +441,6 @@ void reset_sdf_parser(void);
 #define tALWAYSFF      540
 #define tALWAYSLATCH   541
 #define tPARENSTAR     542
+#define tHASHLPAREN    543
 
 #endif  // _SCAN_H

--- a/test/test_vlog.c
+++ b/test/test_vlog.c
@@ -653,6 +653,28 @@ START_TEST(test_param1)
 }
 END_TEST
 
+START_TEST(test_param2)
+{
+   input_from_file(TESTDIR "/vlog/param2.v");
+
+   const error_t expect[] = {
+      {  13, "duplicate declaration" },
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   vlog_node_t m = vlog_parse();
+   fail_if(m == NULL);
+   fail_unless(vlog_kind(m) == V_MODULE);
+
+   vlog_check(m);
+
+   fail_unless(vlog_parse() == NULL);
+
+   check_expected_errors();
+}
+END_TEST
+
 START_TEST(test_pp3)
 {
    input_from_file(TESTDIR "/vlog/pp3.v");
@@ -802,6 +824,7 @@ Suite *get_vlog_tests(void)
    tcase_add_test(tc, test_enum1);
    tcase_add_test(tc, test_union1);
    tcase_add_test(tc, test_param1);
+   tcase_add_test(tc, test_param2);
    tcase_add_test(tc, test_pp3);
    tcase_add_test(tc, test_concat1);
    tcase_add_test(tc, test_pp4);

--- a/test/vlog/param2.v
+++ b/test/vlog/param2.v
@@ -1,0 +1,14 @@
+module param2 # (
+  [7:0] p1 = 8'd5,
+  parameter p2 = 8,
+  p3 = 7,
+  localparam bit p4 = 0,
+  p5 = 5,
+  parameter p6 = 4
+) (
+  input x, y,
+  output reg z
+);
+  assign w1 = p1;   // OK
+  parameter logic p1 = 1;   // Error
+endmodule // param2


### PR DESCRIPTION
Add changes to parse parameters inside `#()` for a module declaration.
 