### PR TITLE
fix coverage report table sorting with N/A, #1179

### DIFF
--- a/src/cov/cov-report.c
+++ b/src/cov/cov-report.c
@@ -994,7 +994,7 @@ static void cover_print_jscript_funcs(FILE *f)
             "      let v = tr.getElementsByTagName(\"TD\")[n];\n"
             "      v = parseInt(v.innerHTML.split(\"%%\")[0]);\n"
             "      if (isNaN(v)) {\n"
-            "         v = tr.getElementsByTagName(\"TD\")[n].innerHTML.toLowerCase();\n"
+            "         v = -1;\n"
             "      }\n"
             "      return v;\n"
             "   }\n"


### PR DESCRIPTION
Fix sorting of coverage data in summary tables.
By converting anything NaN to -1, such row becomes last even if there is a row that has 0 %.