### PR TITLE
Add physical values to VHPI get_value

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
   random seed for the simulation.
 - Fixed an error when setting generics on the command line with `-g`
   after analysing with `--preserve-case` (#1421).
+- Added support for reading physical types in `vhpi_get_value`.
 - Several other minor bugs were resolved (#1422).
 
 ## Version 1.19.1 - 2026-02-07

--- a/src/vhpi/vhpi-model.c
+++ b/src/vhpi/vhpi-model.c
@@ -3367,6 +3367,13 @@ int vhpi_get_value(vhpiHandleT expr, vhpiValueT *value_p)
       value_p->value.real = ((const double *)value)[offset];
       return 0;
 
+   case vhpiPhysVal:
+#define READ_ENUM(type) scalar = ((const type *)value)[offset]
+      FOR_ALL_SIZES(size, READ_ENUM);
+      value_p->numElems = num_elems;
+      value_p->value.phys = vhpi_phys_from_native(scalar);
+      return 0;
+
    case vhpiLogicVecVal:
       {
          const int max = value_p->bufSize / sizeof(vhpiEnumT);
@@ -3412,6 +3419,24 @@ int vhpi_get_value(vhpiHandleT expr, vhpiValueT *value_p)
          } while (0)
 
          FOR_ALL_SIZES(size, READ_ENUMV);
+         return 0;
+      }
+
+   case vhpiPhysVecVal:
+      {
+         const int max = value_p->bufSize / sizeof(vhpiPhysT);
+         if (max < num_elems)
+            return num_elems * sizeof(vhpiPhysT);
+
+         value_p->numElems = num_elems;
+
+#define READ_PHYSV(type) do {                                           \
+            const type *p = ((const type *)value) + offset;             \
+            for (int i = 0; i < value_p->numElems; i++)                 \
+               value_p->value.physs[i] = vhpi_phys_from_native(*p++);   \
+         } while (0)
+
+         FOR_ALL_SIZES(size, READ_PHYSV);
          return 0;
       }
 

--- a/src/vhpi/vhpi-util.c
+++ b/src/vhpi/vhpi-util.c
@@ -290,6 +290,9 @@ vhpiFormatT vhpi_format_for_type(type_t type, const char **map_str)
    case T_REAL:
       return vhpiRealVal;
 
