### PR TITLE
add --merge-mode option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
   `--preserve-case` (#1195).
 - Fixed a crash when expression coverage is enabled and a port is
   associated with a non-static expression (#1194).
+- Added `--merge-mode` option to control behaviour when merging
+  non-equal coverage databases.
 
 ## Version 1.16.0 - 2025-04-21
 - Added support for PSL `prev()`, `stable()`, `rose()` and `fell()`

--- a/nvc.1
+++ b/nvc.1
@@ -504,6 +504,13 @@ names in the output.
 .\" --output
 .It Fl o , Fl \-output= Ns Ar file
 File name of output coverage database.
+.\" --merge-mode
+.It Fl m , Fl \-merge-mode= Ns Ar mode
+Where
+.Ar mode
+can be one of:
+.Ar union ,
+.Ar intersect
 .El
 .\" ------------------------------------------------------------
 .\" Coverage report options
@@ -758,10 +765,22 @@ $ nvc --cover-merge -o merged.ncdb first.ncdb second.ncdb third.ncdb ...
 During code coverage merging, NVC sums together coverage bins with equal
 hierarchical paths in the elaborated design.
 .Pp
-NVC creates union of all coverage bins from all input coverage databases
-in the merged code coverage database. This allows merging code coverage from
-different designs (e.g. where part of the hierarchy is formed by
-"if-generate" statement).
+NVC supports different modes of merging. The merge mode controls what NVC
+does if a coverage database that is being merged (new) contains a coverage
+item that is not present in the coverage database being merged into (old).
+The merge mode can be selected by a
+.Cm --merge-mode=mode
+option where
+.Cm mode
+can be one of:
+.Bl -bullet
+.It
+.Cm union
+- The item is added to the merged (old) database. This is the default mode.
+.It
+.Cm intersect
+- The item is dropped from the merged (old) database.
+.El
 .Ss Generating code coverage report
 To generate code coverage report in HTML format, run:
 .Bd -literal -offset indent

--- a/src/cov/cov-api.h
+++ b/src/cov/cov-api.h
@@ -215,6 +215,11 @@ typedef enum {
                         | COVER_MASK_TOGGLE | COVER_MASK_EXPRESSION     \
                         | COVER_MASK_STATE | COVER_MASK_FUNCTIONAL)
 
+typedef enum {
+   MERGE_INTERSECT,
+   MERGE_UNION,
+} merge_mode_t;
+
 cover_data_t *cover_data_init(cover_mask_t mask, int array_limit, int threshold);
 bool cover_enabled(cover_data_t *data, cover_mask_t mask);
 
@@ -223,7 +228,7 @@ unsigned cover_count_items(cover_data_t *data);
 void cover_dump_items(cover_data_t *data, fbuf_t *f, cover_dump_t dt,
                       const int32_t *counts);
 cover_data_t *cover_read_items(fbuf_t *f, uint32_t pre_mask);
-void cover_merge_items(fbuf_t *f, cover_data_t *data);
+void cover_merge_items(fbuf_t *f, cover_data_t *data, merge_mode_t mode);
 
 //
 // Spec and exclude file handling


### PR DESCRIPTION
Adds `--merge-mode` option to `--cover-merge` option.

Allows `intersect` merging where items that are not located in the old DB will
not be taken into account from the newDB.