### PR TITLE
Code changes to allow WASM build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 PKGBUILD text eol=lf
 test/regress/vlog2.v -text
 test/vlog/pp7.v -text
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true -diff

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ test/vests/*
 
 # Examples has its own repository
 test/examples/*
+# pixi environments
+.pixi/*
+!.pixi/config.toml

--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,9 @@ AC_C_RESTRICT
 
 AC_CHECK_HEADERS([sys/ptrace.h sys/prctl.h])
 AC_CHECK_FUNCS([tcgetwinsize memmem strcasestr getline fseeko ftello])
-AC_CHECK_FUNCS([fpurge __fpurge strchrnul strndup gettid popen])
+AC_CHECK_FUNCS([__fpurge strchrnul strndup gettid popen])
+AS_IF([test "x$ac_cv_func___fpurge" != xyes],
+  [AC_CHECK_FUNCS([fpurge])])
 
 AC_CHECK_MEMBERS([struct stat.st_mtimespec.tv_nsec])
 AC_CHECK_MEMBERS([struct stat.st_mtim.tv_nsec])
@@ -275,9 +277,24 @@ AX_DEFINE_DIR([LIBEXECDIR], [libexecdir/nvc], [Location of internal programs])
 AX_DEFINE_DIR([DATADIR], [datadir/nvc], [Location of data files])
 AX_DEFINE_DIR([TESTDIR], [srcdir/test], [Location of testcases])
 
-AM_CONDITIONAL([ARCH_X86_64],
-               [test x$target_cpu = xx86_64 -o x$target_cpu = xamd64])
 AM_CONDITIONAL([ARCH_ARM64], [test x$target_cpu = xaarch64])
+
+AC_CACHE_CHECK([whether C compiler targets WebAssembly],
+          [ac_cv_cc_wasm32],
+          [AC_COMPILE_IFELSE(
+            [AC_LANG_PROGRAM([[
+#if !defined(__wasm32__) && !defined(__wasm__) && !defined(__EMSCRIPTEN__)
+# error not wasm32
+#endif
+            ]], [[]])],
+            [ac_cv_cc_wasm32=yes],
+            [ac_cv_cc_wasm32=no])])
+
+AM_CONDITIONAL([ARCH_WASM32], [test x$ac_cv_cc_wasm32 = xyes])
+
+AM_CONDITIONAL([ARCH_X86_64],
+          [test x$ac_cv_cc_wasm32 != xyes -a \
+           \( x$target_cpu = xx86_64 -o x$target_cpu = xamd64 \)])
 
 case $host_os in
   *cygwin*|msys*|mingw32*)

--- a/src/jit/Makemodule.am
+++ b/src/jit/Makemodule.am
@@ -16,8 +16,12 @@ lib_libnvc_a_SOURCES += \
 	src/jit/jit-intrin.c \
 	src/jit/jit-tramp.c
 
+if ARCH_WASM32
+## wasm32 uses only architecture-neutral JIT sources from this directory.
+else
 if ARCH_X86_64
 lib_libnvc_a_SOURCES += src/jit/jit-x86.c
+endif
 endif
 
 if ENABLE_LLVM

--- a/src/jit/jit-code.c
+++ b/src/jit/jit-code.c
@@ -841,6 +841,11 @@ static void arm64_patch_page_base_rel21(uint32_t *patch, void *ptr)
 
 static void *code_emit_trampoline(code_blob_t *blob, void *dest)
 {
+#if defined ARCH_WASM32
+   // wasm32 does not execute bytes from writable code buffers.
+   // Calls are represented by function/table indices instead of absolute jumps.
+   return dest;
+#else
 #if defined ARCH_X86_64
    const uint8_t veneer[] = {
       0x48, 0xb8, __IMM64((uintptr_t)dest),  // MOVABS RAX, dest
@@ -867,11 +872,15 @@ static void *code_emit_trampoline(code_blob_t *blob, void *dest)
       code_blob_emit(blob, veneer, ARRAY_LEN(veneer));
       return addr;
    }
+#endif
 }
 
 #if !defined __MINGW32__ && !defined __APPLE__
 static void *code_emit_got(code_blob_t *blob, void *dest)
 {
+#if defined ARCH_WASM32
+   return dest;
+#else
    const uint8_t data[] = { __IMM64((uintptr_t)dest) };
 
    void *prev = memmem(blob->veneers, blob->veneers - blob->wptr,
@@ -885,6 +894,7 @@ static void *code_emit_got(code_blob_t *blob, void *dest)
       code_blob_emit(blob, data, ARRAY_LEN(data));
       return addr;
    }
+#endif
 }
 #endif
 

--- a/src/jit/jit-intrin.c
+++ b/src/jit/jit-intrin.c
@@ -194,13 +194,6 @@ static const uint8_t lane_iota[16] = {
    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
 };
 
-static const uint32_t spread_nibble[16] = {
-   0x02020202, 0x03020202, 0x02030202, 0x03030202,
-   0x02020302, 0x03020302, 0x02030302, 0x03030302,
-   0x02020203, 0x03020203, 0x02030203, 0x03030203,
-   0x02020303, 0x03020303, 0x02030303, 0x03030303,
-};
-
 #ifdef HAVE_SSE41
 __attribute__((aligned(16)))
 static const uint8_t reverse_lane[16] = {
@@ -221,6 +214,13 @@ static const uint8_t spread_mask[16] = {
 #endif
 
 #endif
+
+static const uint32_t spread_nibble[16] = {
+   0x02020202, 0x03020202, 0x02030202, 0x03030202,
+   0x02020302, 0x03020302, 0x02030302, 0x03030302,
+   0x02020203, 0x03020203, 0x02030203, 0x03030203,
+   0x02020303, 0x03020303, 0x02030303, 0x03030303,
+};
 
 static void (*ieee_packed_add)(const uint8_t *, const uint8_t *,
                                int, int, uint8_t *);

--- a/src/rt/fileio.c
+++ b/src/rt/fileio.c
@@ -287,11 +287,11 @@ void __nvc_truncate(jit_scalar_t *args)
          goto failed;
    }
 
-#if defined HAVE_FPURGE
+#if defined HAVE___FPURGE
+   __fpurge(slot->file);
+#elif defined HAVE_FPURGE
    if (fpurge(slot->file) != 0)
       goto failed;
-#elif defined HAVE___FPURGE
-   __fpurge(slot->file);
 #endif
 
 #endif  // !__MINGW32__

--- a/src/thread.c
+++ b/src/thread.c
@@ -58,7 +58,7 @@
 #define SUSPEND_TIMEOUT 1
 #define THREAD_NAME_LEN 16
 
-#if !defined __MINGW32__ && !defined __APPLE__
+#if !defined __MINGW32__ && !defined __APPLE__ && !defined __EMSCRIPTEN__
 #define POSIX_SUSPEND 1
 #define SIGSUSPEND    SIGRTMIN
 #define SIGRESUME     (SIGRTMIN + 1)
@@ -1374,6 +1374,9 @@ void stop_world(stop_world_fn_t callback, void *arg)
 #elif defined __SANITIZE_THREAD__
    // https://github.com/google/sanitizers/issues/1179
    fatal_trace("stop_world is not supported with tsan");
+#elif defined __EMSCRIPTEN__
+   if (atomic_load(&running_threads) > 1)
+      fatal_trace("stop_world is not supported on emscripten with multiple threads");
 #else
    assert(sem_trywait(&stop_sem) == -1 && errno == EAGAIN);
 
@@ -1437,6 +1440,8 @@ void start_world(void)
       if (kern_result != KERN_SUCCESS)
          fatal_trace("failed to resume thread %d (%d)", i, kern_result);
    }
+#elif defined __EMSCRIPTEN__
+   // No-op: stop_world only supports inspecting the current thread.
 #else
    assert(sem_trywait(&stop_sem) == -1 && errno == EAGAIN);
 

--- a/src/util.h
+++ b/src/util.h
@@ -69,7 +69,10 @@
 #define ASAN_UNPOISON(addr, size)
 #endif
 
-#if defined __x86_64__
+#if defined __wasm32__ || defined __wasm__ || defined __EMSCRIPTEN__ \
+   || defined __EMSCRIPTEN_major__ || defined __wasm32
+#define ARCH_WASM32 1
+#elif defined __x86_64__
 #define ARCH_X86_64 1
 #elif defined __i386__
 #define ARCH_I386 1

--- a/src/vhpi/vhpi_user.h
+++ b/src/vhpi/vhpi_user.h
@@ -52,10 +52,9 @@ typedef unsigned __int8 uint8_t;
 typedef signed __int64 int64_t;
 typedef signed __int32 int32_t;
 typedef signed __int8 int8_t;
-#elif defined(__MINGW32__) || defined(__APPLE__)
+#elif defined(__MINGW32__) || defined(__APPLE__) || defined(__EMSCRIPTEN__) \
+   || defined(__linux__)
 #include <stdint.h>
-#elif defined(__linux)
-#include <inttypes.h>
 #else
 #include <sys/types.h>
 #endif

--- a/test/Makemodule.am
+++ b/test/Makemodule.am
@@ -41,8 +41,12 @@ bin_unit_test_SOURCES = \
 	test/test_mir.c \
 	test/test_cover.c
 
+if ARCH_WASM32
+## wasm32 skips host-native x86 test sources.
+else
 if ARCH_X86_64
 bin_unit_test_SOURCES += test/test_native.c
+endif
 endif
 
 if ENABLE_TCL

--- a/thirdparty/cpustate.c
+++ b/thirdparty/cpustate.c
@@ -180,6 +180,11 @@ void fill_cpu_state(struct cpu_state *cpu, ucontext_t *uc)
    cpu->regs[13] = uc->uc_mcontext->__ss.__r13;
    cpu->regs[14] = uc->uc_mcontext->__ss.__r14;
    cpu->regs[15] = uc->uc_mcontext->__ss.__r15;
+#elif defined __EMSCRIPTEN__
+   /* wasm32 / Emscripten: the wasm runtime does not expose hardware
+      register state via ucontext_t; leave all fields zero as set by
+      the memset above. */
+   (void)uc;
 #else
 #error Please port fill_cpu_state to this OS/CPU combination
 #endif


### PR DESCRIPTION
Primarily for reference (and to see if it still builds on all other platforms). At least the pixi-stuff should be reconsidered.

However, with this it at least compiles and links with emscripten.

Closes #1502
