### PR TITLE
Collect code coverage for package declarations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 - Local variables are now ignored in Verilog `@(*)` sensitivity lists
   (#1480).
 - PSL `next_a` is now supported with simple expressions.
+- Code coverage can now be collected for package declarations, opted
+  in via the new `+package` directive in a coverage specification
+  file (#1007).
 - Several other minor bugs were resolved (#1506, #1516, #1522, #1529).
 
 ## Version 1.20.1 - 2026-04-22

--- a/nvc.1
+++ b/nvc.1
@@ -983,12 +983,30 @@ NVC can collect code coverage only on part of the simulated design.
 When coverage specification file is passed during elaboration time,
 NVC collects code coverage only as specified in this file. If
 the file is ommited, NVC collects code coverage on whole design.
+Packages are an exception: code coverage is never collected on
+packages by default and they must be explicitly opted in via a
+.Ql +package
+or
+.Ql +hierarchy
+directive in the coverage specification file.  Packages from the
+standard libraries
+.Pq Cm STD , Cm IEEE , Cm NVC
+are never instrumented even when a spec rule would otherwise match
+them.
 The format of commands in the coverage specification file is as follows:
 .Bd -literal -offset indent
 (+|-)block <ENTITY_NAME>
 (+|-)hierarchy <HIERARCHY>
+(+|-)package <PATTERN>
 (+|-)fsm-type <TYPE>
 .Ed
+.Pp
+The argument to
+.Ql package
+is a glob pattern matched against the package name (the last
+component of the package's qualified identifier).  Use
+.Ql *
+to match zero or more characters within a single name component.
 .Pp
 An example of coverage specification file is following:
 .Bd -literal -offset indent
@@ -1005,6 +1023,14 @@ An example of coverage specification file is following:
 
 # Example how to disable collecting code coverage on entity or block:
 -block clock_gate_model
+
+# Example how to enable collecting code coverage on every package
+# whose name ends with '_pkg' (packages are not collected by default):
++package *_PKG
+
+# Example how to exclude a package by name, overriding any +package
+# rule that would otherwise match it:
+-package LEGACY_PKG
 
 # Example how to force all signals of enum types named 'T_FSM_STATE'
 # to be recognized as FSM
@@ -1027,7 +1053,16 @@ disabled hierarchy / block (
 .Ql -
 ) has priority over enabled hierarchy / block (
 .Ql +
-).
+).  For packages, a
+.Ql \-package
+match overrides any
+.Ql +package
+or
+.Ql +hierarchy
+rule, and a
+.Ql \-hierarchy
+match overrides
+.Ql +package .
 .Ss Exclude file
 NVC can exclude any coverage bins when generating code coverage report.
 When a coverage bin is excluded, it is counted as "Covered" in the

--- a/src/cov/cov-api.h
+++ b/src/cov/cov-api.h
@@ -262,6 +262,7 @@ void cover_export_xml(cover_data_t *data, FILE *f, const char *relative);
 // Interface to code generator
 //
 
+cover_scope_t *cover_get_root_scope(cover_data_t *db);
 cover_scope_t *cover_create_block(cover_data_t *db, ident_t qual,
                                   cover_scope_t *parent, tree_t inst,
                                   tree_t unit);
@@ -274,5 +275,7 @@ cover_item_t *cover_add_items_for(cover_data_t *data, cover_scope_t *cscope,
 
 bool cover_compatible_spec(cover_data_t *db, const cover_scope_t *a,
                            const cover_scope_t *b);
+
+bool cover_should_emit_package(cover_data_t *db, tree_t pack);
 
 #endif   // _COV_API_H

--- a/src/cov/cov-data.c
+++ b/src/cov/cov-data.c
@@ -876,6 +876,11 @@ bool cover_enabled(cover_data_t *data, cover_mask_t mask)
    return data != NULL && (data->mask & mask);
 }
 
+cover_scope_t *cover_get_root_scope(cover_data_t *db)
+{
+   return db != NULL ? db->root_scope : NULL;
+}
+
 cover_scope_t *cover_create_block(cover_data_t *db, ident_t qual,
                                   cover_scope_t *parent, tree_t inst,
                                   tree_t unit)
@@ -933,7 +938,7 @@ cover_scope_t *cover_create_scope(cover_data_t *db, cover_scope_t *parent,
 
    assert(parent != NULL);
    assert(db->root_scope != NULL);
-   assert(!is_design_unit(t));
+   assert(!is_design_unit(t) || is_package(t));
 
    cover_scope_t *s = pool_calloc(db->pool, sizeof(cover_scope_t));
 
@@ -971,7 +976,16 @@ cover_scope_t *cover_create_scope(cover_data_t *db, cover_scope_t *parent,
    s->block  = parent->block;
    s->name   = name;
    s->loc    = *tree_loc(t);
-   s->hier   = ident_prefix(parent->hier, s->name, '.');
+
+   // Top-level packages already carry their library in tree_ident
+   // (e.g. LIB1.PKG1). Storing the hierarchy as
+   // <work-lib>.<pkg-lib>.<pkg-name> would be misleading, so use the
+   // package ident directly as the hier path.
+   if (s->kind == CSCOPE_PACKAGE && parent == db->root_scope)
+      s->hier = s->name;
+   else
+      s->hier = ident_prefix(parent->hier, s->name, '.');
+
    s->emit   = cover_should_emit_scope(db, s);
 
    if (s->sig_pos == 0)

--- a/src/cov/cov-exclude.c
+++ b/src/cov/cov-exclude.c
@@ -17,6 +17,7 @@
 
 #include "util.h"
 #include "array.h"
+#include "common.h"
 #include "cov/cov-api.h"
 #include "cov/cov-data.h"
 #include "ident.h"
@@ -29,11 +30,21 @@
 
 typedef struct _excl_children excl_children_t;
 typedef struct _excl_trie excl_trie_t;
+typedef struct _excl_glob excl_glob_t;
+
+struct _excl_glob {
+   char       *glob;
+   bool        include;
+   excl_glob_t *next;
+};
 
 typedef struct _cover_spec {
    excl_trie_t *hier_trie;
+   // TODO: convert block_trie and fsm_trie to glob lists so users can write
+   // e.g. "+fsm_type *_fsm_t" matching across name components.
    excl_trie_t *block_trie;
    excl_trie_t *fsm_trie;
+   excl_glob_t *pkg_globs;
 } cover_spec_t;
 
 typedef enum {
@@ -136,17 +147,28 @@ static excl_trie_t *excl_trie_search(excl_trie_t *et, ident_t id)
    return NULL;
 }
 
-static excl_trie_t *excl_trie_for_scope(excl_trie_t *root,
-                                        const cover_scope_t *cs)
+static excl_trie_t *excl_trie_for_hier(excl_trie_t *root, ident_t hier)
 {
-   if (cs == NULL)
+   if (hier == NULL)
       return root;
 
-   excl_trie_t *parent = excl_trie_for_scope(root, cs->parent);
-   if (parent == NULL)
-      return NULL;
+   ident_t prefix = ident_runtil(hier, '.');
+   excl_trie_t *parent;
+   ident_t leaf;
 
-   excl_trie_t *et = excl_trie_search(parent, ident_rfrom(cs->hier, '.'));
+   if (prefix == hier) {
+      // Single-segment hier
+      parent = root;
+      leaf = hier;
+   }
+   else {
+      parent = excl_trie_for_hier(root, prefix);
+      if (parent == NULL)
+         return NULL;
+      leaf = ident_rfrom(hier, '.');
+   }
+
+   excl_trie_t *et = excl_trie_search(parent, leaf);
    if (et != NULL)
       return et;
 
@@ -154,6 +176,14 @@ static excl_trie_t *excl_trie_for_scope(excl_trie_t *root,
       return parent;
 
    return NULL;
+}
+
+static excl_trie_t *excl_trie_for_scope(excl_trie_t *root,
+                                        const cover_scope_t *cs)
+{
+   if (cs == NULL)
+      return root;
+   return excl_trie_for_hier(root, cs->hier);
 }
 
 static void excl_trie_print(excl_trie_t *et, int indent)
@@ -508,26 +538,41 @@ void cover_load_spec_file(cover_data_t *db, const char *path)
 
       tok++;
 
-      excl_trie_t *root;
-      if (strcmp(tok, "hierarchy") == 0)
+      const char *kind = tok;
+      excl_trie_t *root = NULL;
+      if (strcmp(kind, "hierarchy") == 0)
          root = spec->hier_trie;
-      else if (strcmp(tok, "block") == 0)
+      else if (strcmp(kind, "block") == 0)
          root = spec->block_trie;
-      else if (!strcmp(tok, "fsm_type"))
+      else if (strcmp(kind, "fsm_type") == 0)
          root = spec->fsm_trie;
+      else if (strcmp(kind, "package") != 0) {
+         error_at(&loc, "invalid command $bold$%s$$", kind);
+         continue;
+      }
+
+      char *arg = strtok(NULL, delim);
+      if (arg == NULL) {
+         error_at(&loc, "%s name missing", kind);
+         continue;
+      }
+
+      if (root != NULL) {
+         excl_trie_t *et = excl_trie_get(db, root, arg);
+         et->action = include ? ACTION_INCLUDE : ACTION_EXCLUDE;
+      }
       else {
-         error_at(&loc, "invalid command $bold$%s$$", tok);
-         continue;
+         // Package patterns are stored as a linked list of globs since
+         // they need glob matching against the package's name.
+         excl_glob_t *p = pool_calloc(db->pool, sizeof(excl_glob_t));
+         const size_t len = strlen(arg) + 1;
+         p->glob = pool_calloc(db->pool, len);
+         memcpy(p->glob, arg, len);
+         to_upper_str(p->glob);
+         p->include = include;
+         p->next = spec->pkg_globs;
+         spec->pkg_globs = p;
       }
-
-      char *hier = strtok(NULL, delim);
-      if (!hier) {
-         error_at(&loc, "%s name missing", tok);
-         continue;
-      }
-
-      excl_trie_t *et = excl_trie_get(db, root, hier);
-      et->action = include ? ACTION_INCLUDE : ACTION_EXCLUDE;
 
       if ((tok = strtok(NULL, delim)) != NULL)
          error_at(&loc, "unexpected '%s' after coverage specification "
@@ -553,6 +598,50 @@ void cover_load_spec_file(cover_data_t *db, const char *path)
    }
 }
 
+static bool cover_match_package(cover_spec_t *spec, ident_t pkg_name,
+                                ident_t pkg_hier)
+{
+   // -package always overrides anything else.
+   for (excl_glob_t *p = spec->pkg_globs; p != NULL; p = p->next) {
+      if (!p->include && ident_glob(pkg_name, p->glob, strlen(p->glob)))
+         return false;
+   }
+
+   excl_trie_t *hier_et = excl_trie_for_hier(spec->hier_trie, pkg_hier);
+   if (hier_et != NULL && hier_et->action == ACTION_EXCLUDE)
+      return false;
+
+   for (excl_glob_t *p = spec->pkg_globs; p != NULL; p = p->next) {
+      if (p->include && ident_glob(pkg_name, p->glob, strlen(p->glob)))
+         return true;
+   }
+
+   if (hier_et != NULL && hier_et->action == ACTION_INCLUDE)
+      return true;
+
+   return false;
+}
+
+bool cover_should_emit_package(cover_data_t *db, tree_t pack)
+{
+   // Packages are not collected by default; the user must opt-in via a
+   // coverage spec file with +package or +hierarchy directives.
+   if (db == NULL || db->spec == NULL)
+      return false;
+
+   // Standard libraries are never instrumented even when the spec would
+   // match them: several IEEE subprograms are replaced by intrinsics so
+   // coverage data would not be representative anyway.
+   ident_t pack_hier = tree_ident(pack);
+   ident_t pack_lib = ident_until(pack_hier, '.');
+   if (pack_lib == well_known(W_STD) || pack_lib == well_known(W_IEEE)
+       || pack_lib == well_known(W_NVC))
+      return false;
+
+   ident_t pack_name = ident_rfrom(pack_hier, '.');
+   return cover_match_package(db->spec, pack_name, pack_hier);
+}
+
 bool cover_should_emit_scope(cover_data_t *db, cover_scope_t *cs)
 {
    if (db->spec == NULL)
@@ -563,6 +652,9 @@ bool cover_should_emit_scope(cover_data_t *db, cover_scope_t *cs)
 
    if (blk == NULL)
       return true;
+
+   if (blk->kind == CSCOPE_PACKAGE)
+      return cover_match_package(db->spec, blk->block_name, blk->hier);
 
    ident_t ename = ident_until(blk->block_name, '-');
 

--- a/src/cov/cov-html.c
+++ b/src/cov/cov-html.c
@@ -1004,7 +1004,7 @@ static void cover_print_summary_table_row(FILE *f, cover_data_t *data, const rpt
 }
 
 static void cover_print_nav_hier_node(html_gen_t *g, FILE *f, cover_scope_t *s,
-                                      cover_scope_t *sel)
+                                      cover_scope_t *sel, ident_t display)
 {
    const char *link = rpt_get_hier(g->rpt, s)->name_hash;
 
@@ -1021,7 +1021,7 @@ static void cover_print_nav_hier_node(html_gen_t *g, FILE *f, cover_scope_t *s,
    fprintf(f, "<a href=\"%s.html\"", link);
    if (s == sel)
       fprintf(f, " class=\"nav-sel\"");
-   fprintf(f, ">%s</a>\n", istr(s->name));
+   fprintf(f, ">%s</a>\n", istr(display != NULL ? display : s->name));
 
    if (!leaf) {
       fprintf(f, "</summary>\n");
@@ -1029,7 +1029,7 @@ static void cover_print_nav_hier_node(html_gen_t *g, FILE *f, cover_scope_t *s,
       for (int i = 0; i < s->children.count; i++) {
          cover_scope_t *c = s->children.items[i];
          if (cover_is_hier(c))
-            cover_print_nav_hier_node(g, f, c, sel);
+            cover_print_nav_hier_node(g, f, c, sel, NULL);
       }
 
       fprintf(f, "</details>\n");
@@ -1042,12 +1042,43 @@ static void cover_print_hier_nav_tree(html_gen_t *g, FILE *f, cover_scope_t *s)
 
    fprintf(f, "<nav style=\"clear: left\">\n");
    fprintf(f, "<details open>\n");
-   fprintf(f, "<summary><a href=\"../index.html\">%s</a></summary>\n",
-           istr(g->data->root_scope->name));
+   fprintf(f, "<summary><a href=\"../index.html\">root</a></summary>\n");
 
-   for (int i = 0; i < g->data->root_scope->children.count; i++) {
-      cover_scope_t *c = g->data->root_scope->children.items[i];
-      cover_print_nav_hier_node(g, f, c, s);
+   // Group top-level scopes by their library so that packages compiled
+   // into a non-work library appear under their own library node rather
+   // than being lumped together under the elaboration work library.
+   cover_scope_t *root = g->data->root_scope;
+   const int nchildren = root->children.count;
+   for (int i = 0; i < nchildren; i++) {
+      cover_scope_t *c = root->children.items[i];
+      ident_t lib = ident_until(c->hier, '.');
+
+      bool already_emitted = false;
+      for (int j = 0; j < i && !already_emitted; j++) {
+         cover_scope_t *p = root->children.items[j];
+         already_emitted = (ident_until(p->hier, '.') == lib);
+      }
+      if (already_emitted)
+         continue;
+
+      // The library node opens when the selected scope's own hier
+      // belongs to this library; root_scope itself is intentionally
+      // skipped so its work-lib hier does not force an unrelated group
+      // open when viewing a package from a different library.
+      const bool open =
+         s != NULL && s->hier != NULL && ident_until(s->hier, '.') == lib;
+
+      fprintf(f, "<details%s>\n", open ? " open" : "");
+      fprintf(f, "<summary>%s</summary>\n", istr(lib));
+
+      for (int j = i; j < nchildren; j++) {
+         cover_scope_t *cc = root->children.items[j];
+         if (ident_until(cc->hier, '.') != lib)
+            continue;
+         cover_print_nav_hier_node(g, f, cc, s, ident_from(cc->hier, '.'));
+      }
+
+      fprintf(f, "</details>\n");
    }
 
    fprintf(f, "</details>\n");

--- a/src/elab.c
+++ b/src/elab.c
@@ -2860,6 +2860,8 @@ static void elab_print_stats(const elab_ctx_t *ctx)
 tree_t elab(object_t *top, jit_t *jit, unit_registry_t *ur, mir_context_t *mc,
             cover_data_t *cover, sdf_file_t *sdf, rt_model_t *m)
 {
+   unit_registry_set_cover(ur, cover);
+
    make_new_arena();
 
    ident_t name = NULL;

--- a/src/lower.c
+++ b/src/lower.c
@@ -8019,7 +8019,7 @@ static void lower_resolution_var(lower_unit_t *lu, tree_t decl, type_t type)
    ident_t name = ident_prefix(prefix, well_known(W_RESOLUTION), '$');
 
    unit_registry_defer(lu->registry, name, lu, emit_function,
-                       lower_resolution_wrapper, NULL, type_to_object(type));
+                       lower_resolution_wrapper, type_to_object(type));
 
    vcode_type_t rtype = lower_func_result_type(type);
 
@@ -8620,7 +8620,7 @@ static void lower_implicit_decl(lower_unit_t *parent, tree_t decl)
          ident_t func = ident_prefix(qual, ident_new("guard"), '$');
 
          unit_registry_defer(parent->registry, func, parent, emit_process,
-                             lower_implicit_guard, NULL, tree_to_object(decl));
+                             lower_implicit_guard, tree_to_object(decl));
 
          vcode_reg_t vdummy = vtype_opaque();
          vcode_reg_t context_reg = emit_context_upref(0);
@@ -8644,7 +8644,7 @@ static void lower_implicit_decl(lower_unit_t *parent, tree_t decl)
          ident_t name = ident_prefix(parent->name, tree_ident(decl), '.');
 
          unit_registry_defer(parent->registry, name, parent, emit_process,
-                             lower_implicit_delayed, NULL, obj);
+                             lower_implicit_delayed, obj);
 
          vcode_reg_t vdummy = vtype_opaque();
          vcode_reg_t context_reg = emit_context_upref(0);
@@ -8667,7 +8667,7 @@ static void lower_implicit_decl(lower_unit_t *parent, tree_t decl)
          ident_t qual = ident_prefix(parent->name, name, '.');
 
          unit_registry_defer(parent->registry, qual, parent, emit_process,
-                             lower_implicit_transaction, NULL, obj);
+                             lower_implicit_transaction, obj);
 
          vcode_reg_t vdummy = vtype_opaque();
          vcode_reg_t context_reg = emit_context_upref(0);
@@ -8691,7 +8691,7 @@ static void lower_implicit_decl(lower_unit_t *parent, tree_t decl)
          ident_t qual = ident_prefix(parent->name, name, '.');
 
          unit_registry_defer(parent->registry, qual, parent, emit_process,
-                             lower_implicit_stable, NULL, obj);
+                             lower_implicit_stable, obj);
 
          vcode_reg_t vdummy = vtype_opaque();
          vcode_reg_t context_reg = emit_context_upref(0);
@@ -9940,41 +9940,41 @@ static void lower_decl(lower_unit_t *lu, tree_t decl, gen_stack_t *gs)
 
             ident_t value = ident_prefix(id, ident_new("value"), '$');
             unit_registry_defer(lu->registry, value, lu, emit_function,
-                                lower_value_helper, NULL, obj);
+                                lower_value_helper, obj);
          }
 
          if (!type_is_homogeneous(type) && can_be_signal(type)) {
             ident_t resolved = ident_prefix(id, ident_new("resolved"), '$');
             unit_registry_defer(lu->registry, resolved, lu, emit_function,
-                                lower_resolved_helper, NULL, obj);
+                                lower_resolved_helper, obj);
 
             ident_t last_value = ident_prefix(id, ident_new("last_value"), '$');
             unit_registry_defer(lu->registry, last_value, lu, emit_function,
-                                lower_last_value_helper, NULL, obj);
+                                lower_last_value_helper, obj);
 
             ident_t last_event = ident_sprintf("%s$last_event", istr(id));
             unit_registry_defer(lu->registry, last_event, lu, emit_function,
-                                lower_last_event_helper, NULL, obj);
+                                lower_last_event_helper, obj);
 
             ident_t last_active = ident_sprintf("%s$last_active", istr(id));
             unit_registry_defer(lu->registry, last_active, lu, emit_function,
-                                lower_last_active_helper, NULL, obj);
+                                lower_last_active_helper, obj);
 
             ident_t driving = ident_prefix(id, ident_new("driving"), '$');
             unit_registry_defer(lu->registry, driving, lu, emit_function,
-                                lower_driving_value_helper, NULL, obj);
+                                lower_driving_value_helper, obj);
          }
 
          if (!lower_trivially_copyable(type)) {
             ident_t copy = ident_prefix(id, ident_new("copy"), '$');
             unit_registry_defer(lu->registry, copy, lu, emit_function,
-                                lower_copy_helper, NULL, obj);
+                                lower_copy_helper, obj);
          }
 
          if (type_is_record(type) && !type_const_bounds(type)) {
             ident_t new = ident_prefix(id, ident_new("new"), '$');
             unit_registry_defer(lu->registry, new, lu, emit_function,
-                                lower_new_helper, NULL, obj);
+                                lower_new_helper, obj);
          }
       }
       break;
