### PR TITLE
Fix generic array override parsing for VHDL-2008

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 ## Unreleased changes
 - Added basic support for System Verilog assignment pattern expressions.
+- Generics of an array type other than a character array can now be
+  overridden on the command line with an aggregate value, for example
+  `-gVALUES='(1, 2, 3)'` (#1465).
 
 ## Version 1.22.1 - 2026-08-01
 - Waveform dumping now dumps multiple top units instead of only the first

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 - Generics of an array type other than a character array can now be
   overridden on the command line with an aggregate value, for example
   `-gVALUES='(1, 2, 3)'` (#1465).
+- Fixed VHPI reporting `vhpiIsUnconstrainedP` as true for the constraint
+  of a subtype whose bounds are determinate but not statically foldable,
+  such as a port whose index constraint is derived from an array generic.
 
 ## Version 1.22.1 - 2026-08-01
 - Waveform dumping now dumps multiple top units instead of only the first

--- a/src/elab.c
+++ b/src/elab.c
@@ -1068,14 +1068,152 @@ static void elab_ports(tree_t entity, tree_t bind, const elab_ctx_t *ctx)
    }
 }
 
-static tree_t elab_parse_generic_string(tree_t generic, const char *str)
+static const char *elab_skip_spaces(const char *s)
 {
-   type_t type = tree_type(generic);
+   while (isspace_iso88591(*s))
+      s++;
+   return s;
+}
+
+static char *elab_trim_string(const char *start, size_t len)
+{
+   while (len > 0 && isspace_iso88591(start[len - 1]))
+      len--;
+
+   while (len > 0 && isspace_iso88591(*start)) {
+      start++;
+      len--;
+   }
+
+   return xstrndup(start, len);
+}
+
+__attribute__((noreturn))
+static void elab_generic_parse_failed(tree_t generic, type_t type,
+                                      const char *str)
+{
+   fatal("failed to parse \"%s\" as type %s for generic %s",
+         str, type_pp(type), istr(tree_ident(generic)));
+}
+
+__attribute__((noreturn))
+static void elab_generic_cannot_override(tree_t generic, type_t type)
+{
+   fatal("cannot override generic %s of type %s", istr(tree_ident(generic)),
+         type_pp(type));
+}
+
+static void elab_check_generic_length(tree_t generic, type_t type, int count)
+{
+   // The bounds of an unconstrained generic are taken from the value but
+   // otherwise the number of elements must match exactly
+
+   int64_t length;
+   if (type_is_unconstrained(type))
+      return;
+   else if (!folded_length(range_of(type, 0), &length))
+      return;   // Checked later when the bounds are known
+   else if (length != count)
+      fatal("expected %"PRIi64" elements for generic %s of type %s but have %d",
+            length, istr(tree_ident(generic)), type_pp(type), count);
+}
+
+// Find the end of one aggregate element: the first comma or closing
+// parenthesis that is not nested within a sub-aggregate or a literal
+static const char *elab_scan_generic_element(const char *s)
+{
+   for (int depth = 0; *s != '\0'; s++) {
+      switch (*s) {
+      case '\'':
+      case '"':
+         {
+            const char quote = *s;
+            while (*++s != '\0' && *s != quote)
+               ;
+            if (*s == '\0')
+               return s;
+         }
+         break;
+      case '(':
+         depth++;
+         break;
+      case ')':
+         if (depth == 0)
+            return s;
+         depth--;
+         break;
+      case ',':
+         if (depth == 0)
+            return s;
+         break;
+      }
+   }
+
+   return s;
+}
+
+static tree_t elab_parse_generic_value(tree_t generic, type_t type,
+                                       const char *str);
+
+static tree_t elab_parse_generic_array(tree_t generic, type_t type,
+                                       const char *str)
+{
+   type_t elem = type_elem(type);
+
+   if (dimension_of(type) > 1 || type_is_unconstrained(elem))
+      elab_generic_cannot_override(generic, type);
+
+   const char *cursor = elab_skip_spaces(str);
+   if (*cursor != '(')
+      elab_generic_parse_failed(generic, type, str);
+   else
+      cursor++;
+
+   tree_t agg = tree_new(T_AGGREGATE);
+   tree_set_loc(agg, tree_loc(generic));
+   tree_set_type(agg, type);
+
+   for (int pos = 0; ; pos++) {
+      const char *end = elab_scan_generic_element(cursor);
+
+      char *value LOCAL = elab_trim_string(cursor, end - cursor);
+      if (*value == '\0')
+         elab_generic_parse_failed(generic, type, str);
+
+      tree_t assoc = tree_new(T_ASSOC);
+      tree_set_subkind(assoc, A_POS);
+      tree_set_pos(assoc, pos);
+      tree_set_loc(assoc, tree_loc(generic));
+      tree_set_value(assoc, elab_parse_generic_value(generic, elem, value));
+
+      tree_add_assoc(agg, assoc);
+
+      cursor = end;
+      if (*cursor != ',')
+         break;
+      else
+         cursor++;
+   }
+
+   if (*cursor != ')')
+      elab_generic_parse_failed(generic, type, str);
+   else if (*elab_skip_spaces(cursor + 1) != '\0')
+      elab_generic_parse_failed(generic, type, str);
+
+   elab_check_generic_length(generic, type, tree_assocs(agg));
+
+   return agg;
+}
+
+static tree_t elab_parse_generic_value(tree_t generic, type_t type,
+                                       const char *str)
+{
+   if (type_is_array(type) && !type_is_character_array(type))
+      return elab_parse_generic_array(generic, type, str);
 
    parsed_value_t value;
    if (!parse_value(type, str, &value))
-      fatal("failed to parse \"%s\" as type %s for generic %s",
-            str, type_pp(type), istr(tree_ident(generic)));
+      elab_generic_parse_failed(generic, type, str);
 
    if (type_is_enum(type)) {
       type_t base = type_base_recur(type);
@@ -1118,6 +1256,8 @@ static tree_t elab_parse_generic_string(tree_t generic, const char *str)
       return result;
    }
    else if (type_is_character_array(type)) {
+      elab_check_generic_length(generic, type, value.enums->count);
+
       tree_t t = tree_new(T_STRING);
       tree_set_loc(t, tree_loc(generic));
 
@@ -1135,9 +1275,13 @@ static tree_t elab_parse_generic_string(tree_t generic, const char *str)
       tree_set_type(t, subtype_for_string(t, type));
       return t;
    }
-   else
-      fatal("cannot override generic %s of type %s", istr(tree_ident(generic)),
-            type_pp(type));
+
+   elab_generic_cannot_override(generic, type);
+}
+
+static tree_t elab_parse_generic_string(tree_t generic, const char *str)
+{
+   return elab_parse_generic_value(generic, tree_type(generic), str);
 }
 
 static tree_t elab_find_generic_override(tree_t g, const elab_ctx_t *ctx)

