### PR TITLE
Allow constant record elements in case choice

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 - Fixed a mis-optimisation which would cause the result of `x * x` to be
   zero (#1338, from @Blebowski).
 - Several other minor bugs were resolved (#1239, #1237, #1332, #1334,
-  #1335).
+  #1335, #1347).
 
 ## Version 1.18.1 - 2025-10-18
 - Fixed a crash when compiling with AVX2 enabled (#1311).

--- a/test/simp/issue1347.vhd
+++ b/test/simp/issue1347.vhd
@@ -1,0 +1,45 @@
+entity issue1347 is end entity;
+
+architecture test of issue1347 is
+  type reg_addrs_t is record
+    A, B, C, D : integer;
+  end record;
+  constant REGS : reg_addrs_t := (A => 0, B => 42, C => 3, D => -1024);
+  signal sel, sig : integer;
+begin
+  process (all)
+  begin
+    case sel is
+      when REGS.A => sig <= 1;
+      when REGS.B => sig <= 2;
+      when REGS.C |
+           REGS.D => sig <= 3;
+      when OTHERS => sig <= -1;
+    end case;
+  end process;
+
+  process
+  begin
+    sel <= -1;
+    wait for 1 ns;
+    assert sig = -1;
+
+    sel <= 0;
+    wait for 1 ns;
+    assert sig = 1;
+    
+    sel <= 42;
+    wait for 1 ns;
+    assert sig = 2;
+    
+    sel <= 3;
+    wait for 1 ns;
+    assert sig = 3;
+
+    sel <= -1024;
+    wait for 1 ns;
+    assert sig = 3;
+    
+    wait;
+  end process;
+end architecture;

--- a/test/test_simp.c
+++ b/test/test_simp.c
@@ -1938,6 +1938,23 @@ START_TEST(test_issue1318)
 }
 END_TEST
 
+START_TEST(test_issue1347)
+{
+   set_standard(STD_08);
+   input_from_file(TESTDIR "/simp/issue1347.vhd");
+
+   tree_t a = parse_check_and_simplify(T_ENTITY, T_ARCH);
+
+   tree_t c = tree_stmt(tree_stmt(a, 0), 0);
+   fail_unless(folded_i(tree_name(tree_assoc(tree_stmt(c, 0), 0)), 0));
+   fail_unless(folded_i(tree_name(tree_assoc(tree_stmt(c, 1), 0)), 42));
+   fail_unless(folded_i(tree_name(tree_assoc(tree_stmt(c, 2), 0)), 3));
+   fail_unless(folded_i(tree_name(tree_assoc(tree_stmt(c, 2), 1)), -1024));
+
+   fail_if_errors();
+}
+END_TEST
+
 Suite *get_simp_tests(void)
 {
    Suite *s = suite_create("simplify");
@@ -2013,6 +2030,7 @@ Suite *get_simp_tests(void)
    tcase_add_test(tc_core, test_issue1182);
    tcase_add_test(tc_core, test_issue1239);
    tcase_add_test(tc_core, test_issue1318);
+   tcase_add_test(tc_core, test_issue1347);
    suite_add_tcase(s, tc_core);
 
    return s;


### PR DESCRIPTION
I took a shot at issue #1347.

It's kinda arbitrary how I solved it. It looks for this specific case and then does basically the same `eval_try_fold` that would happen if it'd be wrapped in an `integer()` type conversion.

Feels not like the cleanest approach, so I'm definitely open for alternative ideas.

Cheers, Nik