@@ -10012,7 +10012,7 @@ static void lower_decl(lower_unit_t *lu, tree_t decl, gen_stack_t *gs)
          object_t *obj = tree_to_object(decl);
 
          unit_registry_defer(lu->registry, name, lu, emit_package,
-                             lower_instantiated_package, lu->cover, obj);
+                             lower_instantiated_package, obj);
 
          vcode_type_t vcontext = vtype_context(name);
          vcode_var_t var = emit_var(vcontext, VCODE_INVALID_STAMP, name, 0);
@@ -10135,7 +10135,7 @@ static void lower_decls(lower_unit_t *lu, tree_t scope, gen_stack_t *gs)
          continue;
       else if (ident_casecmp(tree_ident(d), well_known(W_FOREIGN)))
          unit_registry_defer(lu->registry, tree_ident2(tree_ref(d)), lu,
-                             emit_function, lower_foreign_stub, NULL,
+                             emit_function, lower_foreign_stub,
                              tree_to_object(d));
    }
 
@@ -10158,7 +10158,7 @@ static void lower_decls(lower_unit_t *lu, tree_t scope, gen_stack_t *gs)
             if (!unit_registry_query(lu->registry, mangled))
                unit_registry_defer(lu->registry, mangled, lu,
                                    emit_function, lower_func_body,
-                                   lu->cover, tree_to_object(d));
+                                   tree_to_object(d));
 
             lower_put_vcode_obj(d, 0, lu);   // Dummy value
          }
