### PR TITLE
Cover embed source files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@
   previous behaviour.
 - Fixed a crash when `set_cover_scope_name` from `nvc.cover_pkg` was
   called with coverage disabled (#1218).
+- Code coverage reports now contain the source files instead of
+  referencing them.
 
 ## Version 1.16.2 - 2025-06-11
 - Fixed a crash when an entity uses VHDL-2019 enhanced type generics and

--- a/src/cov/cov-data.c
+++ b/src/cov/cov-data.c
@@ -999,7 +999,7 @@ cover_scope_t *cover_create_instance(cover_data_t *data, cover_scope_t *parent,
    cover_scope_t *s = xcalloc(sizeof(cover_scope_t));
    s->name       = tree_ident(block);
    s->parent     = parent;
-   s->loc        = *tree_loc(block);
+   s->loc        = *tree_loc(unit);
    s->hier       = ident_prefix(s->parent->hier, s->name, '.');
    s->emit       = cover_should_emit_scope(data, s, block);
    s->block_name = ident_rfrom(tree_ident(unit), '.');

--- a/src/cov/cov-report.c
+++ b/src/cov/cov-report.c
@@ -289,26 +289,26 @@ static cover_file_t *cover_file_for_scope(cover_scope_t *s)
    if (cover_files == NULL)
       cover_files = shash_new(64);
 
-   const char *path = loc_file_str(&(s->loc));
-   cover_file_t *f = shash_get(cover_files, path);
+   const char *src_path = loc_file_str(&(s->loc));
+   cover_file_t *f = shash_get(cover_files, src_path);
 
    if (f != NULL)
       return f->valid ? f : NULL;
 
    f = xmalloc(sizeof(cover_file_t));
-   f->src_path    = path;
+   f->src_path    = src_path;
    f->n_lines     = 0;
    f->alloc_lines = 1024;
    f->lines       = xmalloc_array(f->alloc_lines, sizeof(cover_line_t));
    f->valid       = false;
 
-   shash_put(cover_files, path, f);
+   shash_put(cover_files, src_path, f);
 
-   FILE *fp = fopen(path, "r");
+   FILE *fp = fopen(src_path, "r");
 
    if (fp == NULL) {
       // Guess the path is relative to the work library
-      char *path LOCAL = xasprintf("%s/../%s", lib_path(lib_work()), path);
+      char *path LOCAL = xasprintf("%s/../%s", lib_path(lib_work()), src_path);
       fp = fopen(path, "r");
    }
 
@@ -325,7 +325,7 @@ static cover_file_t *cover_file_for_scope(cover_scope_t *s)
       if (fgets(buf, sizeof(buf), fp) != NULL)
          cover_append_line(f, buf);
       else if (ferror(fp))
-         fatal("error reading %s", path);
+         fatal("error reading %s", src_path);
    }
 
    fclose(fp);

--- a/src/cov/cov-report.c
+++ b/src/cov/cov-report.c
@@ -77,7 +77,8 @@ typedef struct {
 } cover_chain_t;
 
 typedef struct {
-   const char   *name;
+   const char   *src_path;
+   const char   *rpt_path;
    cover_line_t *lines;
    unsigned      n_lines;
    unsigned      alloc_lines;
@@ -149,59 +150,6 @@ static void cover_append_line(cover_file_t *f, const char *buf)
    cover_line_t *l = &(f->lines[(f->n_lines)++]);
    l->text = xstrdup(buf);
    l->len  = strlen(buf);
-}
-
-static cover_file_t *cover_file_for_scope(cover_scope_t *s)
-{
-   if (loc_invalid_p(&(s->loc)))
-      return NULL;
-
-   if (cover_files == NULL)
-      cover_files = shash_new(64);
-
-   const char *name = loc_file_str(&(s->loc));
-   cover_file_t *f = shash_get(cover_files, name);
-
-   if (f != NULL)
-      return f->valid ? f : NULL;
-
-   f = xmalloc(sizeof(cover_file_t));
-   f->name        = name;
-   f->n_lines     = 0;
-   f->alloc_lines = 1024;
-   f->lines       = xmalloc_array(f->alloc_lines, sizeof(cover_line_t));
-   f->valid       = false;
-
-   shash_put(cover_files, name, f);
-
-   FILE *fp = fopen(name, "r");
-
-   if (fp == NULL) {
-      // Guess the path is relative to the work library
-      char *path LOCAL = xasprintf("%s/../%s", lib_path(lib_work()), name);
-      fp = fopen(path, "r");
-   }
-
-   if (fp == NULL) {
-      warn_at(&(s->loc), "omitting hierarchy %s from the coverage report as "
-              "the correpsonding source file could not be found",
-              istr(s->hier));
-      return NULL;
-   }
-
-   f->valid = true;
-
-   while (!feof(fp)) {
-      char buf[1024];
-      if (fgets(buf, sizeof(buf), fp) != NULL)
-         cover_append_line(f, buf);
-      else if (ferror(fp))
-         fatal("error reading %s", name);
-   }
-
-   fclose(fp);
-
-   return f;
 }
 
 static void cover_print_html_header(FILE *f)
@@ -317,11 +265,106 @@ static void cover_print_html_header(FILE *f)
    fprintf(f, "</header>\n\n");
 }
 
