### PR TITLE
Fix parser crash on spurious PURE

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -8991,8 +8991,10 @@ static void p_package_declarative_item(tree_t pack)
    case tPROCEDURE:
    case tIMPURE:
    case tPURE:
-      if (peek_nth(3) == tIS && peek_nth(4) == tNEW)
-         tree_add_decl(pack, p_subprogram_instantiation_declaration());
+      if (peek_nth(3) == tIS && peek_nth(4) == tNEW) {
+         tree_t decl = p_subprogram_instantiation_declaration();
+         if (decl != NULL) tree_add_decl(pack, decl);
+      }
       else {
          tree_t spec = p_subprogram_specification();
          if (peek() == tSEMI)

--- a/test/parse/fuzzing.vhd
+++ b/test/parse/fuzzing.vhd
@@ -9,3 +9,9 @@ end package;
 PACKAGE pkg IS
   CONSTANT c : INTEGER := 16#_.FF#E0;  -- Error
 END PACKAGE;
+
+--------------------------------------------------------------------------------
+
+package p is
+  pure bad1 is new gen_clock;
+end package;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -7421,11 +7421,13 @@ START_TEST(test_fuzzing)
             "**, when or ;" },
       { 10, "a VHDL basic identifier must not start or end with an underscore, "
             "or contain multiple consecutive underscores" },
+      { 16, "unexpected pure while parsing package declarative item, "
+            "expecting one of function or procedure" },
       { -1, NULL }
    };
    expect_errors(expect);
 
-   parse_and_check(T_PACKAGE, T_PACKAGE);
+   parse_and_check(T_PACKAGE, T_PACKAGE, T_PACKAGE);
 
    check_expected_errors();
 }


### PR DESCRIPTION
A simple fix for a simple crash. Found by AFL++ fuzzer.
Cheers, Nik

PS.: I'm hesitant to add anything to the `NEWS.md` for such tiny changes. LMK if you'd like to have something written there anyway.