@@ -10182,7 +10182,7 @@ static void lower_decls(lower_unit_t *lu, tree_t scope, gen_stack_t *gs)
 
             if (!unit_registry_query(lu->registry, mangled))
                unit_registry_defer(lu->registry, mangled, lu,
-                                   emitfn, lower_proc_body, lu->cover,
+                                   emitfn, lower_proc_body,
                                    tree_to_object(d));
 
             lower_put_vcode_obj(d, 0, lu);   // Dummy value
@@ -10191,7 +10191,7 @@ static void lower_decls(lower_unit_t *lu, tree_t scope, gen_stack_t *gs)
       case T_PROT_BODY:
          unit_registry_defer(lu->registry, type_ident(tree_type(d)),
                              lu, emit_protected, lower_protected_body,
-                             lu->cover, tree_to_object(d));
+                             tree_to_object(d));
          lower_put_vcode_obj(d, 0, lu);   // Dummy value
          break;
       case T_FUNC_DECL:
@@ -10214,7 +10214,7 @@ static void lower_decls(lower_unit_t *lu, tree_t scope, gen_stack_t *gs)
                                                   istr(tree_ident(p)));
                  unit_registry_defer(lu->registry, def_func, lu,
                                      emit_function, lower_subprogram_default,
-                                     lu->cover, tree_to_object(p));
+                                     tree_to_object(p));
               }
 
               lower_put_vcode_obj(d, 0, lu);   // Dummy value
