### PR TITLE
src: refactor expression printing in code coverage report.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 - Code coverage report style was improved.
 - Average coverage numbers are now printed on command line when processing
   coverage.
+- Expression coverage reporting for multi-line expressions is improved.
 - Several other minor bugs were resolved (#1237, #1350, #1351, #1353,
   #1366, #1372, #1333).
 


### PR DESCRIPTION
This MR has two changes to the way coverage items are printed in the HTML coverage report:
1. Line numbers are printed in the coverage item title, as opposed to only start of the code sample
2. Expressions are printed within single line. Comments are filtered. This simplifies drawing of LHS/RHS indicators and allows to draw them also for multi-line expressions. This format matches how some of the commercial tools show expressions in coverage tools.

Very long expressions don't fit into single line, but I think that can be tolerated. 