### PR TITLE
Fix crash with parsing implicit signal attributes

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -2681,7 +2681,7 @@ bool same_tree(tree_t a, tree_t b)
 
    switch (akind) {
    case T_REF:
-      return tree_ref(a) == tree_ref(b);
+      return tree_has_ref(a) && tree_has_ref(b) && tree_ref(a) == tree_ref(b);
    case T_ARRAY_REF:
       {
          if (!same_tree(tree_value(a), tree_value(b)))

--- a/test/parse/implicit.vhd
+++ b/test/parse/implicit.vhd
@@ -12,3 +12,17 @@ package body implicit is
     end procedure;
 
 end package body;
+
+--------------------------------------------------------------------------------
+
+entity e is begin end entity;
+
+architecture a of e is
+    signal s : integer;
+begin
+    process is begin
+        assert s'delayed(undefined) = 5;  -- Error
+        assert s'delayed(undefined) = 5;  -- Error (suppressed)
+        wait;
+    end process;
+end architecture;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -3572,11 +3572,12 @@ START_TEST(test_implicit)
       {  3, "missing body for function \">=\" [UNSIGNED, UNSIGNED return BOOLEAN]" },
       {  0, "\">=\" [UNSIGNED, UNSIGNED return BOOLEAN] declared here" },
       {  0, "body not found in WORK.IMPLICIT-body" },
+      { 24, "no visible declaration for UNDEFINED" },
       { -1, NULL }
    };
    expect_errors(expect);
 
-   parse_and_check(T_PACKAGE, T_PACK_BODY);
+   parse_and_check(T_PACKAGE, T_PACK_BODY, T_ENTITY, T_ARCH);
 
    check_expected_errors();
 }


### PR DESCRIPTION
A new fuzzing campaign based on AFL++ revealed some interesting crashes.

For one of them, a repeated access to implicit signal attribute `delayed` with the same undefined identifier crashed the parser in `same_tree()`.

Input:
```vhd
entity e is begin end entity;
architecture a of e is
    signal s : integer;
begin
    process is begin
        assert s'delayed(tdelay) = 5;
        assert s'delayed(tdelay) = 5;
    end process;
end architecture;
```

Full crash:
```
# nvc -a ../test/aflfuzz/tofix/4b927a9.vhd 
** Error: no visible declaration for TDELAY
   > ../test/aflfuzz/tofix/4b927a9.vhd:6
   |
 6 |         assert s'delayed(tdelay) = 5;
   |                          ^^^^^^
nvc: ../src/tree.c:1049: tree_ref: Assertion `item->object != NULL' failed.

*** Caught signal 6 (SIGABRT) ***

[0x560e9b6e5e28] ../src/util.c:713 signal_handler
-->    show_stacktrace();
[0x7f94261a132f] (/usr/lib/x86_64-linux-gnu/libc.so.6) 
[0x7f94261fab2c] (/usr/lib/x86_64-linux-gnu/libc.so.6) ./nptl/pthread_kill.c:44 __pthread_kill_implementation
[0x7f94261fab2c] (/usr/lib/x86_64-linux-gnu/libc.so.6) ./nptl/pthread_kill.c:78 __pthread_kill_internal
[0x7f94261fab2c] (/usr/lib/x86_64-linux-gnu/libc.so.6) ./nptl/pthread_kill.c:89 pthread_kill@@GLIBC_2.34
[0x7f94261a127d] (/usr/lib/x86_64-linux-gnu/libc.so.6) ../sysdeps/posix/raise.c:26 raise
[0x7f94261848fe] (/usr/lib/x86_64-linux-gnu/libc.so.6) ./stdlib/abort.c:79 abort
[0x7f942618481a] (/usr/lib/x86_64-linux-gnu/libc.so.6) ./assert/assert.c:96 __assert_fail_base.cold
[0x7f9426197516] (/usr/lib/x86_64-linux-gnu/libc.so.6) ./assert/assert.c:105 __assert_fail
[0x560e9b73148d] ../src/tree.c:1049 tree_ref
       item_t *item = lookup_item(&tree_object, t, I_REF);
-->    assert(item->object != NULL);
       return container_of(item->object, struct _tree, object);
[0x560e9b76fdbe] ../src/common.c:2684 same_tree
       case T_REF:
-->       return tree_ref(a) == tree_ref(b);
       case T_ARRAY_REF:
[0x560e9b6f3bab] ../src/parse.c:2248 implicit_signal_attribute
                    || (delay != NULL && tree_has_delay(value)
-->                     && same_tree(tree_delay(value), delay)));
          }
[0x560e9b6f7fea] ../src/parse.c:3599 p_attribute_name
                || kind == ATTR_STABLE || kind == ATTR_QUIET)
