### PR TITLE
Add `--ieee-warnings=off-at-0` option

### DIFF
--- a/lib/ieee.08/numeric_bit-body.vhdl
+++ b/lib/ieee.08/numeric_bit-body.vhdl
@@ -66,7 +66,10 @@ package body NUMERIC_BIT is
 
   -- implementation controls
 
-  constant NO_WARNING : BOOLEAN := not ieee_warnings;
+  function NO_WARNING return BOOLEAN is
+  begin
+    return not ieee_warnings;
+  end NO_WARNING;
 
   -- =========================Local Subprograms =================================
 

--- a/lib/ieee.08/numeric_std-body.vhdl
+++ b/lib/ieee.08/numeric_std-body.vhdl
@@ -74,7 +74,10 @@ package body NUMERIC_STD is
 
   -- implementation controls
 
-  constant NO_WARNING : BOOLEAN := not ieee_warnings;
+  function NO_WARNING return BOOLEAN is
+  begin
+    return not ieee_warnings;
+  end NO_WARNING;
 
   -- =========================Local Subprograms =================================
 

--- a/lib/ieee/numeric_bit-body.vhdl
+++ b/lib/ieee/numeric_bit-body.vhdl
@@ -66,7 +66,10 @@ package body NUMERIC_BIT is
 
   -- implementation controls
 
-  constant NO_WARNING : BOOLEAN := not ieee_warnings;
+  function NO_WARNING return BOOLEAN is
+  begin
+    return not ieee_warnings;
+  end NO_WARNING;
 
   -- =========================Local Subprograms =================================
 

--- a/lib/ieee/numeric_std-body.vhdl
+++ b/lib/ieee/numeric_std-body.vhdl
@@ -69,7 +69,10 @@ package body NUMERIC_STD is
 
   -- implementation controls
 
-  constant NO_WARNING : BOOLEAN := not ieee_warnings;
+  function NO_WARNING return BOOLEAN is
+  begin
+    return not ieee_warnings;
+  end NO_WARNING;
 
   -- =========================Local Subprograms =================================
 

--- a/lib/synopsys/std_logic_arith.vhd
+++ b/lib/synopsys/std_logic_arith.vhd
@@ -200,7 +200,10 @@ use nvc.sim_pkg.ieee_warnings;
 
 package body std_logic_arith is
 
-    constant NO_WARNING : BOOLEAN := not ieee_warnings;
+    function NO_WARNING return BOOLEAN is
+    begin
+        return not ieee_warnings;
+    end NO_WARNING;
 
     function max(L, R: INTEGER) return INTEGER is
     begin

--- a/src/jit/jit-intrin.c
+++ b/src/jit/jit-intrin.c
@@ -289,7 +289,7 @@ __attribute__((cold, noinline))
 static void ieee_warn(jit_func_t *func, jit_anchor_t *caller,
                       const char *fmt, ...)
 {
-   if (!opt_get_int(OPT_IEEE_WARNINGS))
+   if (opt_get_int(OPT_IEEE_WARNINGS) == IEEE_WARNINGS_OFF)
       return;
 
    va_list ap;

--- a/src/nvc.c
+++ b/src/nvc.c
@@ -641,7 +641,19 @@ static bool parse_on_off(const char *str)
    else if (strcasecmp(str, "off") == 0)
       return false;
 
-   fatal("specifiy 'on' or 'off' instead of '%s'", str);
+   fatal("specify 'on' or 'off' instead of '%s'", str);
+}
+
+static ieee_warnings_t parse_ieee_warnings(const char *str)
+{
+   if (strcasecmp(str, "off") == 0)
+      return IEEE_WARNINGS_OFF;
+   else if (strcasecmp(str, "on") == 0)
+      return IEEE_WARNINGS_ON;
+   else if (strcasecmp(str, "off-at-0") == 0)
+      return IEEE_WARNINGS_OFF_AT_0;
+   else
+      fatal("specify 'on', 'off' or 'off-at-0' instead of '%s'", str);
 }
 
 static vhdl_severity_t parse_severity(const char *str)
