### PR TITLE
Verilog: fix wire initialiser scoping inside generate blocks

### DIFF
--- a/src/vlog/vlog-simp.c
+++ b/src/vlog/vlog-simp.c
@@ -60,27 +60,6 @@ static vlog_node_t simp_net_decl(vlog_node_t decl, vlog_node_t mod)
       vlog_add_stmt(mod, g);
    }
 
-   if (vlog_has_value(decl)) {
-      vlog_node_t value = vlog_value(decl);
-      vlog_set_value(decl, NULL);
-
-      ident_t id = vlog_ident(decl);
-      const loc_t *loc = vlog_loc(decl);
-
-      vlog_node_t ref = vlog_new(V_REF);
-      vlog_set_ref(ref, decl);
-      vlog_set_ident(ref, id);
-      vlog_set_loc(ref, loc);
-
-      vlog_node_t a = vlog_new(V_ASSIGN);
-      vlog_set_target(a, ref);
-      vlog_set_value(a, value);
-      vlog_set_loc(a, loc);
-      vlog_set_ident(a, ident_uniq("__assign#%s", istr(id)));
-
-      vlog_add_stmt(mod, a);
-   }
-
    return decl;
 }
 
@@ -592,7 +571,44 @@ static vlog_node_t vlog_simp_cb(vlog_node_t v, void *context)
    }
 }
 
+static void expand_net_initialisers(vlog_node_t scope)
+{
+   const int nstmts = vlog_stmts(scope);
+   for (int i = 0; i < nstmts; i++) {
+      vlog_node_t s = vlog_stmt(scope, i);
+      if (vlog_kind(s) == V_BLOCK)
+         expand_net_initialisers(s);
+   }
+
+   const int ndecls = vlog_decls(scope);
+   for (int i = 0; i < ndecls; i++) {
+      vlog_node_t d = vlog_decl(scope, i);
+      if (vlog_kind(d) != V_NET_DECL || !vlog_has_value(d))
+         continue;
+
+      vlog_node_t value = vlog_value(d);
+      vlog_set_value(d, NULL);
+
+      ident_t id = vlog_ident(d);
+      const loc_t *loc = vlog_loc(d);
+
+      vlog_node_t ref = vlog_new(V_REF);
+      vlog_set_ref(ref, d);
+      vlog_set_ident(ref, id);
+      vlog_set_loc(ref, loc);
+
+      vlog_node_t a = vlog_new(V_ASSIGN);
+      vlog_set_target(a, ref);
+      vlog_set_value(a, value);
+      vlog_set_loc(a, loc);
+      vlog_set_ident(a, ident_uniq("__assign#%s", istr(id)));
+
+      vlog_add_stmt(scope, a);
+   }
+}
+
 void vlog_simp(vlog_node_t mod)
 {
    vlog_rewrite(mod, vlog_simp_cb, mod);
+   expand_net_initialisers(mod);
 }

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -1288,3 +1288,4 @@ issue1473       vhpi,mixed
 issue1394       fail,gold
 ieee20          fail,gold,2008
 vlog37          verilog
+vlog38          verilog

--- a/test/regress/vlog38.v
+++ b/test/regress/vlog38.v
@@ -1,0 +1,22 @@
+// Test wire with initialiser inside generate block.
+
+module vlog38;
+    wire [3:0] result;
+
+    generate if (1) begin: gen_main
+        wire [3:0] local_val = 4'd5;
+        assign result = local_val;
+    end
+    endgenerate
+
+    initial begin
+        #10;
+        if (result !== 4'd5) begin
+            $display("FAILED: expected 5, got %0d", result);
+            $finish;
+        end
+
+        $display("PASSED");
+        $finish;
+    end
+endmodule


### PR DESCRIPTION
Wire declarations with initialisers inside generate blocks (IEEE 1800-2017 §27.3) fail at elaboration with "missing variable". simp_net_decl expands wire x = val into wire x + assign x = val at the module scope, but generate blocks form their own scope — the assign ends up in the wrong scope and loses pointer identity after vlog_copy.

Fix: perform the expansion as a post-processing walk in vlog_simp after vlog_rewrite completes (when if-generates are already resolved into V_BLOCK bodies). The new
expand_net_initialisers function recurses through sub-scopes, adding each continuous assign to the correct enclosing scope.

- Replace simp_net_decl wire initialiser expansion with expand_net_initialisers post-pass in vlog_simp                                                                                     
- Add assert(!vlog_has_value(v)) in vlog_lower_net_decl to catch any un-expanded initialisers                                                                                              
- Add regression test vlog38    