### PR TITLE
[Preprocessor] Parse constant numbers as a single tTEXT token

### DIFF
--- a/src/vlog/vlog-pp.c
+++ b/src/vlog/vlog-pp.c
@@ -269,6 +269,14 @@ static token_t lex_text(scan_buf_t buf)
    while (scan_peek(buf, &ch)) {
       switch (ch) {
       case '0'...'9':
+      case 'A'...'F':
+      case 'a'...'f':
+      case 'h': case 'H':
+      case 'o': case 'O':
+      case 's': case 'S':
+      case 'x': case 'X':
+      case 'z': case 'Z': case '?':
+      case '\'': case '_':
       case '+': case '-': case '*':
          scan_advance(&buf);
          continue;

--- a/test/test_vlog.c
+++ b/test/test_vlog.c
@@ -1587,7 +1587,14 @@ START_TEST(test_pp8)
       "((1) + (y)) // Error\n"
       "(4, 5, 6) // Warning\n"
       "\n"
-      " // Error\n");
+      " // Error\n"
+      "\n"
+      "'hAbCdEf10 * 'hAbCdEf10         // hex literal (no size)\n"
+      "12'b0100_0000_0000 * 12'b0100_0000_0000 // unsigned binary literal (with underscores)\n"
+      "12'd1024 * 12'd1024           // unsigned decimal literal\n"
+      "12'sh400 * 12'sh400           // signed hex literal\n"
+      "12'o2000 * 12'o2000           // unsigned octal literal\n"
+      );
 
    check_expected_errors();
 }

--- a/test/vlog/pp8.v
+++ b/test/vlog/pp8.v
@@ -8,3 +8,9 @@ hello
 `baz(4, 5, 6) // Warning
 `define foo(fff)
 `foo(4, 5, 6) // Error
+`define pow2(a) a * a
+`pow2('hAbCdEf10)         // hex literal (no size)
+`pow2(12'b0100_0000_0000) // unsigned binary literal (with underscores)
+`pow2(12'd1024)           // unsigned decimal literal
+`pow2(12'sh400)           // signed hex literal
+`pow2(12'o2000)           // unsigned octal literal


### PR DESCRIPTION
* Fix passing a constant number with size and base to a macro as argument
* Update test pp8.v to regress various combinations of constant numbers as arguments