@@ -10274,7 +10274,7 @@ static void lower_decls(lower_unit_t *lu, tree_t scope, gen_stack_t *gs)
            default:
               unit_registry_defer(lu->registry, tree_ident2(d),
                                   lu, emit_function, lower_predef,
-                                  lu->cover, tree_to_object(d));
+                                  tree_to_object(d));
            }
         }
         break;
@@ -11216,7 +11216,7 @@ static void lower_converter(lower_unit_t *parent, tree_t map,
    }
 
    unit_registry_defer(parent->registry, name, parent, emit_process,
-                       fn, NULL, tree_to_object(map));
+                       fn, tree_to_object(map));
 
    type_t src_arg_type, dst_arg_type;
    switch (tree_kind(conv)) {
@@ -11495,7 +11495,7 @@ static void lower_inertial_actual(lower_unit_t *parent, tree_t dst, tree_t map)
 
    ident_t qual = ident_prefix(parent->name, tree_ident(inertial), '.');
    unit_registry_defer(parent->registry, qual, parent, emit_process,
-                       lower_inertial_actual_process, parent->cover,
+                       lower_inertial_actual_process,
                        tree_to_object(map));
 
    vcode_reg_t vdummy = vtype_opaque();
@@ -12453,6 +12453,39 @@ static void lower_cache_instance_name(lower_unit_t *lu, attr_kind_t which)
    lower_put_vcode_obj(name, var, lu);
 }
 
