### PR TITLE
fix coverage off pragma being ignored when surrounding generate scope. Fixes #1284

### DIFF
--- a/test/regress/cover28.sh
+++ b/test/regress/cover28.sh
@@ -1,0 +1,6 @@
+set -xe
+
+nvc -a $TESTDIR/regress/cover28.vhd -e --cover cover28 -r
+nvc --cover-report --output=html cover28.ncdb 2>&1 | tee out.txt
+
+diff -u $TESTDIR/regress/gold/cover28.txt out.txt

--- a/test/regress/cover28.vhd
+++ b/test/regress/cover28.vhd
@@ -1,0 +1,23 @@
+entity cover28 is
+end entity;
+
+architecture test of cover28 is
+
+begin
+
+-- coverage off
+gen_1 : for i in 0 to 0 generate
+begin
+
+    process
+    begin
+        wait for 1 ns;
+        report "Dummy statement";
+        wait for 1 ns;
+        wait;
+    end process;
+
+end generate;
+-- coverage on
+
+end architecture;

--- a/test/regress/gold/cover28.txt
+++ b/test/regress/gold/cover28.txt
@@ -1,0 +1,9 @@
+** Note: Code coverage report folder: html.
+** Note: Code coverage report contains: covered, uncovered, excluded coverage details.
+** Note: code coverage results for: WORK.COVER28
+** Note:      statement:     N.A.
+** Note:      branch:        N.A.
+** Note:      toggle:        N.A.
+** Note:      expression:    N.A.
+** Note:      FSM state:     N.A.
+** Note:      functional:    N.A.

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -1194,3 +1194,4 @@ issue1285       mixed,2008
 vlog25          verilog
 binary2         verilog
 enum1           verilog
+cover28         shell


### PR DESCRIPTION
FIxes #1284 by checking all upstream coverage scopes with matching file ref
instead of just the nearest coverage scope of `CSOPE_INSTANCE`. The igore
from pragma is collected in the scope for the surrounding entity, not the first `CSCOPE_INSTANCE`
scope.