@@ -855,7 +867,7 @@ static int run_cmd(int argc, char **argv, cmd_state_t *state)
          break;
       case 'I':
          {
-            const bool on = parse_on_off(optarg);
+            const ieee_warnings_t on = parse_ieee_warnings(optarg);
 
             // TODO: add an unconditional warning after 1.16
             if (state->jit != NULL && opt_get_int(OPT_IEEE_WARNINGS) != on)
@@ -2126,7 +2138,7 @@ static void usage(void)
         {
            { "-h, --help", "Display this message and exit" },
            { "-H SIZE", "Set the maximum heap size to SIZE bytes" },
-           { "--ieee-warnings={on,off}",
+           { "--ieee-warnings={on,off,off-at-0}",
              "Enable or disable warnings from IEEE packages" },
            { "--ignore-time", "Skip source file timestamp check" },
            { "--load=PLUGIN", "Load VHPI plugin at startup" },
@@ -2545,7 +2557,7 @@ int main(int argc, char **argv)
          opt_set_int(OPT_PLI_DEBUG, 1);
          break;
       case 'W':
-         opt_set_int(OPT_IEEE_WARNINGS, parse_on_off(optarg));
+         opt_set_int(OPT_IEEE_WARNINGS, parse_ieee_warnings(optarg));
          break;
       case 'S':
          opt_set_int(OPT_RANDOM_SEED, parse_int(optarg));

--- a/src/option.c
+++ b/src/option.c
@@ -141,7 +141,7 @@ void set_default_options(void)
    opt_set_int(OPT_IGNORE_TIME, 0);
    opt_set_int(OPT_VERBOSE, 0);
    opt_set_int(OPT_MISSING_BODY, 1);
-   opt_set_int(OPT_IEEE_WARNINGS, 1);
+   opt_set_int(OPT_IEEE_WARNINGS, IEEE_WARNINGS_ON);
    opt_set_size(OPT_ARENA_SIZE, 1 << 24);
    opt_set_int(OPT_DUMP_ARRAYS, 0);
    opt_set_str(OPT_OBJECT_VERBOSE, getenv("NVC_OBJECT_VERBOSE"));

--- a/src/option.h
+++ b/src/option.h
@@ -80,6 +80,12 @@ typedef enum {
    OPT_LAST_NAME
 } opt_name_t;
 
+typedef enum {
+   IEEE_WARNINGS_OFF,
+   IEEE_WARNINGS_ON,
+   IEEE_WARNINGS_OFF_AT_0
+} ieee_warnings_t;
+
 void opt_set_int(opt_name_t name, int val);
 void opt_set_size(opt_name_t name, size_t val);
 void opt_set_str(opt_name_t name, const char *val);

--- a/src/rt/simpkg.c
+++ b/src/rt/simpkg.c
@@ -26,6 +26,15 @@ DLLEXPORT
 void _nvc_ieee_warnings(jit_scalar_t *args)
 {
    args[0].integer = opt_get_int(OPT_IEEE_WARNINGS);
+   if (args[0].integer == IEEE_WARNINGS_OFF_AT_0) {
+      rt_model_t *m = get_model_or_null();
+      if (m != NULL) {
+         unsigned delta;
+         int64_t now = model_now(m, &delta);
+         if (now == 0)
+            args[0].integer = IEEE_WARNINGS_OFF;
+      }
+   }
 }
 
 DLLEXPORT

--- a/test/test_jit.c
+++ b/test/test_jit.c
@@ -329,7 +329,7 @@ END_TEST
 DLLEXPORT
 void _nvc_ieee_warnings(jit_scalar_t *args)
 {
-   args[0].integer = 1;
+   args[0].integer = IEEE_WARNINGS_ON;
 }
 
 START_TEST(test_ieee_warnings)


### PR DESCRIPTION
Closes #1214

## Changes:

- Add an enum for the `ieee-warnings` options (updating `0` / `1` constants with enum values), and a parse function (based on the previous `parse_on_off`)
- Add a check to `_nvc_ieee_warnings` that returns `IEEE_WARNINGS_OFF` if it is set to `off-at-0` and time is 0
- Update help messages
- Update standard library modules: `NO_WARNING` constant to a function so it is evaluated when needed
- I believe my changes follow [contrib/STYLE.md](contrib/STYLE.md), but point out if I've missed something :) 

I also noticed when compiling to test: `parse_on_off` was only used for this option, so it is now unused, should I remove it?

## Testcase:

Command: `nvc --ieee-warnings=off-at-0 -a tb.vhdl --check-synthesis -e tb -r --format fst --wave`

`tb.vhdl`:

```vhdl
library ieee;
use ieee.std_logic_1164.all;
use ieee.numeric_std.all;

entity tb is
end;

architecture sim of tb is
begin
    process
        variable v : STD_LOGIC_VECTOR (7 downto 0) := x"XX";
        variable i : INTEGER;
    begin
        report "start" severity NOTE;
        i := TO_INTEGER(UNSIGNED(v));
        wait for 1 ns;
        report "wait 1 ns" severity NOTE;
        i := TO_INTEGER(UNSIGNED(v));
        report "end" severity NOTE;
        wait;
    end process;
end;
```