### PR TITLE
Remove redundant assignment

### DIFF
--- a/src/vhpi/vhpi-model.c
+++ b/src/vhpi/vhpi-model.c
@@ -1015,7 +1015,7 @@ static void *new_object(size_t size, vhpiClassKindT class)
    return obj;
 }
 
-static void *recyle_object(size_t size, vhpiClassKindT class)
+static void *recycle_object(size_t size, vhpiClassKindT class)
 {
    vhpi_context_t *c = vhpi_context();
 
@@ -2139,7 +2139,7 @@ vhpiHandleT vhpi_register_cb(vhpiCbDataT *cb_data_p, int32_t flags)
    case vhpiCbStartOfElaboration:
    case vhpiCbEndOfElaboration:
       {
-         c_callback *cb = recyle_object(sizeof(c_callback), vhpiCallbackK);
+         c_callback *cb = recycle_object(sizeof(c_callback), vhpiCallbackK);
          init_callback(cb, cb_data_p, flags);
 
          if (cb->data.obj != NULL) {
@@ -2176,7 +2176,7 @@ vhpiHandleT vhpi_register_cb(vhpiCbDataT *cb_data_p, int32_t flags)
             return NULL;
          }
 
-         c_callback *cb = recyle_object(sizeof(c_callback), vhpiCallbackK);
+         c_callback *cb = recycle_object(sizeof(c_callback), vhpiCallbackK);
          init_callback(cb, cb_data_p, flags);
 
          const uint64_t now = model_now(m, NULL);
@@ -2237,7 +2237,7 @@ vhpiHandleT vhpi_register_cb(vhpiCbDataT *cb_data_p, int32_t flags)
             return NULL;
          }
 
-         c_callback *cb = recyle_object(sizeof(c_callback), vhpiCallbackK);
+         c_callback *cb = recycle_object(sizeof(c_callback), vhpiCallbackK);
          init_callback(cb, cb_data_p, flags);
 
          // LRM 08 section 23.29: [..] if the obj member of the callback
@@ -2672,7 +2672,7 @@ vhpiHandleT vhpi_iterator(vhpiOneToManyT type, vhpiHandleT handle)
    if (handle != NULL && (obj = from_handle(handle)) == NULL)
       return NULL;
 
-   c_iterator *it = recyle_object(sizeof(c_iterator), vhpiIteratorK);
+   c_iterator *it = recycle_object(sizeof(c_iterator), vhpiIteratorK);
    if (!init_iterator(it, type, obj)) {
       vhpi_error(vhpiError, obj ? &(obj->loc) : NULL,
                  "relation %s not supported for handle %s",

--- a/src/vpi/vpi-model.c
+++ b/src/vpi/vpi-model.c
@@ -455,7 +455,7 @@ static void *new_object(size_t size, PLI_INT32 type)
    return obj;
 }
 
-static void *recyle_object(size_t size, PLI_INT32 type)
+static void *recycle_object(size_t size, PLI_INT32 type)
 {
    vpi_context_t *c = vpi_context();
 
@@ -900,7 +900,7 @@ vpiHandle vpi_register_systf(p_vpi_systf_data systf_data_p)
 
    assert(systf_data_p->tfname[0] == '$');  // TODO: add test
 
-   c_callback *cb = recyle_object(sizeof(c_callback), vpiCallback);
+   c_callback *cb = recycle_object(sizeof(c_callback), vpiCallback);
    cb->systf = *systf_data_p;
    cb->name  = ident_new(systf_data_p->tfname);
 
@@ -1007,7 +1007,7 @@ vpiHandle vpi_iterate(PLI_INT32 type, vpiHandle refHandle)
    if (refHandle != NULL && (obj = from_handle(refHandle)) == NULL)
       return NULL;
 
-   c_iterator *it = recyle_object(sizeof(c_iterator), vpiIterator);
+   c_iterator *it = recycle_object(sizeof(c_iterator), vpiIterator);
    if (!init_iterator(it, type, obj)) {
       vpi_error(vpiError, obj ? &(obj->loc) : NULL,
                 "relation %s not supported for handle %s",


### PR DESCRIPTION
Stumbled upon this redundant code while trying to understand VHPI a bit better. No need to assign `value_p->format`.

I was considering if the check should have been `tp->format`, but that will lead to failures for the vhpi10 and vhpi14 checks.

One can consider adding the inverted version of the condition to the next check, but it quite long and hard to understand, so while a bit unintuitive to maybe have an empty statement in the if-branch, I thought this was still better (also kept the ; on a separate line, easier to catch but not sure what is common). But are happy to change if you prefer
```C
   else if (!(value_p->format == vhpiBinStrVal && td->map_str != NULL)
            && value_p->format != td->format
            && !vhpi_scalar_fits_format(value_p->format, size))
```
or
```C
   else if ((value_p->format != vhpiBinStrVal || td->map_str == NULL)
            && value_p->format != td->format
            && !vhpi_scalar_fits_format(value_p->format, size))
```

(After playing around a bit with godbolt.org, it seems like this is probably optimized away anyway, but caused me a bit of confusion if nothing else...)

And a minor typo in a function name.