+   case T_PHYSICAL:
+      return vhpiPhysVal;
+
    case T_ARRAY:
       {
          type_t elem = type_base_recur(type_elem(base));
@@ -320,6 +323,9 @@ vhpiFormatT vhpi_format_for_type(type_t type, const char **map_str)
 
          case T_INTEGER:
             return vhpiIntVecVal;
+
+         case T_PHYSICAL:
+            return vhpiPhysVecVal;
 
          default:
             break;

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -1261,3 +1261,5 @@ issue1410       shell
 issue1405       normal,2008
 issue1420       wave,dump-arrays,2008
 vlog31          verilog
+vhpi18          vhpi,2008
+

--- a/test/regress/vhpi18.vhd
+++ b/test/regress/vhpi18.vhd
@@ -1,0 +1,38 @@
+entity vhpi18 is
+end entity;
+
+architecture sim of vhpi18 is
+  type frequency_t is range 0 to 1000000000000000 units
+    Hz;
+    kHz = 1000 Hz;
+    MHz = 1000 kHz;
+    GHz = 1000 MHz;
+    THz = 1000 GHz;
+  end units;
+
+  type voltage_t is range 0 to 5000 units
+    mV;
+    V = 1000 mV;
+  end units;
+
+  type frequency_vector_t is array (natural range <>) of frequency_t;
+  type voltage_vector_t is array (natural range <>) of voltage_t;
+
+  signal s_freq : frequency_t := 0 Hz;
+  signal s_voltage : voltage_t := 0 mV;
+  signal s_time : time := 0 ns;
+  signal v_freq_arr : frequency_vector_t(0 to 2) := (0 Hz, 0 Hz, 0 Hz);
+  signal v_voltage_arr : voltage_vector_t(0 to 2) := (0 mV, 0 mV, 0 mV);
+  signal v_time_arr : time_vector(0 to 2) := (0 ns, 0 ns, 0 ns);
+begin
+  stim : process
+  begin
+    s_freq <= 100 GHz;
+    s_voltage <= 3300 mV;
+    s_time <= 100 ns;
+    v_freq_arr <= (50 MHz, 100 MHz, 150 MHz);
+    v_voltage_arr <= (1500 mV, 3300 mV, 5000 mV);
+    v_time_arr <= (10 ns, 50 ns, 100 ns);
+    wait;
+  end process;
+end architecture;

--- a/test/vhpi/Makemodule.am
+++ b/test/vhpi/Makemodule.am
@@ -34,7 +34,8 @@ lib_vhpi_test_so_SOURCES = \
 	test/vhpi/issue1240.c \
 	test/vhpi/vhpi16.c \
 	test/vhpi/issue1301.c \
-	test/vhpi/vhpi17.c
+	test/vhpi/vhpi17.c \
+	test/vhpi/vhpi18.c
 
 lib_vhpi_test_so_CFLAGS  = $(SHLIB_CFLAGS) -I$(top_srcdir)/src/vhpi $(AM_CFLAGS)
 lib_vhpi_test_so_LDFLAGS = $(SHLIB_LDFLAGS) $(AM_LDFLAGS)

--- a/test/vhpi/vhpi18.c
+++ b/test/vhpi/vhpi18.c
@@ -1,0 +1,77 @@
+#include "vhpi_test.h"
+
+#include <string.h>
+#include <stdlib.h>
+
+static int64_t phys_to_i64(vhpiPhysT phys)
+{
+   return ((uint64_t)phys.high) << 32 | phys.low;
+}
+
+static void check_phys_scalar(vhpiHandleT parent, const char *name,
+                              int64_t expect)
+{
+   vhpiHandleT sig = VHPI_CHECK(vhpi_handle_by_name(name, parent));
+   vhpi_printf("%s handle %p", name, sig);
+
+   vhpiValueT val = { .format = vhpiObjTypeVal };
+   VHPI_CHECK(vhpi_get_value(sig, &val));
+   fail_unless(val.format == vhpiPhysVal);
+   fail_unless(phys_to_i64(val.value.phys) == expect);
+   fail_unless(val.numElems == 1);
+
+   vhpi_release_handle(sig);
+}
+
+static void check_phys_array(vhpiHandleT parent, const char *name,
+                             const int64_t *expect, size_t len)
+{
+   vhpiHandleT sig = VHPI_CHECK(vhpi_handle_by_name(name, parent));
+   vhpi_printf("%s handle %p", name, sig);
+
+   vhpiValueT val = {
+      .format = vhpiPhysVecVal,
+      .bufSize = len * sizeof(vhpiPhysT),
+   };
+   val.value.physs = malloc(len * sizeof(vhpiPhysT));
+
+   VHPI_CHECK(vhpi_get_value(sig, &val));
+   fail_unless(val.format == vhpiPhysVecVal);
+   fail_unless(val.numElems == len);
+
+   for (size_t i = 0; i < len; i++)
+      fail_unless(phys_to_i64(val.value.physs[i]) == expect[i]);
+
+   free(val.value.physs);
+   vhpi_release_handle(sig);
+}
+
+static void end_of_sim(const vhpiCbDataT *cb_data)
+{
+   vhpiHandleT root = VHPI_CHECK(vhpi_handle(vhpiRootInst, NULL));
+   fail_if(root == NULL);
+   vhpi_printf("root handle %p", root);
+
+   check_phys_scalar(root, "s_freq", INT64_C(100000000000));
+   check_phys_scalar(root, "s_voltage", INT64_C(3300));
+   check_phys_scalar(root, "s_time", INT64_C(100000000));
+
+   const int64_t expect_freq[] = { 50000000, 100000000, 150000000 };
+   const int64_t expect_voltage[] = { 1500, 3300, 5000 };
+   const int64_t expect_time[] = { 10000000, 50000000, 100000000 };
+
+   check_phys_array(root, "v_freq_arr", expect_freq, 3);
+   check_phys_array(root, "v_voltage_arr", expect_voltage, 3);
+   check_phys_array(root, "v_time_arr", expect_time, 3);
+
+   vhpi_release_handle(root);
+}
+
+void vhpi18_startup(void)
+{
+   vhpiCbDataT cb_data = {
+      .reason = vhpiCbEndOfSimulation,
+      .cb_rtn = end_of_sim,
+   };
+   VHPI_CHECK(vhpi_register_cb(&cb_data, 0));
+}

--- a/test/vhpi/vhpi_test.c
+++ b/test/vhpi/vhpi_test.c
@@ -58,6 +58,7 @@ static const vhpi_test_t tests[] = {
    { "vhpi16",    vhpi16_startup },
    { "issue1301", NULL },
    { "vhpi17",    vhpi17_startup },
+   { "vhpi18",    vhpi18_startup },
    { NULL,        NULL },
 };
 

--- a/test/vhpi/vhpi_test.h
+++ b/test/vhpi/vhpi_test.h
@@ -57,6 +57,7 @@ void vhpi14_startup(void);
 void vhpi15_startup(void);
 void vhpi16_startup(void);
 void vhpi17_startup(void);
+void vhpi18_startup(void);
 void issue744_startup(void);
 void issue762_startup(void);
 void issue978_startup(void);


### PR DESCRIPTION
Related to https://github.com/nickg/rust-vhpi/pull/4

Using the file from the PR above that includes physical values, this works for two out of three cases. `voltage_t` gives a correct value for the initialized scalar, but not from then on, so there is something I am missing here... I cannot really make sense of the numbers either. Printout below the VHDL code.

(There is a clear risk that I am not really understanding the structure here and it just happens to work for the other two units.)

``` vhdl
library ieee;
use ieee.std_logic_1164.all;

entity tb_physical_time is
end entity;

architecture sim of tb_physical_time is
  type frequency_t is range 0 to 1000000000000000 units
    Hz;
    kHz = 1000 Hz;
    MHz = 1000 kHz;
    GHz = 1000 MHz;
    THz = 1000 GHz;
  end units;

  type voltage_t is range 0 to 5000 units
    mV;
    V = 1000 mV;
  end units;

  type frequency_vector_t is array (natural range <>) of frequency_t;
  type voltage_vector_t is array (natural range <>) of voltage_t;

  signal s_freq : frequency_t := 0 Hz;
  signal s_voltage : voltage_t := 0 mV;
  signal s_time : time := 0 ns;
  signal v_freq_arr : frequency_vector_t(0 to 2) := (0 Hz, 0 Hz, 0 Hz);
  signal v_voltage_arr : voltage_vector_t(0 to 2) := (0 mV, 0 mV, 0 mV);
  signal v_time_arr : time_vector(0 to 2) := (0 ns, 0 ns, 0 ns);
begin
  stim : process
  begin
    s_freq <= 100 MHz;
    s_voltage <= 3300 mV;
    s_time <= 100 ns;
    v_freq_arr <= (50 MHz, 100 MHz, 150 MHz);
    v_voltage_arr <= (1500 mV, 3300 mV, 5000 mV);
    v_time_arr <= (10 ns, 50 ns, 100 ns);
    wait for 10 ns;

    s_freq <= 500 MHz;
    s_voltage <= 2000 mV;
    s_time <= 250 ns;
    v_freq_arr <= (100 MHz, 250 MHz, 500 MHz);
    v_voltage_arr <= (2000 mV, 3300 mV, 3700 mV);
    v_time_arr <= (25 ns, 75 ns, 150 ns);
    wait for 10 ns;

    s_freq <= 100 THz;
    s_voltage <= 1800 mV;
    s_time <= 500 ns;
    v_freq_arr <= (250 MHz, 500 MHz, 1 GHz);
    v_voltage_arr <= (1200 mV, 2000 mV, 3300 mV);
    v_time_arr <= (50 ns, 100 ns, 200 ns);
    wait for 10 ns;

    wait;
  end process;
end architecture;
```

```
** Note: 0ms+1: value change :TB_PHYSICAL_TIME:S_FREQ => 100000000
** Note: 0ms+1: value change :TB_PHYSICAL_TIME:S_VOLTAGE => 3300
** Note: 0ms+1: value change :TB_PHYSICAL_TIME:S_TIME => 100000000
** Note: 0ms+1: element 0 of array V_FREQ_ARR is of type FREQUENCY_T with value 50000000
** Note: 0ms+1: element 1 of array V_FREQ_ARR is of type FREQUENCY_T with value 100000000
** Note: 0ms+1: element 2 of array V_FREQ_ARR is of type FREQUENCY_T with value 150000000
** Note: 0ms+1: element 0 of array V_VOLTAGE_ARR is of type VOLTAGE_T with value 21475052750300
** Note: 0ms+1: element 1 of array V_VOLTAGE_ARR is of type VOLTAGE_T with value 0
** Note: 0ms+1: element 2 of array V_VOLTAGE_ARR is of type VOLTAGE_T with value 0
** Note: 0ms+1: element 0 of array V_TIME_ARR is of type TIME with value 10000000
** Note: 0ms+1: element 1 of array V_TIME_ARR is of type TIME with value 50000000
** Note: 0ms+1: element 2 of array V_TIME_ARR is of type TIME with value 100000000
** Note: 10ns+1: value change :TB_PHYSICAL_TIME:S_FREQ => 500000000
** Note: 10ns+1: value change :TB_PHYSICAL_TIME:S_VOLTAGE => 216270800
** Note: 10ns+1: value change :TB_PHYSICAL_TIME:S_TIME => 250000000
** Note: 10ns+1: element 0 of array V_FREQ_ARR is of type FREQUENCY_T with value 100000000
** Note: 10ns+1: element 1 of array V_FREQ_ARR is of type FREQUENCY_T with value 250000000
** Note: 10ns+1: element 2 of array V_FREQ_ARR is of type FREQUENCY_T with value 500000000
** Note: 10ns+1: element 0 of array V_VOLTAGE_ARR is of type VOLTAGE_T with value 422228356661250000
** Note: 10ns+1: element 1 of array V_VOLTAGE_ARR is of type VOLTAGE_T with value 327683300
** Note: 10ns+1: element 2 of array V_VOLTAGE_ARR is of type VOLTAGE_T with value 0
** Note: 10ns+1: element 0 of array V_TIME_ARR is of type TIME with value 25000000
** Note: 10ns+1: element 1 of array V_TIME_ARR is of type TIME with value 75000000
** Note: 10ns+1: element 2 of array V_TIME_ARR is of type TIME with value 150000000
** Note: 20ns+1: value change :TB_PHYSICAL_TIME:S_FREQ => 100000000000000
** Note: 20ns+1: value change :TB_PHYSICAL_TIME:S_VOLTAGE => 131073800
** Note: 20ns+1: value change :TB_PHYSICAL_TIME:S_TIME => 500000000
** Note: 20ns+1: element 0 of array V_FREQ_ARR is of type FREQUENCY_T with value 250000000
** Note: 20ns+1: element 1 of array V_FREQ_ARR is of type FREQUENCY_T with value 500000000
** Note: 20ns+1: element 2 of array V_FREQ_ARR is of type FREQUENCY_T with value 1000000000
** Note: 20ns+1: element 0 of array V_VOLTAGE_ARR is of type VOLTAGE_T with value 562964126944462000
** Note: 20ns+1: element 1 of array V_VOLTAGE_ARR is of type VOLTAGE_T with value 242486500
** Note: 20ns+1: element 2 of array V_VOLTAGE_ARR is of type VOLTAGE_T with value 0
** Note: 20ns+1: element 0 of array V_TIME_ARR is of type TIME with value 50000000
** Note: 20ns+1: element 1 of array V_TIME_ARR is of type TIME with value 100000000
** Note: 20ns+1: element 2 of array V_TIME_ARR is of type TIME with value 200000000
```