### PR TITLE
Fix crash with open actual for formal without default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,7 @@
   bugs (#1178).
 - Added support for conditional force assignment (#1185).
 - Access and file types are now supported in VHPI (#1192).
+- Fixed a crash when open actual was used for formal parameter without default.
 - Several other minor bugs were resolved (#1174, #1159, #1177, #1191).
 
 ## Version 1.15.2 - 2025-03-01

--- a/src/sem.c
+++ b/src/sem.c
@@ -3283,6 +3283,16 @@ static bool sem_check_call_args(tree_t t, tree_t decl, nametab_t *tab)
                return false;
          }
       }
+
+      if (tree_kind(value) == T_OPEN && !tree_has_value(port)) {
+         diag_t *d = diag_new(DIAG_ERROR, tree_loc(param));
+         diag_printf(d, "OPEN actual for formal parameter %s without "
+                     "default value", istr(tree_ident(port)));
+         diag_hint(d, tree_loc(port), "%s declared here",
+                   istr(tree_ident(port)));
+         diag_emit(d);
+         return false;
+      }
    }
 
    for (int i = 0; i < nports; i++) {

--- a/test/sem/ports.vhd
+++ b/test/sem/ports.vhd
@@ -439,3 +439,16 @@ begin
     end block;
 
 end architecture;
+
+-------------------------------------------------------------------------------
+
+architecture open_actual of top is
+begin
+    process is
+        procedure test (constant c: natural) is begin
+        end procedure;
+    begin
+        test(open);
+        wait;
+    end process;
+end architecture;

--- a/test/test_sem.c
+++ b/test/test_sem.c
@@ -154,12 +154,14 @@ START_TEST(test_ports)
         "conversion" },
       { 437, "type of actual REAL does not match type INTEGER of formal "
         "port IO2" },
+      { 451, "OPEN actual for formal parameter C without default value" },
       { -1, NULL }
    };
    expect_errors(expect);
 
    parse_and_check(T_PACKAGE, T_ENTITY, T_ARCH, T_ENTITY, T_ARCH, T_ARCH,
-                   T_ARCH, T_ENTITY, T_ARCH, T_ARCH, T_ARCH, T_ARCH, T_ARCH);
+                   T_ARCH, T_ENTITY, T_ARCH, T_ARCH, T_ARCH, T_ARCH, T_ARCH,
+                   T_ARCH);
 
    fail_unless(parse() == NULL);
    check_expected_errors();


### PR DESCRIPTION
If one did something like this:
```vhd
entity test is end test;

architecture open_actual of test is
begin
    process is
        procedure test (constant c: natural) is begin end procedure;
    begin
        test(open);
    end process;
end architecture;
```
NVC crashed (quite spectacularly with the colorful jit code dump) during elaboration. I.e. `nvc -a test.vhd` worked great, but `nvc -e test` crashed.

I added a simple semantic check for that:
```
** Error: OPEN actual for formal parameter C without default value
     > ../test/sem/ports.vhd:451
     |
 448 |         procedure test (constant c: natural) is begin
     |                                  ^ C declared here
 449 |         end procedure;
 450 |     begin
 451 |         test(open);
     |              ^^^^ error occurred here
```

GHDL and ModelSim report the error as:

```
$ghdl -a test.vhd
test.vhd:15:13:error: no actual for constant interface "c"
test(OPEN);
    ^
```
```
$vcom test.vhd
Error: test.vhd(15): (vcom-1032) Formal parameter "c" has OPEN or no actual associated with it.
```
 
Cheers