### PR TITLE
Implement fast paths for mul JIT intrinsics

### DIFF
--- a/src/jit/jit-intrin.c
+++ b/src/jit/jit-intrin.c
@@ -541,6 +541,33 @@ static inline void __spread_bits_8(void *vec, uint8_t packed)
    unaligned_store(vec + 4, spread_nibble[(packed >> 0) & 0xf], uint32_t);
 }
 
+static inline uint64_t __pack_to_u64(const uint8_t *arr, int size)
+{
+   uint64_t val = 0;
+   int i = 0;
+   for (; i + 8 <= size; i += 8)
+      val = (val << 8) | __pack_low_bits(arr + i);
+   for (; i < size; i++)
+      val = (val << 1) | (arr[i] & 1);
+   return val;
+}
+
+__attribute__((always_inline))
+static inline void __unpack_from_u64(uint64_t val,
+                                     uint8_t *result, int size)
+{
+   int pos = size;
+   while (pos >= 8) {
+      pos -= 8;
+      __spread_bits_8(result + pos, val & 0xff);
+      val >>= 8;
+   }
+   for (int i = pos - 1; i >= 0; i--) {
+      result[i] = (val & 1) | 0x02;
+      val >>= 1;
+   }
+}
+
 __attribute__((always_inline))
 static inline void __ieee_packed_add_scalar(const uint8_t *left,
                                             const uint8_t *right, int size,
@@ -988,6 +1015,11 @@ static void ieee_mul_unsigned(jit_func_t *func, jit_anchor_t *anchor,
 
       if (left[0] == _X || right[0] == _X)
          memset(result, _X, size);
+      else if (size <= 64) {
+         uint64_t lval = __pack_to_u64(left, lsize);
+         uint64_t rval = __pack_to_u64(right, rsize);
+         __unpack_from_u64(lval * rval, result, size);
+      }
       else
          __mul_unsigned(left, lsize, right, rsize, tlab, result);
 
@@ -1023,6 +1055,16 @@ static void ieee_mul_signed(jit_func_t *func, jit_anchor_t *anchor,
 
       if (left[0] == _X || right[0] == _X)
          memset(result, _X, size);
+      else if (size <= 64) {
+         uint64_t lval = __pack_to_u64(left, lsize);
+         uint64_t rval = __pack_to_u64(right, rsize);
+         if (lsize < 64 && (left[0] & 1))
+            lval |= ~UINT64_C(0) << lsize;
+         if (rsize < 64 && (right[0] & 1))
+            rval |= ~UINT64_C(0) << rsize;
+         __unpack_from_u64((int64_t)lval * (int64_t)rval,
+                           result, size);
+      }
       else
          __mul_signed(left, lsize, right, rsize, tlab, result);
 


### PR DESCRIPTION
The functions of numeric_std run faster if we implement fast paths for computations if the results are less than or equal to 64 bits.

An FIR filter in a typical DSP scenario (100 taps, 25 and 18 bits operands for multiplication) runs 3.2x faster with the changes, most of it (3.1x) stemming from the multiplication fast path, avoiding the approach to realize the multiplication with additions only.

With packing to 64-bits, a plain simulation with 32-bit additions runs 13% faster, 48-bit additions still give a 7% gain. With 6 bits operands, addition speed remains the same.