--- a/src/vhpi/vhpi-model.c
+++ b/src/vhpi/vhpi-model.c
@@ -128,6 +128,7 @@ typedef struct {
    c_range       range;
    c_vhpiObject *source;
    unsigned      nth_dim;
+   bool          NeedsSync;
    vhpiLongIntT  LeftBound;
    vhpiLongIntT  RightBound;
 } c_intRange;
@@ -981,8 +982,9 @@ static void handle_pp_r(vhpiHandleT handle, text_buf_t *tb)
 
       c_intRange *ir = is_intRange(obj);
       if (ir != NULL)
-         tb_printf(tb, " LeftBound=%"PRIi64" RightBound=%"PRIi64,
-                   ir->LeftBound, ir->RightBound);
+         tb_printf(tb, " LeftBound=%"PRIi64" RightBound=%"PRIi64
+                   " NeedsSync=%d", ir->LeftBound, ir->RightBound,
+                   ir->NeedsSync);
    }
 
    tb_append(tb, '}');
@@ -1304,9 +1306,12 @@ static void init_indexedName(c_indexedName *in, c_typeDecl *Type,
    in->offset = BaseIndex * num_elems;
 }
 
+// Fill in the bounds of a range that were not known statically by reading
+// them back from the elaborated object the range was derived from.  Returns
+// false if the bounds cannot be determined at all.
 static bool range_sync(c_intRange *ir)
 {
-   if (!ir->range.IsUnconstrained)
+   if (!ir->NeedsSync)
       return true;
    else if (ir->source == NULL)
       return false;
@@ -4256,12 +4261,16 @@ static c_intRange *build_int_range(tree_t r)
    return ir;
 }
 
