### PR TITLE
Allow protected type objects to be declared before the protected body is elaborated

### DIFF
--- a/src/sem.c
+++ b/src/sem.c
@@ -1108,7 +1108,7 @@ static bool sem_check_var_decl(tree_t t, nametab_t *tab)
    if (type_is_protected(type)) {
       ident_t typeid = ident_rfrom(type_ident(type), '.');
       tree_t pt = get_local_decl(tab, NULL, typeid, 0);
-      if (pt != NULL && tree_kind(pt) == T_PROT_DECL) {
+      if (!relaxed_rules() && pt != NULL && tree_kind(pt) == T_PROT_DECL) {
          diag_t *d = diag_new(DIAG_ERROR, tree_loc(t));
          diag_printf(d, "cannot declare instance of protected type %pT "
                      "before its body has been elaborated", type);

--- a/test/sem/issue1432.vhd
+++ b/test/sem/issue1432.vhd
@@ -1,0 +1,22 @@
+package p is
+  type t_prot is protected
+    procedure dummy;
+  end protected;
+
+  -- Instance declared BEFORE body
+  shared variable obj : t_prot;
+
+end package;
+
+package body p is
+
+  type t_prot is protected body
+
+    procedure dummy is
+    begin
+      null;
+    end procedure;
+
+  end protected body;
+
+end package body;

--- a/test/test_sem.c
+++ b/test/test_sem.c
@@ -4027,6 +4027,38 @@ START_TEST(test_issue1329)
 }
 END_TEST
 
+START_TEST(test_issue1432_strict)
+{
+   opt_set_int(OPT_RELAXED, 0);
+   set_standard(STD_08);
+
+   input_from_file(TESTDIR "/sem/issue1432.vhd");
+
+   const error_t expect[] = {
+      { 7, "cannot declare instance of protected type T_PROT before its body has been elaborated" },
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   parse_and_check(T_PACKAGE, T_PACK_BODY);
+
+   check_expected_errors();
+}
+END_TEST
+
+START_TEST(test_issue1432_relaxed)
+{
+   opt_set_int(OPT_RELAXED, 1);
+   set_standard(STD_08);
+
+   input_from_file(TESTDIR "/sem/issue1432.vhd");
+
+   parse_and_check(T_PACKAGE, T_PACK_BODY);
+
+   fail_if_errors();
+}
+END_TEST
+
 Suite *get_sem_tests(void)
 {
    Suite *s = suite_create("sem");
@@ -4216,6 +4248,8 @@ Suite *get_sem_tests(void)
    tcase_add_test(tc_core, test_issue1279);
    tcase_add_test(tc_core, test_issue1290);
    tcase_add_test(tc_core, test_issue1329);
+   tcase_add_test(tc_core, test_issue1432_strict);
+   tcase_add_test(tc_core, test_issue1432_relaxed);
    suite_add_tcase(s, tc_core);
 
    return s;


### PR DESCRIPTION
Resolves https://github.com/nickg/nvc/issues/1432

We would like to try nvc, but got the same issue in a central component of our codebase. So I took a try in extending the `--relaxed` flag. I would be glad about feedback.

I tested manual with this minimal example (not certain where to add this in the automated tests):

```vhdl
package prot_pkg is
  type t_prot is protected
    impure function get return natural;
  end protected t_prot;

  shared variable shared_var_prot : t_prot;
end package prot_pkg;

package body prot_pkg is
  type t_prot is protected body
    impure function get return natural is
    begin
      return 1;
    end function get;
  end protected body t_prot;
end package body prot_pkg;

----------

entity issue_1432 is end entity;

architecture arch of issue_1432 is
begin
  tb : process
  begin
    report "access shared variable: " & integer'image(work.prot_pkg.shared_var_prot.get);
    wait;
  end process;
end architecture;
```

## Strict

```sh
$ ./bin/nvc -L ./lib -a ../shared_variable_example/issue_1432.vhd -e issue_1432 -r
** Error: cannot declare instance of protected type T_PROT before its body has been elaborated
   > ../shared_variable_example/issue_1432.vhd:6
   |
 2 |   type t_prot is protected
   |                  ^ T_PROT declared here
 ...
 6 |   shared variable shared_var_prot : t_prot;
   |                   ^^^^^^^^^^^^^^^ error occurred here
   |
   = Help: IEEE Std 1076-2008 section 14.4.2 "Elaboration of a declaration"
** Error: design unit depends on WORK.PROT_PKG which was analysed with errors
   > ../shared_variable_example/issue_1432.vhd:9
   |
 9 | package body prot_pkg is
   | ^^^^^^^^^^^^^^^^^^^^^
** Error: design unit depends on WORK.PROT_PKG which was analysed with errors
    > ../shared_variable_example/issue_1432.vhd:27
    |
 27 |     report "access shared variable: " & integer'image(work.prot_pkg.shared_var_prot.get);
    |
```

## With `--relaxed`

```sh
$ ./bin/nvc -L ./lib -a ../shared_variable_example/issue_1432.vhd --relaxed -e issue_1432 -r
** Note: 0ms+0: access shared variable: 1
   Process :issue_1432:tb at ../shared_variable_example/issue_1432.vhd:25
```