### PR TITLE
fix missing END_TEST in last test_jit test.

### DIFF
--- a/test/test_jit.c
+++ b/test/test_jit.c
@@ -2068,6 +2068,7 @@ START_TEST(test_trim1)
    tlab_release(tlab);
    jit_free(j);
 }
+END_TEST
 
 Suite *get_jit_tests(void)
 {


### PR DESCRIPTION
Causes `test_jit.c` compile failure on RHEL8 (gcc version 8.5.0 20210514 (Red Hat 8.5.0-22) (GCC)