### PR TITLE
Fix crash when calculating invalid aggregate bounds

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -2780,6 +2780,8 @@ static range_kind_t get_range_direction(tree_t r)
    assert(kind == ATTR_RANGE || kind == ATTR_REVERSE_RANGE);
 
    type_t prefix_type = tree_type(tree_name(aref));
+   if (type_is_none(prefix_type))
+      return RANGE_ERROR;
    if (type_is_unconstrained(prefix_type))
       return RANGE_EXPR;
 
@@ -2801,6 +2803,9 @@ bool calculate_aggregate_bounds(tree_t expr, range_kind_t *kind,
    // rules in LRM 93 7.3.2.2
 
    type_t type = tree_type(expr);
+   if (type_is_none(type))
+      return false;
+
    type_t index_type = index_type_of(type, 0);
    if (index_type == NULL || type_is_none(index_type))
       return false;

--- a/test/parse/fuzzing.vhd
+++ b/test/parse/fuzzing.vhd
@@ -1,0 +1,5 @@
+package test_pkg is
+  type     t_slv_array   is array (natural range <>) of bit_vector;
+  subtype  t_word_array  is t_slv_array(open)(t_word'range);
+  constant C_NULL_DATA : t_word_array(0 to -1) := (others => (foo => '0'));
+end package;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -7397,6 +7397,24 @@ START_TEST(test_issue1335)
 }
 END_TEST
 
+START_TEST(test_fuzzing)
+{
+   set_standard(STD_08);
+   input_from_file(TESTDIR "/parse/fuzzing.vhd");
+
+   const error_t expect[] = {
+      {  3, "no visible declaration for T_WORD" },
+      {  4, "no visible declaration for FOO" },
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   parse_and_check(T_PACKAGE);
+
+   check_expected_errors();
+}
+END_TEST
+
 Suite *get_parse_tests(void)
 {
    Suite *s = suite_create("parse");
@@ -7586,6 +7604,7 @@ Suite *get_parse_tests(void)
    tcase_add_test(tc_core, test_protect1);
    tcase_add_test(tc_core, test_issue1318);
    tcase_add_test(tc_core, test_issue1335);
+   tcase_add_test(tc_core, test_fuzzing);
    suite_add_tcase(s, tc_core);
 
    return s;


### PR DESCRIPTION
Continuation of #1374.

This time an input like:
```vhd
package test_pkg is
  type     t_slv_array   is array (natural range <>) of bit_vector;
  subtype  t_word_array  is t_slv_array(open)(t_word'range);
  constant C_NULL_DATA : t_word_array(0 to -1) := (others => (foo => '0'));
end package;
```

Crashes with:
```
# nvc --std=08 -a ../test/aflfuzz/tofix/4f9dd1c.vhd
** Error: no visible declaration for T_WORD
   > ../test/aflfuzz/tofix/4f9dd1c.vhd:3
   |
 3 |   subtype  t_word_array  is t_slv_array(open)(t_word'range);
   |                                               ^^^^^^
** Error: no visible declaration for FOO
   > ../test/aflfuzz/tofix/4f9dd1c.vhd:4
   |
 4 |   constant C_NULL_DATA : t_word_array(0 to -1) := (others => (foo => '0'));
   |                                                               ^^^ did you mean NOW?
** Fatal: invalid type kind T_NONE for none in range_of
[0x5555de6423d6] ../src/util.c:410 fatal_trace
-->    show_stacktrace();
[0x5555de6c8842] ../src/common.c:1016 range_of
       default:
-->       fatal_trace("invalid type kind %s for %s in range_of",
                      type_kind_str(type_kind(type)), type_pp(type));
[0x5555de6cd308] ../src/common.c:2788 get_range_direction
-->    tree_t prefix_r = range_of(prefix_type, 0);
[0x5555de6cd4cc] ../src/common.c:2828 calculate_aggregate_bounds
          base_r = range_of(type, 0);
-->       dir = get_range_direction(base_r);
       }
[0x5555de6cda5e] ../src/common.c:2952 calculate_aggregate_subtype
       int64_t ileft, iright;
-->    if (!calculate_aggregate_bounds(expr, &dir, &ileft, &iright))
          return NULL;
[0x5555de730b74] ../src/names.c:4760 solve_array_aggregate
-->    type_t sub = calculate_aggregate_subtype(agg);
       if (sub == NULL) {
[0x5555de730d0c] ../src/names.c:4794 try_solve_aggregate
       else
-->       return solve_array_aggregate(tab, agg, type);
    }
[0x5555de730d49] ../src/names.c:4799 solve_aggregate
    {
-->    type_t type = try_solve_aggregate(tab, agg);
       if (type != NULL)
[0x5555de731ece] ../src/names.c:5180 _solve_types
       case T_AGGREGATE:
-->       return solve_aggregate(tab, expr);
       case T_ARRAY_REF:
[0x5555de730ad4] ../src/names.c:4746 solve_array_aggregate
          else
-->          _solve_types(tab, value);
       }
[0x5555de730d0c] ../src/names.c:4794 try_solve_aggregate
       else
-->       return solve_array_aggregate(tab, agg, type);
    }
[0x5555de730d49] ../src/names.c:4799 solve_aggregate
    {
-->    type_t type = try_solve_aggregate(tab, agg);
       if (type != NULL)
[0x5555de731ece] ../src/names.c:5180 _solve_types
       case T_AGGREGATE:
-->       return solve_aggregate(tab, expr);
       case T_ARRAY_REF:
[0x5555de732126] ../src/names.c:5231 solve_types
       type_set_add(tab, constraint, NULL);
-->    type_t type = _solve_types(tab, expr);
       type_set_pop(tab, &ts);
[0x5555de661090] ../src/parse.c:7206 p_constant_declaration
             if (standard() < STD_19 || type_is_unconstrained(type))
-->             solve_types(nametab, init, type);
             else
[0x5555de66692b] ../src/parse.c:8975 p_package_declarative_item
       case tCONSTANT:
-->       p_constant_declaration(pack);
          break;
[0x5555de666ba7] ../src/parse.c:9036 p_package_declarative_part
       while (not_at_token(tEND))
-->       p_package_declarative_item(pack);
    }
[0x5555de666f0a] ../src/parse.c:9102 p_package_declaration
-->    p_package_declarative_part(pack);
[0x5555de668f41] ../src/parse.c:9685 p_primary_unit
          else
-->          p_package_declaration(unit);
          break;
[0x5555de67596e] ../src/parse.c:13794 p_library_unit
          else
-->          p_primary_unit(unit);
          break;
[0x5555de675cde] ../src/parse.c:13850 p_design_unit
       p_context_clause(unit);
-->    p_library_unit(unit);
[0x5555de675efe] ../src/parse.c:13903 parse
-->    tree_t unit = p_design_unit();
[0x5555de6cca29] ../src/common.c:2600 analyse_file
             tree_t unit;
-->          while (base_errors = error_count(), (unit = parse())) {
                if (error_count() == base_errors) {
[0x5555de6385f2] ../src/nvc.c:349 analyse
          else
-->          analyse_file(argv[i], jit, state->registry, state->mir);
       }
[0x5555de63d706] ../src/nvc.c:2510 process_command
       case 'a':
-->       return analyse(argc, argv, state);
       case 'e':
[0x5555de63dca3] ../src/nvc.c:2676 main
-->    const int ret = process_command(argc, argv, &state);
```

Handling the `T_NONE` type fixes it.

Cheers, Nik.