-static void cover_print_file_name(FILE *f, const char *name)
+static char *cover_get_report_name(const char *in)
+{
+   SHA1_CTX ctx;
+   unsigned char buf[SHA1_LEN];
+   char *rv = xcalloc(2 * SHA1_LEN + 1);
+
+   SHA1Init(&ctx);
+   SHA1Update(&ctx, (const char unsigned*)in, strlen(in));
+   SHA1Final(buf, &ctx);
+
+   for (int i = 0; i < SHA1_LEN; i++)
+      snprintf(rv + i * 2, 3, "%02x", buf[i]);
+
+   return rv;
+}
+
+static cover_file_t *cover_file_for_scope(cover_scope_t *s)
+{
+   if (loc_invalid_p(&(s->loc)))
+      return NULL;
+
+   if (cover_files == NULL)
+      cover_files = shash_new(64);
+
+   const char *path = loc_file_str(&(s->loc));
+   cover_file_t *f = shash_get(cover_files, path);
+
+   if (f != NULL)
+      return f->valid ? f : NULL;
+
+   f = xmalloc(sizeof(cover_file_t));
+   f->src_path    = path;
+   f->n_lines     = 0;
+   f->alloc_lines = 1024;
+   f->lines       = xmalloc_array(f->alloc_lines, sizeof(cover_line_t));
+   f->valid       = false;
+
+   shash_put(cover_files, path, f);
+
+   FILE *fp = fopen(path, "r");
+
+   if (fp == NULL) {
+      // Guess the path is relative to the work library
+      char *path LOCAL = xasprintf("%s/../%s", lib_path(lib_work()), path);
+      fp = fopen(path, "r");
+   }
+
+   if (fp == NULL) {
+      warn_at(&(s->loc), "omitting hierarchy %s from the coverage report as "
+              "the correpsonding source file could not be found",
+              istr(s->hier));
+      return NULL;
+   }
+
+   // Load the source file to buffer for follow-up processing
+   while (!feof(fp)) {
+      char buf[1024];
+      if (fgets(buf, sizeof(buf), fp) != NULL)
+         cover_append_line(f, buf);
+      else if (ferror(fp))
+         fatal("error reading %s", path);
+   }
+
+   fclose(fp);
+
+   // Generate report file with source file contents
+   char *hash = cover_get_report_name(f->src_path);
+   f->rpt_path = xasprintf("%s.html", hash);
+   free(hash);
+   fp = fopen(f->rpt_path, "w");
+
+   if (fp == NULL) {
+      fatal("failed to open report file with source code of: %s\n",
+            f->src_path);
+      return NULL;
+   }
+
+   cover_print_html_header(fp);
+
+   fprintf(fp, "<h2 style=\"text-align: left;\">\n");
+   fprintf(fp, "   File:&nbsp; %s\n", f->src_path);
+   fprintf(fp, "</h2>");
+
+   fprintf(fp, "<pre><code>");
+   for (int i = 0; i < f->n_lines; i++) {
+      fprintf(fp, "%6d: &nbsp; %s", i, f->lines[i].text);
+   }
+   fprintf(fp, "</code></pre>");
+
+   f->valid = true;
+
+   return f;
+}
+
+static void cover_print_file_name(FILE *f, const char *src_name,
+                                  const char *rpt_name)
 {
    fprintf(f, "<h2 style=\"margin-left: " MARGIN_LEFT ";\">\n");
    fprintf(f, "   File:&nbsp; <a href=\"../../%s\">../../%s</a>\n",
-            name, name);
+            rpt_name, src_name);
    fprintf(f, "</h2>\n\n");
 }
 
@@ -1327,22 +1370,6 @@ static void cover_print_summary_table_row(FILE *f, cover_data_t *data, cover_sta
    }
 }
 