+static void lower_cover_setup_package(lower_unit_t *lu, tree_t pack)
+{
+   if (lu->cover == NULL)
+      return;
+
+   cover_scope_t *root = cover_get_root_scope(lu->cover);
+   if (root == NULL)
+      return;
+
+   if (!cover_should_emit_package(lu->cover, pack))
+      return;
+
+   lu->cscope = cover_create_block(lu->cover, lu->name, root, pack, pack);
+
+   vhdl_cover_package(pack, lu->cover, lu->cscope);
+
+   tree_t body = NULL;
+   if (tree_kind(pack) == T_PACKAGE)
+      body = body_of(pack);
+
+   if (body != NULL)
+      vhdl_cover_package(body, lu->cover, lu->cscope);
+
+   vcode_reg_t ptr = emit_get_counters(lu->name);
+
+   vcode_type_t vtype = vcode_reg_type(ptr);
+   ident_t name = well_known(W_COUNTERS);
+   vcode_var_t counters = emit_var(vtype, VCODE_INVALID_STAMP, name, 0);
+   emit_store(ptr, counters);
+
+   lower_put_vcode_obj(name, counters, lu);
+}
+
 static void lower_pack_body(lower_unit_t *lu, object_t *obj)
 {
    tree_t body = tree_from_object(obj);
@@ -12477,6 +12510,8 @@ static void lower_pack_body(lower_unit_t *lu, object_t *obj)
       tree_visit_only(pack, lower_external_name_cache, lu, T_EXTERNAL_NAME);
       tree_visit_only(body, lower_external_name_cache, lu, T_EXTERNAL_NAME);
    }
