### PR TITLE
Verilog: fix constant folding of string comparisons

### DIFF
--- a/src/vlog/vlog-number.c
+++ b/src/vlog/vlog-number.c
@@ -809,13 +809,25 @@ number_t number_logical_equal(number_t a, number_t b)
    bignum_t *result;
    bignum_scratch(1, false, 1, &result);
 
-   assert(bignum_words(a.big) == 1);  // TODO
-   assert(bignum_words(b.big) == 1);  // TODO
+   const int nwords_a = bignum_words(a.big);
+   const int nwords_b = bignum_words(b.big);
+   const int nwords = MAX(nwords_a, nwords_b);
 
-   bignum_abits(result)[0] =
-      bignum_abits(a.big)[0] == bignum_abits(b.big)[0];
-   bignum_bbits(result)[0] =
-      bignum_bbits(a.big)[0] | bignum_bbits(b.big)[0];
+   bool equal = true;
+   bool has_xz = false;
+
+   for (int i = 0; i < nwords; i++) {
+      uint64_t av = (i < nwords_a) ? bignum_abits(a.big)[i] : 0;
+      uint64_t bv = (i < nwords_b) ? bignum_abits(b.big)[i] : 0;
+      uint64_t ax = (i < nwords_a) ? bignum_bbits(a.big)[i] : 0;
+      uint64_t bx = (i < nwords_b) ? bignum_bbits(b.big)[i] : 0;
+
+      if (av != bv) equal = false;
+      if (ax | bx) has_xz = true;
+   }
+
+   bignum_abits(result)[0] = equal ? 1 : 0;
+   bignum_bbits(result)[0] = has_xz ? 1 : 0;
 
    return number_intern(result);
 }

--- a/src/vlog/vlog-simp.c
+++ b/src/vlog/vlog-simp.c
@@ -303,6 +303,7 @@ static bool get_number(vlog_node_t v, number_t *n)
 {
    switch (vlog_kind(v)) {
    case V_NUMBER:
+   case V_STRING:
       *n = vlog_number(v);
       return true;
    case V_REF:

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -1288,3 +1288,4 @@ issue1473       vhpi,mixed
 issue1394       fail,gold
 ieee20          fail,gold,2008
 vlog37          verilog
+vlog45          verilog

--- a/test/regress/vlog45.v
+++ b/test/regress/vlog45.v
@@ -1,0 +1,40 @@
+// Test string comparison in parameter ternary expression.
+// Exercises constant folding of string equality for single-word
+// and multi-word strings (>8 chars = >64 bits).
+
+module vlog45 #(
+    parameter STYLE = "abc"
+);
+
+    // Single-word comparison: "abc" == "abc" (24-bit, 1 word)
+    parameter P1 = (STYLE == "abc") ? "longstring1" : STYLE;
+
+    // Multi-word equal: "longstring1" == "longstring1" (88-bit, 2 words)
+    parameter MW_EQ = (P1 == "longstring1") ? 1 : 0;
+
+    // Multi-word not-equal: "longstring1" vs "longstring2" (88-bit, 2 words)
+    parameter MW_NEQ = ("longstring1" == "longstring2") ? 0 : 1;
+
+    // Different lengths: "abc" (24-bit) vs "longstring1" (88-bit)
+    parameter DIFF_LEN = ("abc" == "longstring1") ? 0 : 1;
+
+    // Case sensitivity: "abc" != "ABC"
+    parameter CASE_SENS = ("abc" == "ABC") ? 0 : 1;
+
+    generate
+        if (MW_EQ && MW_NEQ && DIFF_LEN && CASE_SENS) begin
+            initial begin
+                $display("PASSED");
+                $finish;
+            end
+        end
+        else begin
+            initial begin
+                $display("FAILED: MW_EQ=%0d MW_NEQ=%0d DIFF_LEN=%0d CASE_SENS=%0d",
+                         MW_EQ, MW_NEQ, DIFF_LEN, CASE_SENS);
+                $finish;
+            end
+        end
+    endgenerate
+
+endmodule


### PR DESCRIPTION
Add V_STRING to get_number() in the simplifier so that string equality expressions like (PARAM == "literal") can be evaluated at compile time. This fixes generate branch selection based on string parameter values.

Also fix number_logical_equal() to handle multi-word bignums, needed for strings longer than 8 characters.