### PR TITLE
Fix 'converse for nested views

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -514,8 +514,31 @@ tree_t find_element_mode_indication(tree_t view, tree_t field, bool *converse)
          const int nelems = type_fields(view_type);
          for (int i = 0; i < nelems; i++) {
             tree_t e = type_field(view_type, i);
-            if (tree_ref(e) == field)
+            if (tree_ref(e) == field) {
+               // If this element has a view and we need to apply converse,
+               // recursively apply converse to the element's view
+               if (*converse && tree_has_value(e)) {
+                  tree_t elem_view = tree_value(e);
+                  
+                  // Create a 'converse attribute reference for the element's view
+                  tree_t converse_attr = tree_new(T_ATTR_REF);
+                  tree_set_name(converse_attr, elem_view);
+                  tree_set_subkind(converse_attr, ATTR_CONVERSE);
+                  tree_set_loc(converse_attr, tree_loc(elem_view));
+                  
+                  // Create a new element with the converse view
+                  tree_t new_e = tree_new(tree_kind(e));
+                  tree_set_ref(new_e, tree_ref(e));
+                  tree_set_subkind(new_e, tree_subkind(e));
+                  tree_set_value(new_e, converse_attr);
+                  tree_set_loc(new_e, tree_loc(e));
+                  if (tree_has_type(e))
+                     tree_set_type(new_e, tree_type(e));
+                  
+                  return new_e;
+               }
                return e;
+            }
          }
 
          return NULL;

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -896,6 +896,7 @@ ename6          normal,2008
 cover20         cover,shell
 issue787        normal
 view6           normal,2019
+view7           normal,2019
 issue790        normal
 issue791        normal,2008
 issue794        normal,2008

--- a/test/regress/view4.vhd
+++ b/test/regress/view4.vhd
@@ -4,7 +4,7 @@ package pack is
     subtype rbit_vector is (resolved) bit_vector;
 
     type vec_t is record
-        p : bit_vector(1 to 3);
+        p : rbit_vector(1 to 3);
         q : rbit_vector(1 to 3);
     end record;
 
@@ -78,14 +78,14 @@ begin
         assert o = (0, 0, ("000", "000"));
         wait for 0 ns;
         assert i = (0, 5, ("000", "000"));
-        assert o = (1, 0, ("111", "111"));
+        assert o = (1, 0, ("000", "111"));
         i.x <= 7;
         o.y <= 12;
         i.z.p <= "101";
         i.z.q <= "001";
         wait for 1 ns;
         assert i = (7, 17, ("101", "001"));
-        assert o = (8, 12, ("010", "110"));
+        assert o = (8, 12, ("000", "110"));
         wait;
     end process;
 

--- a/test/regress/view7.vhd
+++ b/test/regress/view7.vhd
@@ -1,0 +1,47 @@
+-- Test that 'converse attribute is applied recursively to nested views
+package test_pack is
+    type inner_rec_t is record
+        a : natural;
+        b : natural;
+    end record;
+
+    type outer_rec_t is record
+        x : natural;
+        inner : inner_rec_t;
+    end record;
+
+    view inner_view of inner_rec_t is
+        a : in;
+        b : out;
+    end view;
+
+    view outer_view of outer_rec_t is
+        x : in;
+        inner : view inner_view;
+    end view;
+
+    alias converse_outer_view is outer_view'converse;
+    -- In converse_outer_view:
+    -- inner.a should be OUT
+    -- inner.b should be IN
+end package;
+
+use work.test_pack.all;
+
+-- Test entity that validates the converse view modes
+entity view7 is
+    port (
+        p : view converse_outer_view
+    );
+end entity;
+
+architecture test of view7 is
+begin
+    -- This assignment only compiles if converse was applied to nested view
+    p.inner.a <= 42;
+
+    p.x <= 10;
+    p.inner.b <= p.inner.b + 1;
+
+    std.env.finish;
+end architecture;


### PR DESCRIPTION
IEEE 1076-2019 section 16.2.8 says that applying `'CONVERSE` to a mode view means that each element mode `EM` becomes `EM'CONVERSE`.  This PR attempts to bring NVC in line with that part of the VHDL 2019 standard.