### PR TITLE
Allow range of const record elements in case choice

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
   option has also been removed.
 - The `--stderr=none` option now prevents any diagnostic messages being
   printed to `stderr`, including those at `failure` severity (#1357).
-- Several other minor bugs were resolved (#1237, #1351).
+- Several other minor bugs were resolved (#1237, #1351, #1353).
 
 ## Version 1.18.2 - 2025-11-19
 - Fixed a mis-optimisation which would cause the result of `x * x` to be

--- a/test/simp/issue1353.vhd
+++ b/test/simp/issue1353.vhd
@@ -1,0 +1,47 @@
+entity bug is end entity;
+
+architecture test of bug is
+  type reg_addrs_t is record
+    A, B, C, D, E, F : integer range 0 to 5;
+  end record;
+  constant REGS : reg_addrs_t := (A => 0, B => 1, C => 2, D => 3, E => 4, F => 5);
+  signal sel, sig : integer range 0 to 5;
+begin
+  process (all)
+  begin
+    case sel is
+      when REGS.A | REGS.B => sig <= 0;
+      when integer(REGS.C) to integer(REGS.D) => sig <= 1;
+      when REGS.E to REGS.F => sig <= 2;
+    end case;
+  end process;
+
+  process
+  begin
+    sel <= 0;
+    wait for 1 ns;
+    assert sig = 0;
+
+    sel <= 1;
+    wait for 1 ns;
+    assert sig = 0;
+
+    sel <= 2;
+    wait for 1 ns;
+    assert sig = 1;
+
+    sel <= 3;
+    wait for 1 ns;
+    assert sig = 1;
+
+    sel <= 4;
+    wait for 1 ns;
+    assert sig = 2;
+
+    sel <= 5;
+    wait for 1 ns;
+    assert sig = 2;
+
+    wait;
+  end process;
+end architecture;

--- a/test/test_simp.c
+++ b/test/test_simp.c
@@ -1955,6 +1955,27 @@ START_TEST(test_issue1347)
 }
 END_TEST
 
+START_TEST(test_issue1353)
+{
+   set_standard(STD_08);
+   input_from_file(TESTDIR "/simp/issue1353.vhd");
+
+   tree_t a = parse_check_and_simplify(T_ENTITY, T_ARCH);
+
+   tree_t c = tree_stmt(tree_stmt(a, 0), 0);
+   fail_unless(folded_i(tree_name(tree_choice(tree_stmt(c, 0), 0)), 0));
+   fail_unless(folded_i(tree_name(tree_choice(tree_stmt(c, 0), 1)), 1));
+   tree_t r1 = tree_range(tree_choice(tree_stmt(c, 1), 0), 0);
+   fail_unless(folded_i(tree_left(r1), 2));
+   fail_unless(folded_i(tree_right(r1), 3));
+   tree_t r2 = tree_range(tree_choice(tree_stmt(c, 2), 0), 0);
+   fail_unless(folded_i(tree_left(r2), 4));
+   fail_unless(folded_i(tree_right(r2), 5));
+
+   fail_if_errors();
+}
+END_TEST
+
 Suite *get_simp_tests(void)
 {
    Suite *s = suite_create("simplify");
@@ -2031,6 +2052,7 @@ Suite *get_simp_tests(void)
    tcase_add_test(tc_core, test_issue1239);
    tcase_add_test(tc_core, test_issue1318);
    tcase_add_test(tc_core, test_issue1347);
+   tcase_add_test(tc_core, test_issue1353);
    suite_add_tcase(s, tc_core);
 
    return s;


### PR DESCRIPTION
I've extended our solution to #1347 with the capability to handle a range of constant record elements.
I don't think a slice i.e. association subkind `A_SLICE` is possible here. So I've left that out.
Cheers, Nik