+
+   lower_cover_setup_package(lu, pack);
 
    lower_dependencies(lu, body);
 
@@ -12511,6 +12546,8 @@ static void lower_package(lower_unit_t *lu, object_t *obj)
 
    if (gflags & TREE_GF_EXTERNAL_NAME)
       tree_visit_only(pack, lower_external_name_cache, lu, T_EXTERNAL_NAME);
+
+   lower_cover_setup_package(lu, pack);
 
    lower_dependencies(lu, pack);
 
@@ -12796,12 +12833,12 @@ lower_unit_t *lower_instance(unit_registry_t *ur, lower_unit_t *parent,
       case T_PROCESS:
          unit_registry_defer(ur, ident_prefix(sym_prefix, tree_ident(s), '.'),
                              lu, emit_process, lower_process,
-                             cover, tree_to_object(s));
+                             tree_to_object(s));
          break;
       case T_PSL_DIRECT:
          unit_registry_defer(ur, ident_prefix(sym_prefix, tree_ident(s), '.'),
                              lu, emit_property, psl_lower_directive,
-                             cover, tree_to_object(s));
+                             tree_to_object(s));
          break;
       case T_BLOCK:
          break;
@@ -12860,6 +12897,7 @@ typedef struct _unit_registry {
    hash_t        *map;
    hset_t        *visited;
    mir_context_t *mir;
+   cover_data_t  *cover;
 } unit_registry_t;
 
 typedef struct {
@@ -12867,7 +12905,6 @@ typedef struct {
    emit_fn_t     emit_fn;
    lower_fn_t    fn;
    object_t     *object;
-   cover_data_t *cover;
 } deferred_unit_t;
 
 unit_registry_t *unit_registry_new(mir_context_t *mc)
@@ -12877,6 +12914,11 @@ unit_registry_t *unit_registry_new(mir_context_t *mc)
    ur->mir = mc;
 
    return ur;
+}
+
+void unit_registry_set_cover(unit_registry_t *ur, cover_data_t *cover)
+{
+   ur->cover = cover;
 }
 
 void unit_registry_free(unit_registry_t *ur)