-static c_intRange *build_unconstrained(c_vhpiObject *source, int nth,
-                                       bool IsDiscrete)
+// Build a range whose bounds are only known once the object has been
+// elaborated.  IsUnconstrained distinguishes a range that has no constraint
+// at all from one that has a constraint which is simply not static.
+static c_intRange *build_dynamic_range(c_vhpiObject *source, int nth,
+                                       bool IsDiscrete, bool IsUnconstrained)
 {
    c_intRange *ir = new_object(sizeof(c_intRange), vhpiIntRangeK);
    ir->range.IsDiscrete = IsDiscrete;
-   ir->range.IsUnconstrained = vhpiTrue;
+   ir->range.IsUnconstrained = IsUnconstrained;
+   ir->NeedsSync = true;
    ir->source = source;
    ir->nth_dim = nth;
    return ir;
@@ -5047,7 +5056,12 @@ static void vhpi_lazy_constraints(c_vhpiObject *obj)
          }
 
          if (dynamic_bounds) {
-            c_intRange *ir = build_unconstrained(obj, std->depth + i, true);
+            // The bounds must be read back from the elaborated object.  This
+            // does not make the range unconstrained: a subtype with a
+            // non-static index constraint, such as one derived from a
+            // generic, still has a determinate constraint.
+            c_intRange *ir = build_dynamic_range(obj, std->depth + i, true,
+                                                 std->typeDecl.IsUnconstrained);
             vhpi_list_add(&std->Constraints.list, &(ir->range.object));
          }
       }

--- a/test/regress/issue1465.sh
+++ b/test/regress/issue1465.sh
@@ -1,0 +1,101 @@
+set -xe
+
+pwd
+which nvc
+
+nvc -a - <<'EOF'
+package issue1465_pkg is
+    type int_vector_t  is array (natural range <>) of integer;
+    type nat_vector_t  is array (natural range <>) of natural;
+    type real_vector_t is array (natural range <>) of real;
+    type time_vector_t is array (natural range <>) of time;
+    type bv_vector_t   is array (natural range <>) of bit_vector(3 downto 0);
+    type matrix_t      is array (natural range <>, natural range <>) of integer;
+
+    subtype quad_t is int_vector_t(0 to 3);
+end package;
+
+use work.issue1465_pkg.all;
+
+entity issue1465 is
+    generic (
+        INTS  : int_vector_t;
+        NATS  : nat_vector_t;
+        REALS : real_vector_t;
+        TIMES : time_vector_t;
+        BITS  : bv_vector_t;
+        QUAD  : quad_t );
+end entity;
+
+architecture test of issue1465 is
+begin
+
+    check: process(all) is
+    begin
+        -- The bounds of an unconstrained generic are taken from the value
+        assert INTS'left = 0 severity failure;
+        assert INTS'right = 3 severity failure;
+        assert INTS'length = 4 severity failure;
+
+        assert INTS = (-1, 0, 3, 4) severity failure;
+        assert NATS = (0, 3, 2) severity failure;
+        assert REALS = (1.5, -2.5) severity failure;
+        assert TIMES = (10 ns, 1 us) severity failure;
+        assert BITS = ("1010", "0101") severity failure;
+
+        -- A constrained generic keeps the bounds of its subtype
+        assert QUAD'left = 0 severity failure;
+        assert QUAD'right = 3 severity failure;
+        assert QUAD = (5, 6, 7, 8) severity failure;
+    end process;
+
+end architecture;
+
+entity issue1465_matrix is
+    generic ( M : work.issue1465_pkg.matrix_t );
+end entity;
+
+architecture test of issue1465_matrix is
+begin
+end architecture;
+EOF
+
+# Space around the elements and parenthesis is ignored
+nvc -e --no-save issue1465 \
+    -gINTS=' ( -1 , 0,3 ,4 ) ' \
+    -gNATS='(0,3,2)' \
+    -gREALS='(1.5,-2.5)' \
+    -gTIMES='(10 ns,1 us)' \
+    -gBITS='("1010","0101")' \
+    -gQUAD='(5,6,7,8)' \
+    -r
+
+elab_fails() {
+   local value="$1" expect="$2"
+   if nvc -e --no-save issue1465 -gINTS="$value" -gNATS='(0)' -gREALS='(0.0)' \
+          -gTIMES='(1 ns)' -gBITS='("0000")' -gQUAD='(1,2,3,4)' 2>err.txt; then
+      echo "expected elaboration to fail for INTS=$value"
+      exit 1
+   fi
+   grep -q "failed to parse \"$expect\" as type INT_VECTOR_T for generic INTS" \
+        err.txt
+}
+
+elab_fails '(1,2,'  '(1,2,'
+elab_fails '(1,2'   '(1,2'
+elab_fails '(1,2))' '(1,2))'
+elab_fails '()'     '()'
+elab_fails '(,1)'   '(,1)'
+elab_fails '(1,,2)' '(1,,2)'
+elab_fails '1,2,3'  '1,2,3'
+
+# The number of elements must match the bounds of a constrained generic
+! nvc -e --no-save issue1465 \
+    -gINTS='(1)' -gNATS='(0)' -gREALS='(0.0)' -gTIMES='(1 ns)' \
+    -gBITS='("0000")' -gQUAD='(1,2,3)' 2>quad.txt
+grep -q 'expected 4 elements for generic QUAD of type QUAD_T but have 3' \
+     quad.txt
+
+# Multidimensional arrays cannot be overridden
+! nvc -e --no-save issue1465_matrix -gM='((1,2),(3,4))' 2>matrix.txt
+grep -q 'cannot override generic M of type MATRIX_T' matrix.txt

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -1456,3 +1456,4 @@ issue1625       verilog
 vlog47          verilog
 issue1629       tcl,2008
 issue1465       shell
