### PR TITLE
Fix replication operator with braced constant expression in Verilog

### DIFF
--- a/src/vlog/vlog-parse.c
+++ b/src/vlog/vlog-parse.c
@@ -1598,6 +1598,12 @@ static vlog_node_t p_multiple_concatenation(vlog_node_t head)
 
    BEGIN_WITH_HEAD("multiple concatenation", head);
 
+   // Handle case like {{N+1}{1'b0}} where head was parsed as a
+   // single-element concatenation {N+1} instead of the expression N+1
+   if (vlog_kind(head) == V_CONCAT && !vlog_has_value(head)
+       && vlog_params(head) == 1)
+      head = vlog_param(head, 0);
+
    vlog_node_t v = p_concatenation(NULL);
    vlog_set_value(v, head);
 

--- a/test/vlog/concat1.v
+++ b/test/vlog/concat1.v
@@ -11,4 +11,8 @@ module concat1;
   assign a3 = {5{x}};   // OK
   assign a4 = {z{x}};   // Error
 
+  parameter N = 4;
+  assign a5 = {{N}{x}};   // OK
+  assign a6 = {{N+1}{x}}; // OK
+
 endmodule // concat1


### PR DESCRIPTION
The Verilog parser incorrectly rejected replication operators where the repeat count was a constant expression enclosed in braces, such as {{N+1}{1'b0}}. The inner {N+1} was parsed as a single-element concatenation rather than being unwrapped to the expression N+1, causing the semantic check to report "expression is not a constant".