### PR TITLE
Verilog: Fix ? don't-care digit in casez/casex and number literals     

### DIFF
--- a/src/jit/jit-exits.c
+++ b/src/jit/jit-exits.c
@@ -1105,6 +1105,66 @@ void __nvc_vec4op(jit_vec_op_t op, jit_anchor_t *anchor, jit_scalar_t *args,
          args[1].pointer = bresult;
       }
       break;
+   case JIT_VEC_EXTRACT:
+      {
+         assert(size > 64);
+
+         const uint64_t *afull = args[0].pointer;
+         const uint64_t *bfull = args[1].pointer;
+         const int pos         = args[2].integer;
+         const int ext_size    = args[3].integer;
+
+         const int bitpos = size - ext_size - pos;
+
+         if (ext_size <= 64) {
+            uint64_t aresult = 0, bresult = 0;
+            const uint64_t mask = ext_size == 64
+               ? ~UINT64_C(0) : (UINT64_C(1) << ext_size) - 1;
+
+            const int word = bitpos / 64;
+            const int bit  = bitpos % 64;
+
+            aresult = afull[word] >> bit;
+            bresult = bfull[word] >> bit;
+
+            if (bit + ext_size > 64 && word + 1 < nwords) {
+               aresult |= afull[word + 1] << (64 - bit);
+               bresult |= bfull[word + 1] << (64 - bit);
+            }
+
+            args[0].integer = aresult & mask;
+            args[1].integer = bresult & mask;
+         }
+         else {
+            const int rwords = (ext_size + 63) / 64;
+            void *ptr = jit_mspace_alloc(rwords * 2 * sizeof(uint64_t));
+            uint64_t *aresult = ptr, *bresult = aresult + rwords;
+
+            for (int i = 0; i < rwords; i++) {
+               const int bp = bitpos + i * 64;
+               const int word = bp / 64;
+               const int bit  = bp % 64;
+
+               aresult[i] = afull[word] >> bit;
+               bresult[i] = bfull[word] >> bit;
+
+               if (bit > 0 && word + 1 < nwords) {
+                  aresult[i] |= afull[word + 1] << (64 - bit);
+                  bresult[i] |= bfull[word + 1] << (64 - bit);
+               }
+            }
+
+            if (ext_size % 64 != 0) {
+               const uint64_t mask = (UINT64_C(1) << (ext_size % 64)) - 1;
+               aresult[rwords - 1] &= mask;
+               bresult[rwords - 1] &= mask;
+            }
+
+            args[0].pointer = aresult;
+            args[1].pointer = bresult;
+         }
+      }
+      break;
    case JIT_VEC_INSERT:
       {
          assert(size > 64);

--- a/src/jit/jit-irgen.c
+++ b/src/jit/jit-irgen.c
@@ -4166,12 +4166,14 @@ static void irgen_op_binary(jit_irgen_t *g, mir_value_t n)
       break;
    case MIR_VEC_CASEZ_EQ:
       {
+         jit_value_t ones = jit_value_from_int64(~UINT64_C(0));
+
          jit_value_t zleft = irgen_alloc_temp(g);
-         j_not(g, zleft, aleft);
+         j_xor(g, zleft, aleft, ones);
          j_and(g, zleft, zleft, bleft);
 
          jit_value_t zright = irgen_alloc_temp(g);
-         j_not(g, zright, aright);
+         j_xor(g, zright, aright, ones);
          j_and(g, zright, zright, bright);
 
          jit_value_t zmask = irgen_alloc_temp(g);
@@ -4183,7 +4185,7 @@ static void irgen_op_binary(jit_irgen_t *g, mir_value_t n)
          j_or(g, rcmpa, aright, zmask);
 
          jit_value_t nzmask = irgen_alloc_temp(g);
-         j_not(g, nzmask, zmask);
+         j_xor(g, nzmask, zmask, ones);
          jit_value_t lcmpb = irgen_alloc_temp(g);
          j_and(g, lcmpb, bleft, nzmask);
          jit_value_t rcmpb = irgen_alloc_temp(g);
@@ -4422,10 +4424,31 @@ static void irgen_op_extract(jit_irgen_t *g, mir_value_t n)
    jit_value_t pos = irgen_get_arg(g, n, 1);
 
    const int arg_size = mir_get_size(g->mu, mir_get_type(g->mu, arg0));
-   assert(arg_size <= 64);  // TODO
 
    mir_type_t type = mir_get_type(g->mu, n);
    const int size = mir_get_size(g->mu, type);
+
+   if (arg_size > 64) {
+      if (mir_is(g->mu, n, MIR_TYPE_VEC4)) {
+         jit_value_t bfull = irgen_get_slot(g, arg0, 1);
+
+         j_send(g, 0, full);
+         j_send(g, 1, bfull);
+         j_send(g, 2, pos);
+         j_send(g, 3, jit_value_from_int64(size));
+
+         macro_vec4op(g, JIT_VEC_EXTRACT, arg_size);
+
+         j_recv(g, irgen_get_slot(g, n, 0), 0);
+         j_recv(g, irgen_get_slot(g, n, 1), 1);
+      }
+      else {
+         // TODO: non-vec4 wide extract
+         assert(false);
+      }
+
+      return;
+   }
 
    jit_value_t bitpos = irgen_alloc_temp(g);
    j_sub(g, bitpos, jit_value_from_int64(arg_size - size), pos);

--- a/src/jit/jit-priv.h
+++ b/src/jit/jit-priv.h
@@ -202,6 +202,7 @@ typedef enum {
    JIT_VEC_ZEXT,
    JIT_VEC_SEXT,
    JIT_VEC_INSERT,
+   JIT_VEC_EXTRACT,
    JIT_VEC_ADD,
    JIT_VEC_MUL,
    JIT_VEC_DIV,

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -143,7 +143,8 @@ TRANSLATE_ON    {PRAGMA}(?i:pragma)[ \t]+(?i:translate_on).*
 PSL_COMMENT     {PRAGMA}(?i:psl)
 PSL_CONT        ^{SPACE}*({PSL_COMMENT}|"--")
 UTF8_MB         [\x80-\xff][\x80-\xbf]{1,3}
-VLOG_NUMBER     ({INTEGER}{SPACE}*)?\'s?[bhdoBHDO]{SPACE}*({HEX}|[?])+
+VLOG_DIGIT      [0-9a-fA-FzZxX?][0-9a-fA-FzZxX_?]*
+VLOG_NUMBER     ({INTEGER}{SPACE}*)?\'s?[bhdoBHDO]{SPACE}*{VLOG_DIGIT}
 VLOG_REAL       {INTEGER}\.{INTEGER}
 UDP_LEVEL       [01xX?bB]
 UDP_EDGE        [rRfFpPnN*]

--- a/src/vpi/vpi-model.c
+++ b/src/vpi/vpi-model.c
@@ -1180,11 +1180,15 @@ void vpi_get_value(vpiHandle handle, p_vpi_value value_p)
          value_p->format = vpiRealVal;
          value_p->value.real = c->args[op->argslot + 1].real;
       }
-      else {
-         assert(size <= 64);
-
+      else if (size <= 64) {
          uint64_t abits[1] = { c->args[op->argslot + 1].integer };
          uint64_t bbits[1] = { c->args[op->argslot + 2].integer };
+
+         vpi_format_number(size, abits, bbits, value_p, c->valuestr);
+      }
+      else {
+         const uint64_t *abits = c->args[op->argslot + 1].pointer;
+         const uint64_t *bbits = c->args[op->argslot + 2].pointer;
 
          vpi_format_number(size, abits, bbits, value_p, c->valuestr);
       }

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -1304,3 +1304,5 @@ ivtest27        verilog
 ivtest28        verilog
 ivtest29        verilog
 issue1505       vhpi,2008
+vlog101         verilog
+vlog102         verilog

--- a/test/regress/vlog101.v
+++ b/test/regress/vlog101.v
@@ -1,0 +1,190 @@
+// Test ? as don't-care digit in casez patterns (IEEE 1364-2005 s9.5.2)
+// Covers: binary, octal, hex radixes; ? in case expression vs item;
+//         mixing ? with z and x; narrow and wide operands; default fallthrough.
+
+module vlog101;
+
+  integer fail = 0;
+
+  task check(input [80*8-1:0] label, input ok);
+    if (!ok) begin
+      $display("FAILED: %0s", label);
+      fail = 1;
+    end
+  endtask
+
+  // --- 1. Basic ? in binary case items ---
+  reg [3:0] sel;
+  reg [1:0] r1;
+
+  always @(*) begin
+    casez (sel)
+      4'b1???:  r1 = 2'd3;
+      4'b01??:  r1 = 2'd2;
+      4'b001?:  r1 = 2'd1;
+      4'b0001:  r1 = 2'd0;
+      default:  r1 = 2'bxx;
+    endcase
+  end
+
+  // --- 2. ? in octal case item ---
+  reg [8:0] osel;
+  reg [1:0] r2;
+
+  always @(*) begin
+    casez (osel)
+      9'o7??:  r2 = 2'd3;
+      9'o3??:  r2 = 2'd2;
+      9'o1??:  r2 = 2'd1;
+      default: r2 = 2'd0;
+    endcase
+  end
+
+  // --- 3. ? in hex case item ---
+  reg [7:0] hsel;
+  reg [1:0] r3;
+
+  always @(*) begin
+    casez (hsel)
+      8'hf?:   r3 = 2'd3;
+      8'ha?:   r3 = 2'd2;
+      8'h5?:   r3 = 2'd1;
+      default:  r3 = 2'd0;
+    endcase
+  end
+
+  // --- 4. ? in case expression (not just items) ---
+  reg [3:0] data;
+  reg [1:0] r4;
+
+  always @(*) begin
+    casez (data)
+      4'b?001:  r4 = 2'd1;
+      4'b?010:  r4 = 2'd2;
+      4'b?100:  r4 = 2'd3;
+      default:  r4 = 2'd0;
+    endcase
+  end
+
+  // --- 5. Mixing ? and z in the same literal ---
+  reg [7:0] mix;
+  reg [1:0] r5;
+
+  always @(*) begin
+    casez (mix)
+      8'b1??z_zz??:  r5 = 2'd1;
+      8'b0?z?_?z?0:  r5 = 2'd2;
+      default:        r5 = 2'd0;
+    endcase
+  end
+
+  // --- 6. ? with expression containing z in case selector ---
+  reg [3:0] zsel;
+  reg [1:0] r6;
+
+  always @(*) begin
+    casez (zsel)
+      4'b1???:  r6 = 2'd1;
+      4'b01??:  r6 = 2'd2;
+      default:  r6 = 2'd0;
+    endcase
+  end
+
+  // --- 7. Wide (>64 bit) casez with ? ---
+  reg [79:0] wide;
+  reg [1:0] r7;
+
+  always @(*) begin
+    casez (wide)
+      {16'hff??, 64'h0000_0000_0000_0001}: r7 = 2'd1;
+      {16'h00??, 64'hffff_ffff_ffff_ffff}: r7 = 2'd2;
+      default:                              r7 = 2'd0;
+    endcase
+  end
+
+  // --- 8. All-? pattern (matches everything before default) ---
+  reg [3:0] anysel;
+  reg [1:0] r8;
+
+  always @(*) begin
+    casez (anysel)
+      4'b????:  r8 = 2'd1;
+      default:  r8 = 2'd0;
+    endcase
+  end
+
+  initial begin
+    // Test 1: binary ? items
+    sel = 4'b1010; #1;
+    check("bin ? MSB=1", r1 === 2'd3);
+    sel = 4'b0110; #1;
+    check("bin ? top=01", r1 === 2'd2);
+    sel = 4'b0010; #1;
+    check("bin ? top=001", r1 === 2'd1);
+    sel = 4'b0001; #1;
+    check("bin ? exact", r1 === 2'd0);
+
+    // Test 2: octal ? items
+    osel = 9'o710; #1;
+    check("oct ? top=7", r2 === 2'd3);
+    osel = 9'o345; #1;
+    check("oct ? top=3", r2 === 2'd2);
+    osel = 9'o177; #1;
+    check("oct ? top=1", r2 === 2'd1);
+    osel = 9'o077; #1;
+    check("oct ? default", r2 === 2'd0);
+
+    // Test 3: hex ? items
+    hsel = 8'hf7; #1;
+    check("hex ? top=f", r3 === 2'd3);
+    hsel = 8'ha3; #1;
+    check("hex ? top=a", r3 === 2'd2);
+    hsel = 8'h5c; #1;
+    check("hex ? top=5", r3 === 2'd1);
+    hsel = 8'h20; #1;
+    check("hex ? default", r3 === 2'd0);
+
+    // Test 4: ? in items, specific low bits
+    data = 4'b1001; #1;
+    check("item ? bit0=001", r4 === 2'd1);
+    data = 4'b0010; #1;
+    check("item ? bit0=010", r4 === 2'd2);
+    data = 4'b1100; #1;
+    check("item ? bit0=100", r4 === 2'd3);
+    data = 4'b0000; #1;
+    check("item ? default", r4 === 2'd0);
+
+    // Test 5: mixed ? and z
+    mix = 8'b1110_0100; #1;
+    check("mix ?/z pattern1", r5 === 2'd1);
+    mix = 8'b0100_0010; #1;
+    check("mix ?/z pattern2", r5 === 2'd2);
+    mix = 8'b0000_0001; #1;
+    check("mix ?/z default", r5 === 2'd0);
+
+    // Test 6: z bits in case expression (z in expr acts as don't-care in casez)
+    zsel = 4'bz100; #1;
+    check("z in expr matches 1???", r6 === 2'd1);
+    zsel = 4'b0100; #1;
+    check("plain matches 01??", r6 === 2'd2);
+
+    // Test 7: wide casez with ?
+    wide = {16'hff00, 64'h0000_0000_0000_0001}; #1;
+    check("wide ? match1", r7 === 2'd1);
+    wide = {16'h0033, 64'hffff_ffff_ffff_ffff}; #1;
+    check("wide ? match2", r7 === 2'd2);
+    wide = {16'h1234, 64'h0000_0000_0000_0000}; #1;
+    check("wide ? default", r7 === 2'd0);
+
+    // Test 8: all-? matches any value
+    anysel = 4'b1010; #1;
+    check("all-? matches", r8 === 2'd1);
+    anysel = 4'bxz01; #1;
+    check("all-? matches xz", r8 === 2'd1);
+
+    if (fail == 0)
+      $display("PASSED");
+    $finish;
+  end
+
+endmodule

--- a/test/regress/vlog102.v
+++ b/test/regress/vlog102.v
@@ -1,0 +1,189 @@
+// Test ? as don't-care digit in casex patterns (IEEE 1364-2005 s9.5.3)
+// Covers: binary, octal, hex radixes; mixing ? with x and z;
+//         narrow and wide operands; x in expression and items.
+
+module vlog102;
+
+  integer fail = 0;
+
+  task check(input [80*8-1:0] label, input ok);
+    if (!ok) begin
+      $display("FAILED: %0s", label);
+      fail = 1;
+    end
+  endtask
+
+  // --- 1. Basic ? in binary casex items ---
+  reg [3:0] sel;
+  reg [1:0] r1;
+
+  always @(*) begin
+    casex (sel)
+      4'b1???:  r1 = 2'd3;
+      4'b01??:  r1 = 2'd2;
+      4'b001?:  r1 = 2'd1;
+      4'b0001:  r1 = 2'd0;
+      default:  r1 = 2'bxx;
+    endcase
+  end
+
+  // --- 2. ? in octal casex item ---
+  reg [8:0] osel;
+  reg [1:0] r2;
+
+  always @(*) begin
+    casex (osel)
+      9'o7??:  r2 = 2'd3;
+      9'o3??:  r2 = 2'd2;
+      9'o1??:  r2 = 2'd1;
+      default: r2 = 2'd0;
+    endcase
+  end
+
+  // --- 3. ? in hex casex item ---
+  reg [7:0] hsel;
+  reg [1:0] r3;
+
+  always @(*) begin
+    casex (hsel)
+      8'hf?:   r3 = 2'd3;
+      8'ha?:   r3 = 2'd2;
+      8'h5?:   r3 = 2'd1;
+      default:  r3 = 2'd0;
+    endcase
+  end
+
+  // --- 4. Mixing ? with x in the same literal ---
+  reg [7:0] mix;
+  reg [1:0] r4;
+
+  always @(*) begin
+    casex (mix)
+      8'b1??x_x??0:  r4 = 2'd1;
+      8'b0?x?_?x?1:  r4 = 2'd2;
+      default:        r4 = 2'd0;
+    endcase
+  end
+
+  // --- 5. Mixing ?, x, and z together ---
+  reg [7:0] triple;
+  reg [1:0] r5;
+
+  always @(*) begin
+    casex (triple)
+      8'b1?xz_??x0:  r5 = 2'd1;
+      8'b0z?x_xz?1:  r5 = 2'd2;
+      default:        r5 = 2'd0;
+    endcase
+  end
+
+  // --- 6. x/z in casex expression (both are don't-care in casex) ---
+  reg [3:0] xsel;
+  reg [1:0] r6;
+
+  always @(*) begin
+    casex (xsel)
+      4'b??10:  r6 = 2'd1;
+      4'b??01:  r6 = 2'd2;
+      default:  r6 = 2'd0;
+    endcase
+  end
+
+  // --- 7. Wide (>64 bit) casex with ? ---
+  reg [79:0] wide;
+  reg [1:0] r7;
+
+  always @(*) begin
+    casex (wide)
+      {16'hf??f, 64'h0000_0000_0000_0001}: r7 = 2'd1;
+      {16'h?00?, 64'hffff_ffff_ffff_ffff}: r7 = 2'd2;
+      default:                              r7 = 2'd0;
+    endcase
+  end
+
+  // --- 8. All-? matches everything (casex) ---
+  reg [3:0] anysel;
+  reg [1:0] r8;
+
+  always @(*) begin
+    casex (anysel)
+      4'b????:  r8 = 2'd1;
+      default:  r8 = 2'd0;
+    endcase
+  end
+
+  initial begin
+    // Test 1: binary ? items in casex
+    sel = 4'b1010; #1;
+    check("casex bin ? MSB=1", r1 === 2'd3);
+    sel = 4'b0110; #1;
+    check("casex bin ? top=01", r1 === 2'd2);
+    sel = 4'b0010; #1;
+    check("casex bin ? top=001", r1 === 2'd1);
+    sel = 4'b0001; #1;
+    check("casex bin ? exact", r1 === 2'd0);
+
+    // Test 2: octal ? items in casex
+    osel = 9'o710; #1;
+    check("casex oct ? top=7", r2 === 2'd3);
+    osel = 9'o345; #1;
+    check("casex oct ? top=3", r2 === 2'd2);
+    osel = 9'o177; #1;
+    check("casex oct ? top=1", r2 === 2'd1);
+    osel = 9'o077; #1;
+    check("casex oct ? default", r2 === 2'd0);
+
+    // Test 3: hex ? items in casex
+    hsel = 8'hf7; #1;
+    check("casex hex ? top=f", r3 === 2'd3);
+    hsel = 8'ha3; #1;
+    check("casex hex ? top=a", r3 === 2'd2);
+    hsel = 8'h5c; #1;
+    check("casex hex ? top=5", r3 === 2'd1);
+    hsel = 8'h20; #1;
+    check("casex hex ? default", r3 === 2'd0);
+
+    // Test 4: mixed ? and x
+    mix = 8'b1110_0100; #1;
+    check("casex mix ?/x pattern1", r4 === 2'd1);
+    mix = 8'b0100_0011; #1;
+    check("casex mix ?/x pattern2", r4 === 2'd2);
+    mix = 8'b0000_0100; #1;
+    check("casex mix ?/x default", r4 === 2'd0);
+
+    // Test 5: mixing ?, x, and z
+    triple = 8'b1010_0100; #1;
+    check("casex triple ?/x/z pat1", r5 === 2'd1);
+    triple = 8'b0100_0011; #1;
+    check("casex triple ?/x/z pat2", r5 === 2'd2);
+    triple = 8'b0000_0100; #1;
+    check("casex triple ?/x/z default", r5 === 2'd0);
+
+    // Test 6: x and z in casex expression are don't-care
+    xsel = 4'bxx10; #1;
+    check("casex x in expr pat1", r6 === 2'd1);
+    xsel = 4'bzz01; #1;
+    check("casex z in expr pat2", r6 === 2'd2);
+    xsel = 4'b?z11; #1;
+    check("casex z in expr default", r6 === 2'd0);
+
+    // Test 7: wide casex with ?
+    wide = {16'hf00f, 64'h0000_0000_0000_0001}; #1;
+    check("casex wide ? match1", r7 === 2'd1);
+    wide = {16'h1002, 64'hffff_ffff_ffff_ffff}; #1;
+    check("casex wide ? match2", r7 === 2'd2);
+    wide = {16'h1234, 64'h0000_0000_0000_0000}; #1;
+    check("casex wide ? default", r7 === 2'd0);
+
+    // Test 8: all-? matches any value including x/z
+    anysel = 4'b1010; #1;
+    check("casex all-? matches", r8 === 2'd1);
+    anysel = 4'bxz01; #1;
+    check("casex all-? matches xz", r8 === 2'd1);
+
+    if (fail == 0)
+      $display("PASSED");
+    $finish;
+  end
+
+endmodule


### PR DESCRIPTION
  - casez/casex comparison was broken when don't-care (?/z) appeared in case items against a plain expression — the JIT irgen used logical NOT  (!) instead of bitwise NOT (~) for z-mask computation, making every casez degenerate to exact match. Existing tests only had z in both the  expression and item so they passed by coincidence.                                                                                            
  - Lexer couldn't tokenise ? followed by _ in number literals (e.g. 8'b1??z_zz??) — added VLOG_DIGIT class that includes ? alongside _.        
  - JIT wide EXTRACT assert on >64-bit operands — added JIT_VEC_EXTRACT exit handler for both narrow and wide results.                          
  - VPI vpi_get_value assert on >64-bit operands — read args as pointers for wide values.    