+vhpi22          vhpi,2008

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -1455,3 +1455,4 @@ issue1627       normal
 issue1625       verilog
 vlog47          verilog
 issue1629       tcl,2008
+issue1465       shell

--- a/test/regress/vhpi22.vhd
+++ b/test/regress/vhpi22.vhd
@@ -1,0 +1,77 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+package vhpi22_pkg is
+    type item_array_t is array (natural range <>) of std_logic_vector;
+    type width_array_t is array (natural range <>) of positive;
+    type matrix_t is array (natural range <>, natural range <>) of std_logic;
+
+    function amax(a : width_array_t) return positive;
+end package;
+
+package body vhpi22_pkg is
+    function amax(a : width_array_t) return positive is
+        variable result : positive := 1;
+    begin
+        for i in a'range loop
+            if a(i) > result then
+                result := a(i);
+            end if;
+        end loop;
+        return result;
+    end function;
+end package body;
+
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use work.vhpi22_pkg.all;
+
+entity vhpi22_sub is
+    generic (
+        ITEM_WIDTH : positive;
+        WIDTHS     : width_array_t );
+    port (
+        -- Index constraint is a function call over an array generic so it
+        -- cannot be folded during analysis
+        p_func   : in item_array_t(amax(WIDTHS) - 1 downto 0)(ITEM_WIDTH - 1 downto 0);
+        -- Likewise for an attribute of, or an index into, an array generic
+        p_len    : in item_array_t(WIDTHS'length - 1 downto 0)(ITEM_WIDTH - 1 downto 0);
+        p_index  : in item_array_t(WIDTHS(0) - 1 downto 0)(ITEM_WIDTH - 1 downto 0);
+        -- These have statically foldable bounds and always worked
+        p_scalar : in item_array_t(ITEM_WIDTH - 1 downto 0)(ITEM_WIDTH - 1 downto 0);
+        p_lit    : in item_array_t(3 downto 0)(ITEM_WIDTH - 1 downto 0);
+        -- Every dimension of a multidimensional constraint must be reported
+        p_2d     : in matrix_t(amax(WIDTHS) - 1 downto 0, WIDTHS'length - 1 downto 0) );
+end entity;
+
+architecture test of vhpi22_sub is
+begin
+end architecture;
+
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use work.vhpi22_pkg.all;
+
+entity vhpi22 is
+end entity;
+
+architecture test of vhpi22 is
+    constant WIDTHS_C : width_array_t(0 to 3) := (1, 2, 3, 5);
+
+    signal p_func   : item_array_t(amax(WIDTHS_C) - 1 downto 0)(3 downto 0);
+    signal p_len    : item_array_t(WIDTHS_C'length - 1 downto 0)(3 downto 0);
+    signal p_index  : item_array_t(WIDTHS_C(0) - 1 downto 0)(3 downto 0);
+    signal p_scalar : item_array_t(3 downto 0)(3 downto 0);
+    signal p_lit    : item_array_t(3 downto 0)(3 downto 0);
+    signal p_2d     : matrix_t(amax(WIDTHS_C) - 1 downto 0, WIDTHS_C'length - 1 downto 0);
+begin
+
+    u: entity work.vhpi22_sub
+        generic map ( ITEM_WIDTH => 4, WIDTHS => WIDTHS_C )
+        port map ( p_func, p_len, p_index, p_scalar, p_lit, p_2d );
+
+end architecture;

--- a/test/vhpi/Makemodule.am
+++ b/test/vhpi/Makemodule.am
@@ -43,7 +43,8 @@ lib_vhpi_test_so_SOURCES = \
 	test/vhpi/issue1473.c \
 	test/vhpi/issue1505.c \
 	test/vhpi/issue1616.c \
-	test/vhpi/issue1621.c
+	test/vhpi/issue1621.c \
+	test/vhpi/vhpi22.c
 
 lib_vhpi_test_so_CFLAGS  = $(SHLIB_CFLAGS) -I$(top_srcdir)/src/vhpi $(AM_CFLAGS)
 lib_vhpi_test_so_LDFLAGS = $(SHLIB_LDFLAGS) $(AM_LDFLAGS)

--- a/test/vhpi/vhpi22.c
+++ b/test/vhpi/vhpi22.c
@@ -1,0 +1,131 @@
+#include "vhpi_test.h"
+
+#include <stdarg.h>
+
+// A port or signal whose index constraint is not statically foldable, for
+// example because it is derived from an array generic, must still report
+// itself as constrained through vhpiConstraints.  The bounds are only known
+// once the object has been elaborated but the subtype is not unconstrained.
+
+static void check_range(vhpiHandleT scope, const char *name, int ndims, ...)
+{
+   vhpiHandleT obj = VHPI_CHECK(vhpi_handle_by_name(name, scope));
+   check_handle(obj);
+
+   vhpiHandleT type = VHPI_CHECK(vhpi_handle(vhpiType, obj));
+   check_handle(type);
+   fail_unless(vhpi_get(vhpiKindP, type) == vhpiSubtypeDeclK);
+   fail_if(vhpi_get(vhpiIsUnconstrainedP, type));
+
+   vhpiHandleT constraints = VHPI_CHECK(vhpi_iterator(vhpiConstraints, type));
+   check_handle(constraints);
+
+   va_list ap;
+   va_start(ap, ndims);
+
+   for (int i = 0; i < ndims; i++) {
+      const int left = va_arg(ap, int), right = va_arg(ap, int);
+
+      vhpiHandleT range = VHPI_CHECK(vhpi_scan(constraints));
+      check_handle(range);
+      fail_unless(vhpi_get(vhpiKindP, range) == vhpiIntRangeK);
+
+      // This is the property cocotb consults before reading the bounds
+      fail_if(vhpi_get(vhpiIsUnconstrainedP, range));
+
+      fail_unless(vhpi_get(vhpiLeftBoundP, range) == left);
+      fail_unless(vhpi_get(vhpiRightBoundP, range) == right);
+      fail_if(vhpi_get(vhpiIsUpP, range));
+      fail_if(vhpi_get(vhpiIsNullP, range));
+      fail_unless(vhpi_get(vhpiIsDiscreteP, range));
+      check_error();
+
+      vhpi_printf("%s dimension %d range %d downto %d", name, i, left, right);
+
+      vhpi_release_handle(range);
+   }
+
+   va_end(ap);
+
+   fail_unless(vhpi_scan(constraints) == NULL);
+
+   vhpi_release_handle(type);
+   vhpi_release_handle(obj);
+}
+
+// The converse must still hold: a subtype that really has no index constraint
+// reports itself, and its constraints, as unconstrained even though the
+// bounds can be read back from the elaborated object.
+static void check_unconstrained(vhpiHandleT scope, const char *name,
+                                int left, int right)
+{
+   vhpiHandleT obj = VHPI_CHECK(vhpi_handle_by_name(name, scope));
+   check_handle(obj);
+
+   vhpiHandleT type = VHPI_CHECK(vhpi_handle(vhpiType, obj));
+   check_handle(type);
+   fail_unless(vhpi_get(vhpiKindP, type) == vhpiSubtypeDeclK);
+   fail_unless(vhpi_get(vhpiIsUnconstrainedP, type));
+
+   vhpiHandleT constraints = VHPI_CHECK(vhpi_iterator(vhpiConstraints, type));
+   check_handle(constraints);
+
+   vhpiHandleT range = VHPI_CHECK(vhpi_scan(constraints));
+   check_handle(range);
+   fail_unless(vhpi_get(vhpiIsUnconstrainedP, range));
+
+   fail_unless(vhpi_get(vhpiLeftBoundP, range) == left);
+   fail_unless(vhpi_get(vhpiRightBoundP, range) == right);
+   check_error();
+
+   vhpi_printf("%s unconstrained range %d to %d", name, left, right);
+
+   fail_unless(vhpi_scan(constraints) == NULL);
+
+   vhpi_release_handle(range);
+   vhpi_release_handle(type);
+   vhpi_release_handle(obj);
+}
+
+static void start_of_simulation(const vhpiCbDataT *cb_data)
+{
+   vhpiHandleT root = VHPI_CHECK(vhpi_handle(vhpiRootInst, NULL));
+   check_handle(root);
+
+   // Signals in the top-level architecture
+   check_range(root, "p_func", 1, 4, 0);
+   check_range(root, "p_len", 1, 3, 0);
+   check_range(root, "p_index", 1, 0, 0);
+   check_range(root, "p_scalar", 1, 3, 0);
+   check_range(root, "p_lit", 1, 3, 0);
+   check_range(root, "p_2d", 2, 4, 0, 3, 0);
+
+   // Ports of the instantiated entity, where the bounds come from the
+   // actual generic values
+   vhpiHandleT sub = VHPI_CHECK(vhpi_handle_by_name("u", root));
+   check_handle(sub);
+
+   check_range(sub, "p_func", 1, 4, 0);
+   check_range(sub, "p_len", 1, 3, 0);
+   check_range(sub, "p_index", 1, 0, 0);
+   check_range(sub, "p_scalar", 1, 3, 0);
+   check_range(sub, "p_lit", 1, 3, 0);
+   check_range(sub, "p_2d", 2, 4, 0, 3, 0);
+
+   // The array generic itself has an unconstrained subtype
+   check_unconstrained(sub, "WIDTHS", 0, 3);
+
+   vhpi_release_handle(sub);
+   vhpi_release_handle(root);
+
+   VHPI_CHECK(vhpi_control(vhpiFinish));
+}
+
+void vhpi22_startup(void)
+{
+   vhpiCbDataT cb_data = {
+      .reason = vhpiCbStartOfSimulation,
+      .cb_rtn = start_of_simulation,
+   };
+   VHPI_CHECK(vhpi_register_cb(&cb_data, 0));
+}

--- a/test/vhpi/vhpi_test.c
+++ b/test/vhpi/vhpi_test.c
@@ -67,6 +67,7 @@ static const vhpi_test_t tests[] = {
    { "issue1505", issue1505_startup },
    { "issue1616", issue1616_startup },
    { "issue1621", issue1621_startup },
+   { "vhpi22",    vhpi22_startup },
    { NULL,        NULL },
 };
 

--- a/test/vhpi/vhpi_test.h
+++ b/test/vhpi/vhpi_test.h
@@ -60,6 +60,7 @@ void vhpi17_startup(void);
 void vhpi18_startup(void);
 void vhpi19_startup(void);
 void vhpi21_startup(void);
+void vhpi22_startup(void);
 void issue744_startup(void);
 void issue762_startup(void);
 void issue978_startup(void);


### PR DESCRIPTION
Fixes #1465. Add support for parsing command-line generic overrides for unconstrained array types during elaboration.