@@ -13033,11 +13075,11 @@ vcode_unit_t unit_registry_get(unit_registry_t *ur, ident_t ident)
             return NULL;
 
          unit_registry_defer(ur, unit_name, NULL, emit_package,
-                             lower_pack_body, NULL, tree_to_object(body));
+                             lower_pack_body, tree_to_object(body));
       }
       else
          unit_registry_defer(ur, unit_name, NULL, emit_package,
-                             lower_package, NULL, tree_to_object(unit));
+                             lower_package, tree_to_object(unit));
 
       if (unit_name != ident) {
          // We actually wanted a unit inside this package so need to
@@ -13061,7 +13103,7 @@ vcode_unit_t unit_registry_get(unit_registry_t *ur, ident_t ident)
          vcode_unit_t vu = (*du->emit_fn)(ident, du->object, context);
          tree_t container = tree_from_object(du->object);
          lower_unit_t *lu = lower_unit_new(ur, du->parent, vu,
-                                           du->cover, container);
+                                           ur->cover, container);
 
          hash_put(ur->map, ident, tag_pointer(lu, UNIT_GENERATED));
 
@@ -13128,8 +13170,7 @@ vcode_unit_t unit_registry_get_parent(unit_registry_t *ur, ident_t name)
 
 void unit_registry_defer(unit_registry_t *ur, ident_t ident,
                          lower_unit_t *parent, emit_fn_t emit_fn,
-                         lower_fn_t fn, cover_data_t *cover,
-                         object_t *object)
+                         lower_fn_t fn, object_t *object)
 {
    void *ptr = hash_get(ur->map, ident);
    if (ptr == NULL) {
@@ -13137,7 +13178,6 @@ void unit_registry_defer(unit_registry_t *ur, ident_t ident,
       du->emit_fn = emit_fn;
       du->fn      = fn;
       du->parent  = parent;
-      du->cover   = cover;
       du->object  = object;
 
       for (lower_unit_t *p = du->parent; p; p = p->parent)
@@ -13150,7 +13190,6 @@ void unit_registry_defer(unit_registry_t *ur, ident_t ident,
       deferred_unit_t *du = untag_pointer(ptr, deferred_unit_t);
       assert(du->emit_fn == emit_fn);
       assert(du->fn == fn);
-      assert(du->cover == cover);
       assert(du->object == object);
    }
 #endif

--- a/src/lower.h
+++ b/src/lower.h
@@ -53,13 +53,13 @@ typedef struct _lower_unit {
 } lower_unit_t;
 
 unit_registry_t *unit_registry_new(mir_context_t *mc);
+void unit_registry_set_cover(unit_registry_t *ur, cover_data_t *cover);
 void unit_registry_free(unit_registry_t *ur);
 vcode_unit_t unit_registry_get(unit_registry_t *ur, ident_t ident);
 void unit_registry_put(unit_registry_t *ur, lower_unit_t *lu);
 void unit_registry_defer(unit_registry_t *ur, ident_t ident,
                          lower_unit_t *parent, emit_fn_t emit_fn,
-                         lower_fn_t fn, cover_data_t *cover,
-                         object_t *object);
+                         lower_fn_t fn, object_t *object);
 void unit_registry_defer2(unit_registry_t *ur, ident_t name,
                           lower_unit_t *parent, mir_unit_kind_t kind,
                           mir_lower_fn_t fn, object_t *object);

--- a/src/psl/psl-lower.c
+++ b/src/psl/psl-lower.c
@@ -662,7 +662,7 @@ static void psl_lower_clock_decl(unit_registry_t *ur, lower_unit_t *parent,
    ident_t name = ident_prefix(prefix, label, '.');
 
    unit_registry_defer(ur, name, parent, emit_function, psl_lower_clock_func,
-                       NULL, psl_to_object(p));
+                       psl_to_object(p));
 
    vcode_type_t vtrigger = vtype_trigger();
    vcode_var_t var = emit_var(vtrigger, VCODE_INVALID_STAMP, label, 0);

--- a/src/reheat.c
+++ b/src/reheat.c
@@ -94,6 +94,8 @@ void reheat(tree_t top, unit_registry_t *ur, mir_context_t *mc,
 {
    assert(tree_kind(top) == T_ELAB);
 
+   unit_registry_set_cover(ur, cover);
+
    rt_scope_t *root = create_scope(m, top, NULL);
 
    reheat_ctx_t ctx = {

--- a/src/vhdl/vhdl-cover.c
+++ b/src/vhdl/vhdl-cover.c
@@ -376,3 +376,15 @@ ident_t vhdl_scope_name(tree_t t, int nth)
          return ident_sprintf("_S%u", nth);
    }
 }
+
+void vhdl_cover_package(tree_t pack, cover_data_t *db, cover_scope_t *cs)
+{
+   if (db == NULL || cs == NULL)
+      return;
+
+   cover_ignore_from_pragmas(db, cs, pack);
+
+   lazy_cscope_t lcs = { NULL, cs, pack };
+
+   vhdl_cover_decls(pack, db, &lcs);
+}

--- a/src/vhdl/vhdl-phase.h
+++ b/src/vhdl/vhdl-phase.h
@@ -25,6 +25,7 @@ tree_t vhdl_architecture_instance(tree_t arch, tree_t inst, ident_t dotted);
 tree_t vhdl_config_instance(tree_t conf, tree_t bind, ident_t dotted);
 
 void vhdl_cover_block(tree_t block, cover_data_t *db, cover_scope_t *cs);
+void vhdl_cover_package(tree_t pack, cover_data_t *db, cover_scope_t *cs);
 ident_t vhdl_scope_name(tree_t t, int nth);
 
 #endif  // _VHDL_PHASE_H

--- a/test/regress/cover30.sh
+++ b/test/regress/cover30.sh
@@ -1,0 +1,16 @@
+set -xe
+
+pwd
+which nvc
+
+nvc --work=OTHER_LIB:other_lib -a $TESTDIR/regress/cover30.vhd
+
+nvc --map=OTHER_LIB:other_lib \
+    -a $TESTDIR/regress/cover30.vhd \
+    -e --cover=all \
+       --cover-spec=$TESTDIR/regress/data/cover30.spec \
+       --cover-file=cover30.ncdb cover30 -r
+
+nvc --cover-report -o html cover30.ncdb 2>&1 | grep -v '^** Debug:' | tee out.txt
+
+diff -u $TESTDIR/regress/gold/cover30.txt out.txt

--- a/test/regress/cover30.vhd
+++ b/test/regress/cover30.vhd
@@ -1,0 +1,64 @@
+-- Package compiled into other_lib in the shell driver.  Although its
+-- name matches the +package *_pkg pattern, the -hierarchy other_lib.*
+-- rule in cover30.spec excludes it from the coverage report.
+package util_pkg is
+    function clamp(x, lo, hi : integer) return integer;
+end package;
+
+package body util_pkg is
+
+    function clamp(x, lo, hi : integer) return integer is
+    begin
+        if x < lo then
+            return lo;
+        elsif x > hi then
+            return hi;
+        else
+            return x;
+        end if;
+    end function;
+
+end package body;
+
+-------------------------------------------------------------------------------
+
+-- Package compiled into the work library: should be covered
+-- (+package *_pkg).
+package math_pkg is
+    function abs_diff(a, b : integer) return integer;
+end package;
+
+package body math_pkg is
+
+    function abs_diff(a, b : integer) return integer is
+    begin
+        if a >= b then
+            return a - b;
+        else
+            return b - a;
+        end if;
+    end function;
+
+end package body;
+
+-------------------------------------------------------------------------------
+
+library other_lib;
+use other_lib.util_pkg.all;
+
+use work.math_pkg.all;
+
+entity cover30 is
+end cover30;
+
+architecture test of cover30 is
+begin
+    process
+        variable v : integer;
+    begin
+        v := abs_diff(10, 3);
+        v := clamp(v, 0, 5);
+        assert v = 5;
+        wait;
+    end process;
+end architecture;

--- a/test/regress/data/cover30.spec
+++ b/test/regress/data/cover30.spec
@@ -1,0 +1,10 @@
+# Exercise the +package / -package coverage spec directives.
+
+# Include every package whose name ends in _pkg ...
++package *_pkg
+
+# ... except those compiled into other_lib.
+-hierarchy other_lib.*
+
+# Always cover the top-level entity itself.
++block cover30

--- a/test/regress/gold/cover30.txt
+++ b/test/regress/gold/cover30.txt
@@ -1,0 +1,18 @@
+** Note: Code coverage report folder: html.
+** Note: Code coverage report contains: covered, uncovered, excluded coverage details.
+** Note: code coverage results for: WORK.COVER30
+** Note:      statement:     100.0 % (4/4)
+** Note:      branch:        N.A.
+** Note:      toggle:        N.A.
+** Note:      expression:    N.A.
+** Note:      FSM state:     N.A.
+** Note:      functional:    N.A.
+** Note:      average:       100.0 % (4/4)
+** Note: code coverage results for: WORK.MATH_PKG
+** Note:      statement:     66.7 % (2/3)
+** Note:      branch:        50.0 % (1/2)
+** Note:      toggle:        N.A.
+** Note:      expression:    50.0 % (1/2)
+** Note:      FSM state:     N.A.
+** Note:      functional:    N.A.
+** Note:      average:       57.1 % (4/7)

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -1349,3 +1349,4 @@ ivtest40        verilog
 select18        verilog
 select19        verilog
 select20        verilog
+cover30         shell


### PR DESCRIPTION
Previously, coverage instrumentation was only applied to design hierarchy instances.  Top-level packages loaded via USE clauses were lowered without coverage data, so any functions, procedures, or expressions defined in packages were invisible to the coverage report.

Pass coverage data through the unit registry so that lower_package and lower_pack_body can create coverage scopes under the root scope.  A new helper vhdl_cover_package walks the package and body declarations to register coverage items.  Standard libraries (STD, IEEE, NVC) are excluded.

Fixes #1007 