-->       implicit_signal_attribute(t);
[0x560e9b6f9a51] ../src/parse.c:4049 p_name
             else {
-->             prefix = p_attribute_name(prefix);
                mask = is_type_attribute(tree_subkind(prefix)) ? N_TYPE : N_OBJECT;
[0x560e9b6fc419] ../src/parse.c:4815 p_primary
          {
-->          tree_t expr = p_name(0);
             if (peek() == tLSQUARE)
[0x560e9b6fc7d4] ../src/parse.c:4917 p_unary_expression
       else
-->       return p_primary(NULL);
    }
[0x560e9b6fc889] ../src/parse.c:4926 p_factor
-->    tree_t operand = p_unary_expression(head);
[0x560e9b6fca83] ../src/parse.c:4965 p_term
-->    tree_t term = p_factor(head);
[0x560e9b6fcd17] ../src/parse.c:5020 p_simple_expression
       else
-->       expr = p_term(head);
[0x560e9b6fcefb] ../src/parse.c:5058 p_shift_expression
-->    tree_t shift = p_simple_expression(head);
[0x560e9b6fd1eb] ../src/parse.c:5115 p_relation
-->    tree_t rel = p_shift_expression(head);
[0x560e9b6fd360] ../src/parse.c:5140 p_expression_with_head
-->    tree_t expr = p_relation(head);
[0x560e9b6fd552] ../src/parse.c:5184 p_expression
       else
-->       return p_expression_with_head(NULL);
    }
[0x560e9b704218] ../src/parse.c:7222 p_condition
-->    tree_t value = p_expression();
       solve_condition(nametab, &value);
[0x560e9b7042f5] ../src/parse.c:7238 p_assertion
-->    tree_set_value(s, p_condition());
[0x560e9b70da6c] ../src/parse.c:10242 p_assertion_statement
-->    tree_t t = p_assertion();
       consume(tSEMI);
[0x560e9b70f73b] ../src/parse.c:10781 p_sequential_statement
       case tASSERT:
-->       return p_assertion_statement(label);
[0x560e9b708272] ../src/parse.c:8505 p_sequence_of_statements
       while (not_at_token(tEND, tELSE, tELSIF, tWHEN))
-->       tree_add_stmt(parent, p_sequential_statement());
    }
[0x560e9b708ca3] ../src/parse.c:8702 p_process_statement_part
-->    p_sequence_of_statements(proc);
    }
[0x560e9b708f8b] ../src/parse.c:8764 p_process_statement
-->    p_process_statement_part(t);
[0x560e9b7175d6] ../src/parse.c:13389 p_concurrent_statement
       case tPROCESS:
-->       return p_process_statement(label);
[0x560e9b710e11] ../src/parse.c:11238 p_concurrent_statement_or_psl
       else
-->       tree_add_stmt(parent, p_concurrent_statement());
    }
[0x560e9b717b21] ../src/parse.c:13499 p_architecture_statement_part
       while (not_at_token(tEND))
-->       p_concurrent_statement_or_psl(arch);
    }
[0x560e9b717e1a] ../src/parse.c:13557 p_architecture_body
-->    p_architecture_statement_part(unit);
[0x560e9b718877] ../src/parse.c:13761 p_secondary_unit
       case tARCHITECTURE:
-->       p_architecture_body(unit);
          break;
[0x560e9b7189a3] ../src/parse.c:13787 p_library_unit
       case tARCHITECTURE:
-->       p_secondary_unit(unit);
          break;
[0x560e9b718d40] ../src/parse.c:13850 p_design_unit
       p_context_clause(unit);
-->    p_library_unit(unit);
[0x560e9b718f60] ../src/parse.c:13903 parse
-->    tree_t unit = p_design_unit();
[0x560e9b76fa8b] ../src/common.c:2600 analyse_file
             tree_t unit;
-->          while (base_errors = error_count(), (unit = parse())) {
                if (error_count() == base_errors) {
[0x560e9b6db612] ../src/nvc.c:349 analyse
          else
-->          analyse_file(argv[i], jit, state->registry, state->mir);
       }
[0x560e9b6e0726] ../src/nvc.c:2510 process_command
       case 'a':
-->       return analyse(argc, argv, state);
       case 'e':
[0x560e9b6e0cc3] ../src/nvc.c:2676 main
-->    const int ret = process_command(argc, argv, &state);

DEDUP_TOKEN: signal_handler--tree_ref--same_tree--implicit_signal_attribute
```

Because the parent function was named `implicit_signal_attribute` I put the test for this in `test/parse/implicit.vhd` (for which I also fixed the test). LMK if this is not ideal.

More to come.
Cheers, Nik