### PR TITLE
Fix crash when parsing illegal based literals

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -126,7 +126,7 @@ CHAR            '.'
 INTEGER         [0-9][0-9_]*
 EXPONENT        [Ee][+-]?{INTEGER}
 DECIMAL         {INTEGER}(\.{INTEGER})?{EXPONENT}?
-HEX             [0-9a-fA-FzZxX_]+
+HEX             [0-9a-fA-FzZxX][0-9a-fA-FzZxX_]*
 BASED_HASH      {INTEGER}[#]{HEX}(\.{HEX})?[#]{EXPONENT}?
 BASED_COLON     {INTEGER}[:]{HEX}(\.{HEX})?[:]{EXPONENT}?
 BASED           {BASED_HASH}|{BASED_COLON}

--- a/test/parse/fuzzing.vhd
+++ b/test/parse/fuzzing.vhd
@@ -3,3 +3,9 @@ package test_pkg is
   subtype  t_word_array  is t_slv_array(open)(t_word'range);
   constant C_NULL_DATA : t_word_array(0 to -1) := (others => (foo => '0'));
 end package;
+
+--------------------------------------------------------------------------------
+
+PACKAGE pkg IS
+  CONSTANT c : INTEGER := 16#_.FF#E0;  -- Error
+END PACKAGE;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -7416,11 +7416,15 @@ START_TEST(test_fuzzing)
    const error_t expect[] = {
       {  3, "no visible declaration for T_WORD" },
       {  4, "no visible declaration for FOO" },
+      { 10, "unexpected # while parsing constant declaration, expecting one of "
+            "**, when or ;" },
+      { 10, "a VHDL basic identifier must not start or end with an underscore, "
+            "or contain multiple consecutive underscores" },
       { -1, NULL }
    };
    expect_errors(expect);
 
-   parse_and_check(T_PACKAGE);
+   parse_and_check(T_PACKAGE, T_PACKAGE);
 
    check_expected_errors();
 }


### PR DESCRIPTION
Next one. Thanks for merging the others.

A based literal in the form of `16#_.FF#E0` was able to crash the parser.

<details>
<summary>Full crash:</summary>

```
# nvc --std=08 -a ../test/aflfuzz/minimized_crashes/6d83562.vhd 

*** Caught signal 11 (SEGV_MAPERR) [address=(nil), ip=0x7fec01fbb45f] ***

[0x559ca2873dc6] ../src/util.c:707 signal_handler
-->    show_stacktrace();
[0x7fec01fac32f] (/usr/lib/x86_64-linux-gnu/libc.so.6) 
[0x7fec01fbb45f] (/usr/lib/x86_64-linux-gnu/libc.so.6) ../stdlib/strtol_l.c:304 ____strtoll_l_internal
[0x559ca28b9b26] ../src/lexer.l:1167 parse_based_literal
-->          double tmp = (double)strtoll(rational, &eptr_rational, atoi(base));
             tmp *= pow((double)atoi(base), (double)((long)(0 - strlen(rational))));
[0x559ca28b4b73] ../src/lexer.l:868 yylex
    <INITIAL,PSL>{DECIMAL}   { return parse_decimal_literal(yytext); }
--> <INITIAL,PSL>{BASED}     { return parse_based_literal(yytext); }
    <INITIAL,PSL>{BITSTRING} { return parse_bit_string(yytext); }
[0x559ca296b716] ../src/scan.c:458 pp_yylex
    {
-->    const int tok = input_buf.lookahead != -1 ? input_buf.lookahead : yylex();
       input_buf.lookahead = -1;
[0x559ca296c25d] ../src/scan.c:734 processed_yylex
       for (;;) {
-->       token_t token = pp_yylex();
          switch (token) {
[0x559ca2879c2c] ../src/parse.c:223 wrapped_yylex
       for (;;) {
-->       const token_t token = processed_yylex();
          switch (token) {
[0x559ca2879cff] ../src/parse.c:252 peek_nth
       while (((tokenq_head - tokenq_tail) & (tokenq_sz - 1)) < n) {
-->       const token_t token = wrapped_yylex();
[0x559ca287a54a] ../src/parse.c:424 optional
    {
-->    if (peek() == tok) {
          consume(tok);
[0x559ca288b488] ../src/parse.c:5175 p_expression
-->    if (optional(tCCONV)) {
          require_std(STD_08, "condition conversion");
[0x559ca28919a7] ../src/parse.c:7062 p_conditional_expression
-->    tree_t expr0 = p_expression();
[0x559ca2891f5a] ../src/parse.c:7171 p_constant_declaration
       if (optional(tWALRUS))
-->       init = p_conditional_expression();
[0x559ca289792b] ../src/parse.c:8975 p_package_declarative_item
       case tCONSTANT:
-->       p_constant_declaration(pack);
          break;
[0x559ca2897ba7] ../src/parse.c:9036 p_package_declarative_part
       while (not_at_token(tEND))
-->       p_package_declarative_item(pack);
    }
[0x559ca2897f0a] ../src/parse.c:9102 p_package_declaration
-->    p_package_declarative_part(pack);
[0x559ca2899f41] ../src/parse.c:9685 p_primary_unit
          else
-->          p_package_declaration(unit);
          break;
[0x559ca28a696e] ../src/parse.c:13794 p_library_unit
          else
-->          p_primary_unit(unit);
          break;
[0x559ca28a6cde] ../src/parse.c:13850 p_design_unit
       p_context_clause(unit);
-->    p_library_unit(unit);
[0x559ca28a6efe] ../src/parse.c:13903 parse
-->    tree_t unit = p_design_unit();
[0x559ca28fda29] ../src/common.c:2601 analyse_file
             tree_t unit;
-->          while (base_errors = error_count(), (unit = parse())) {
                if (error_count() == base_errors) {
[0x559ca28695f2] ../src/nvc.c:349 analyse
          else
-->          analyse_file(argv[i], jit, state->registry, state->mir);
       }
[0x559ca286e706] ../src/nvc.c:2510 process_command
       case 'a':
-->       return analyse(argc, argv, state);
       case 'e':
[0x559ca286eca3] ../src/nvc.c:2676 main
-->    const int ret = process_command(argc, argv, &state);
```

</details>

I modified the lexer regex to make this not recognized. Funnily this also makes it actually aligned with the standard (2008), which defines:
> ```
> based_integer ::=
>     extended_digit { [ underline ] extended_digit }
> ```

I'm not sure if this has performance implications. If yes, then there would be other possible fixes. For example a simple if/else inside `parse_based_literal()`.

Cheers, Nik