### PR TITLE
Improve parsing of integer constants

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -135,7 +135,7 @@ TRANSLATE_ON    {PRAGMA}(?i:pragma)[ \t]+(?i:translate_on).*
 PSL_COMMENT     {PRAGMA}(?i:psl)
 PSL_CONT        ^{SPACE}*({PSL_COMMENT}|"--")
 UTF8_MB         [\x80-\xff][\x80-\xbf]{1,3}
-VLOG_NUMBER     {INTEGER}?\'s?[bhdo]{HEX}
+VLOG_NUMBER     ({INTEGER}{SPACE}*)?\'s?[bhdoBHDO]{SPACE}*({HEX}|[?])+
 VLOG_REAL       {INTEGER}\.{INTEGER}
 UDP_LEVEL       [01xX?bB]
 UDP_EDGE        [rRfFpPnN*]

--- a/src/vlog/vlog-number.c
+++ b/src/vlog/vlog-number.c
@@ -216,10 +216,11 @@ number_t number_new(const char *str, const loc_t *loc)
       else if (tick != NULL) {
          char *eptr;
          width = strtol(str, &eptr, 10);
-         if (eptr != tick)
-            should_not_reach_here();
 
-         p = tick + 1;
+         p = eptr;
+         while (isspace_iso88591(*p)) p++;
+         assert(p == tick);
+         p++;
       }
    }
 
@@ -246,7 +247,7 @@ number_t number_new(const char *str, const loc_t *loc)
       error_at(loc, "number cannot start with an underscore");
 
    // Skip optional spaces after the radix
-   while (*p == ' ')
+   while (isspace_iso88591(*p))
       p++;
 
    if (radix == RADIX_STR) {
@@ -275,7 +276,8 @@ number_t number_new(const char *str, const loc_t *loc)
          if (*p == '_')
             p++;
          if (*p != '\0')
-            error_at(loc, "invalid character '%c' in decimal number %s", *p, str);
+            error_at(loc, "invalid character '%c' in decimal number %s",
+                     *p, str);
          break;
       default:
          for (; *p; p++) {
@@ -292,7 +294,8 @@ number_t number_new(const char *str, const loc_t *loc)
             case '_':
                continue;
             default:
-               error_at(loc, "invalid character '%c' in decimal number %s", *p, str);
+               error_at(loc, "invalid character '%c' in decimal number %s",
+                        *p, str);
             }
          }
       }
@@ -324,7 +327,8 @@ number_t number_new(const char *str, const loc_t *loc)
                case '_':
                   continue;
                default:
-                  error_at(loc, "invalid character '%c' in binary number %s", *p, str);
+                  error_at(loc, "invalid character '%c' in binary number %s",
+                           *p, str);
                }
 
                if (bit >= width) {
@@ -359,7 +363,8 @@ number_t number_new(const char *str, const loc_t *loc)
                case '_':
                   continue;
                default:
-                  error_at(loc, "invalid character '%c' in octal number %s", *p, str);
+                  error_at(loc, "invalid character '%c' in octal number %s",
+                           *p, str);
                }
 
                if (bit >= width) {
@@ -399,7 +404,8 @@ number_t number_new(const char *str, const loc_t *loc)
                case '_':
                   continue;
                default:
-                  error_at(loc, "invalid character '%c' in hex number %s", *p, str);
+                  error_at(loc, "invalid character '%c' in hex number %s",
+                           *p, str);
                }
 
                if (bit >= width) {

--- a/src/vlog/vlog-number.c
+++ b/src/vlog/vlog-number.c
@@ -230,9 +230,13 @@ number_t number_new(const char *str, const loc_t *loc)
 
    vlog_radix_t radix = RADIX_DEC;
    switch (*p) {
+   case 'B':
    case 'b': radix = RADIX_BIN; p++; break;
+   case 'O':
    case 'o': radix = RADIX_OCT; p++; break;
+   case 'H':
    case 'h': radix = RADIX_HEX; p++; break;
+   case 'D':
    case 'd': radix = RADIX_DEC; p++; break;
    case '"': radix = RADIX_STR; p++; break;
    default: result.big->issigned = true; break;
@@ -240,6 +244,10 @@ number_t number_new(const char *str, const loc_t *loc)
 
    if (*p == '_' && radix != RADIX_STR)
       error_at(loc, "number cannot start with an underscore");
+
+   // Skip optional spaces after the radix
+   while (*p == ' ')
+      p++;
 
    if (radix == RADIX_STR) {
       for (int bit = width - 8; !(*p == '"' && *(p + 1) == '\0');
@@ -250,21 +258,42 @@ number_t number_new(const char *str, const loc_t *loc)
       }
    }
    else if (radix == RADIX_DEC) {
-      for (; *p; p++) {
-         switch (*p) {
-         case '0'...'9':
-            {
-               const uint64_t ten[] = { 10 };
-               const uint64_t digit[] = { *p - '0' };
+      bool is_x_digit = false;
+      switch (*p) {
+      case 'X':
+      case 'x':
+         is_x_digit = true;
+      case '?':
+      case 'Z':
+      case 'z':
+         p++;
+         for (int bit = 0; bit < width; bit++) {
+            if (is_x_digit)
+               bignum_set_abit(result.big, bit, 1);
+            bignum_set_bbit(result.big, bit, 1);
+         }
+         if (*p == '_')
+            p++;
+         if (*p != '\0')
+            error_at(loc, "invalid character '%c' in decimal number %s", *p, str);
+         break;
+      default:
+         for (; *p; p++) {
+            switch (*p) {
+            case '0'...'9':
+               {
+                  const uint64_t ten[] = { 10 };
+                  const uint64_t digit[] = { *p - '0' };
 
-               vec2_mul(result.big->words, width, ten, 64);
-               vec2_add(width, result.big->words, digit);
+                  vec2_mul(result.big->words, width, ten, 64);
+                  vec2_add(width, result.big->words, digit);
+               }
+               break;
+            case '_':
+               continue;
+            default:
+               error_at(loc, "invalid character '%c' in decimal number %s", *p, str);
             }
-            break;
-         case '_':
-            continue;
-         default:
-            error_at(loc, "invalid character '%c' in number %s", *p, str);
          }
       }
    }
@@ -282,17 +311,20 @@ number_t number_new(const char *str, const loc_t *loc)
                case '1':
                   bignum_set_abit(result.big, bit, 1);
                   break;
+               case 'X':
                case 'x':
                   bignum_set_abit(result.big, bit, 1);
                   bignum_set_bbit(result.big, bit, 1);
                   break;
+               case '?':
+               case 'Z':
                case 'z':
                   bignum_set_bbit(result.big, bit, 1);
                   break;
                case '_':
                   continue;
                default:
-                  error_at(loc, "invalid character '%c' in number %s", *p, str);
+                  error_at(loc, "invalid character '%c' in binary number %s", *p, str);
                }
 
                if (bit >= width) {
@@ -307,12 +339,15 @@ number_t number_new(const char *str, const loc_t *loc)
          case RADIX_OCT:
             {
                switch (*p) {
+               case 'X':
                case 'x':
                   for (int i = 0; i < 3; i++) {
                      bignum_set_abit(result.big, bit + i, 1);
                      bignum_set_bbit(result.big, bit + i, 1);
                   }
                   break;
+               case '?':
+               case 'Z':
                case 'z':
                   for (int i = 0; i < 3; i++)
                      bignum_set_bbit(result.big, bit + i, 1);
@@ -324,7 +359,7 @@ number_t number_new(const char *str, const loc_t *loc)
                case '_':
                   continue;
                default:
-                  error_at(loc, "invalid character '%c' in number %s", *p, str);
+                  error_at(loc, "invalid character '%c' in octal number %s", *p, str);
                }
 
                if (bit >= width) {
@@ -339,12 +374,15 @@ number_t number_new(const char *str, const loc_t *loc)
          case RADIX_HEX:
             {
                switch (*p) {
+               case 'X':
                case 'x':
                   for (int i = 0; i < 4; i++) {
                      bignum_set_abit(result.big, bit + i, 1);
                      bignum_set_bbit(result.big, bit + i, 1);
                   }
                   break;
+               case '?':
+               case 'Z':
                case 'z':
                   for (int i = 0; i < 4; i++)
                      bignum_set_bbit(result.big, bit + i, 1);
@@ -361,7 +399,7 @@ number_t number_new(const char *str, const loc_t *loc)
                case '_':
                   continue;
                default:
-                  error_at(loc, "invalid character '%c' in number %s", *p, str);
+                  error_at(loc, "invalid character '%c' in hex number %s", *p, str);
                }
 
                if (bit >= width) {

--- a/test/test_vlog.c
+++ b/test/test_vlog.c
@@ -1119,6 +1119,27 @@ START_TEST(test_pp5)
 }
 END_TEST
 
+START_TEST(test_integers1)
+{
+   input_from_file(TESTDIR "/vlog/integers1.sv");
+
+   const error_t expect[] = {
+      {  21, "unexpected identifier while parsing statement item, expecting ;" },
+      {  28, "unexpected ' while parsing statement item, expecting ;" },
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   vlog_node_t m = vlog_parse();
+   fail_if(m == NULL);
+   fail_unless(vlog_kind(m) == V_MODULE);
+
+   fail_unless(vlog_parse() == NULL);
+
+   check_expected_errors();
+}
+END_TEST
+
 Suite *get_vlog_tests(void)
 {
    Suite *s = suite_create("vlog");
@@ -1159,6 +1180,7 @@ Suite *get_vlog_tests(void)
    tcase_add_test(tc, test_keywords);
    tcase_add_test(tc, test_error1);
    tcase_add_test(tc, test_pp5);
+   tcase_add_test(tc, test_integers1);
    suite_add_tcase(s, tc);
 
    return s;

--- a/test/vlog/integers1.sv
+++ b/test/vlog/integers1.sv
@@ -1,0 +1,39 @@
+module integers1;
+  logic [9:0]  a;
+  logic [19:0] b;
+  logic [12:0] c;
+  logic [10:0] d;
+  logic [3:0]  e;
+  logic [4:0]  f;
+  logic [2:0]  g;
+  logic [11:0] h;
+  logic [15:0] i;
+  logic [7:0]  l;
+  logic [7:0]  m;
+  logic [3:0]  n;
+  logic [3:0]  o;
+  logic [15:0] p;
+
+  initial begin
+    a = 659;      // is a decimal number
+    b = 'h 837FF; // is a hexadecimal number
+    c = 'o7460;   // is an octal number
+    d = 4af;      // is illegal (hexadecimal format requires 'h)
+    e = 4'b1001;  // is a 4-bit binary number
+    f = 5 'D 3;   // is a 5-bit decimal number
+    g = 3'b01x;   // is a 3-bit number with the least
+                  // significant bit unknown
+    h = 12'hx;    // is a 12-bit unknown number
+    i = 16'hz;    // is a 16-bit high-impedance number
+    l = 8 'd -6;  // this is illegal syntax
+    m = -8 'd 6;  // this defines the two's-complement of 6,
+                  // held in 8 bits—equivalent to -(8'd 6)
+    n = 4 'shf;   // this denotes the 4-bit number '1111', to
+                  // be interpreted as a two's-complement number,
+                  // or '-1'. This is equivalent to -4'h 1
+    o = -4 'sd15; // this is equivalent to -(-4'd 1), or '0001'
+    p = 16'sd?;   // the same as 16'sbz
+
+  end
+
+endmodule // integers1


### PR DESCRIPTION
* Accept and parse upper case letters for integer constants radix
* Accept spaces between size and radix as well as between radix and number
* Accept '?' as a z digit