-static char *cover_get_report_name(const char *in)
-{
-   SHA1_CTX ctx;
-   unsigned char buf[SHA1_LEN];
-   char *rv = xcalloc(2 * SHA1_LEN + 1);
-
-   SHA1Init(&ctx);
-   SHA1Update(&ctx, (const char unsigned*)in, strlen(in));
-   SHA1Final(buf, &ctx);
-
-   for (int i = 0; i < SHA1_LEN; i++)
-      snprintf(rv + i * 2, 3, "%02x", buf[i]);
-
-   return rv;
-}
-
 static void cover_print_hier_nav_tree(FILE *f, cover_scope_t *s)
 {
    fprintf(f, "<nav>\n"
@@ -1389,8 +1416,10 @@ static void cover_report_hier(cover_rpt_hier_ctx_t *ctx,
    cover_print_inst_name(f, s);
 
    cover_file_t *src = cover_file_for_scope(s);
-   const char *filename = (src) ? src->name : "";
-   cover_print_file_name(f, filename);
+   if (src)
+      cover_print_file_name(f, src->src_path, src->rpt_path);
+   else
+      cover_print_file_name(f, "", "");
 
    fprintf(f, "<h2 style=\"margin-left: " MARGIN_LEFT ";\">\n  Sub-instances:\n</h2>\n\n");
    cover_print_summary_table_header(f, "sub_inst_table", true);
@@ -1499,12 +1528,12 @@ static void cover_print_file_nav_tree(FILE *f, cover_rpt_file_ctx_t *ctx_list,
 {
    fprintf(f, "<nav>\n");
    fprintf(f, "<b><a href=../index.html>Back to summary</a></p></b>\n");
-   fprintf(f, "<b>Files:</b><br>\n");
+   fprintf(f, "<b>Coverage report for file:</b><br>\n");
 
    for (int i = 0; i < n_ctxs; i++) {
       cover_rpt_file_ctx_t *ctx = ctx_list + i;
 
-      char *tmp LOCAL = xstrdup((char *)ctx->file->name);
+      char *tmp LOCAL = xstrdup((char *)ctx->file->src_path);
       const char *file_name = basename(tmp);
       fprintf(f, "<p style=\"margin-left: %dpx\"><a href=%s.html>%s</a></p>\n",
                   10, file_name, file_name);
@@ -1654,7 +1683,7 @@ static void cover_report_per_file(FILE *top_f, cover_data_t *data, char *subdir)
       }
 
       // Print per-file report
-      char *file_name LOCAL = xstrdup((char*)ctx->file->name);
+      char *file_name LOCAL = xstrdup((char*)ctx->file->src_path);
       ident_t base_name_id = ident_new(basename(file_name));
       char *file_path LOCAL = xasprintf("%s/%s.html", subdir, istr(base_name_id));
 
@@ -1665,7 +1694,7 @@ static void cover_report_per_file(FILE *top_f, cover_data_t *data, char *subdir)
 
       cover_print_html_header(f);
       cover_print_file_nav_tree(f, ctx_list, n_ctxs);
-      cover_print_file_name(f, ctx->file->name);
+      cover_print_file_name(f, ctx->file->src_path, ctx->file->rpt_path);
 
       fprintf(f, "<h2 style=\"margin-left: " MARGIN_LEFT ";\">\n  Current File:\n</h2>\n\n");
       cover_print_summary_table_header(f, "cur_file_table", true);

--- a/src/nvc.c
+++ b/src/nvc.c
@@ -2208,11 +2208,18 @@ static void usage(void)
 #endif
       { "Coverage report options",
         {
+           { "-o, --output=dir",
+             "Output directory where to store HTML report" },
            { "--exclude-file=FILE",
              "Apply exclude file when generating report, see manual for syntax"
            },
            { "--dont-print={covered,uncovered,excluded}",
              "Exclude specified items from coverage report" },
+           { "--item-limit=limit",
+             "Maximal number of items displayed in single report file. "
+             "Default is 5000." },
+           { "--per-file",
+             "Create source file code coverage report."},
         }
       },
       { "Coverage merge options",

--- a/src/nvc.c
+++ b/src/nvc.c
@@ -2208,18 +2208,17 @@ static void usage(void)
 #endif
       { "Coverage report options",
         {
-           { "-o, --output=dir",
-             "Output directory where to store HTML report" },
+           { "-o, --output=dir", "Output directory for HTML report" },
            { "--exclude-file=FILE",
              "Apply exclude file when generating report, see manual for syntax"
            },
            { "--dont-print={covered,uncovered,excluded}",
              "Exclude specified items from coverage report" },
-           { "--item-limit=limit",
-             "Maximal number of items displayed in single report file. "
-             "Default is 5000." },
+           { "--item-limit=LIMIT",
+             "Display at most LIMIT items in a single report file "
+             "(default 5000)" },
            { "--per-file",
-             "Create source file code coverage report."},
+             "Create source file code coverage report." },
         }
       },
       { "Coverage merge options",

--- a/test/regress/gold/cover2.xml
+++ b/test/regress/gold/cover2.xml
@@ -227,7 +227,7 @@
     </scope>
     <scope name="MY_IGNORED_SIGNAL" line="79">
     </scope>
-    <scope name="SUB_MODULE_INST" block_name="SUB_MODULE-TEST" line="85">
+    <scope name="SUB_MODULE_INST" block_name="SUB_MODULE-TEST" line="12">
       <scope name="A" line="6">
         <toggle hier="WORK.COVER2.SUB_MODULE_INST.A.BIN_0_TO_1" data="1"/>
         <toggle hier="WORK.COVER2.SUB_MODULE_INST.A.BIN_1_TO_0" data="1"/>
@@ -249,7 +249,7 @@
       <scope name="TGL_PROC" line="22">
       </scope>
     </scope>
-    <scope name="SUB_MODULE_INST_2" block_name="SUB_MODULE-TEST" line="93">
+    <scope name="SUB_MODULE_INST_2" block_name="SUB_MODULE-TEST" line="12">
       <scope name="A" line="6">
         <toggle hier="WORK.COVER2.SUB_MODULE_INST_2.A.BIN_0_TO_1" data="1"/>
         <toggle hier="WORK.COVER2.SUB_MODULE_INST_2.A.BIN_1_TO_0" data="0"/>
@@ -271,7 +271,7 @@
       <scope name="TGL_PROC" line="22">
       </scope>
     </scope>
-    <scope name="SUB_MODULE_INST_3" block_name="SUB_MODULE-TEST" line="101">
+    <scope name="SUB_MODULE_INST_3" block_name="SUB_MODULE-TEST" line="12">
       <scope name="A" line="6">
         <toggle hier="WORK.COVER2.SUB_MODULE_INST_3.A.BIN_0_TO_1" data="0"/>
         <toggle hier="WORK.COVER2.SUB_MODULE_INST_3.A.BIN_1_TO_0" data="1"/>

--- a/test/regress/gold/cover25.xml
+++ b/test/regress/gold/cover25.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0"?>
 <scope name="WORK" file="cover25.vhd">
   <scope name="COVER25" block_name="COVER25-TEST" line="35">
-    <scope name="SUB1_I" block_name="SUB-TEST" line="42">
+    <scope name="SUB1_I" block_name="SUB-TEST" line="8">
       <scope name="P1" line="11">
       </scope>
-      <scope name="sub_scope">
+      <scope name="sub_scope" line="42">
         <functional hier="WORK.COVER25.SUB1_I.sub_scope.item" data="10"/>
       </scope>
     </scope>
-    <scope name="SUB2_I" block_name="SUB-TEST" line="44">
+    <scope name="SUB2_I" block_name="SUB-TEST" line="8">
       <scope name="P1" line="11">
       </scope>
       <scope name="sub_scope" line="39">

--- a/test/regress/gold/issue909.txt
+++ b/test/regress/gold/issue909.txt
@@ -1,5 +1,5 @@
-Warning: omitting hierarchy WORK.TOP.UUT._P0._S0 from the coverage report as the correpsonding source file could not be found
-> sub.vhd:8
+Warning: omitting hierarchy WORK.TOP.UUT from the coverage report as the correpsonding source file could not be found
+> sub.vhd:5
       statement:     100.0 % (1/1)
       branch:        N.A.
       toggle:        N.A.

--- a/test/regress/gold/issue941.xml
+++ b/test/regress/gold/issue941.xml
@@ -10,7 +10,7 @@
         <statement hier="WORK.ISSUE941._P0._S0" data="1"/>
       </scope>
     </scope>
-    <scope name="U1" block_name="SUB-TEST" line="29">
+    <scope name="U1" block_name="SUB-TEST" line="6">
       <scope name="X" line="2">
       </scope>
       <scope name="Y" line="3">


### PR DESCRIPTION
This MR copies each source file to a stand-alone HTML file when generating code coverage report.
The generated HTML file is then referenced from the "File" in the coverage hierarchy header.
This is usefull when e.g. a regression is run in CI, and code coverage report is extracted in artifacts.
After downloading the artifacts, the reference to the source files remains valid.

To do this, I needed to track location of the underlying "unit" for the scope, not the "instance".
It affects the XML file output, but I guess this is no big deal since this format is subject to change.
The issue909 also now gives more relevant output since the source file for instance itself can't be found.