### PR TITLE
PSL sequence instances support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 - Systems with emulated thread-local storage (in particular all MSYS2
   environments except Clang x64 and Clang Arm) are no longer supported
   due to performance issues.
+- PSL sequence instances are now supported.
 - Several other minor bugs were resolved (#1498, #1505).
 
 ## Version 1.20.0 - 2026-04-12

--- a/src/common.c
+++ b/src/common.c
@@ -552,6 +552,7 @@ class_t class_of(tree_t t)
    case T_PORT_DECL:
    case T_GENERIC_DECL:
    case T_PARAM_DECL:
+   case T_PSL_PARAM_DECL:
    case T_EXTERNAL_NAME:
       return tree_class(t);
    case T_ENUM_LIT:

--- a/src/lower.c
+++ b/src/lower.c
@@ -3169,6 +3169,9 @@ static vcode_reg_t lower_ref(lower_unit_t *lu, tree_t ref, expr_ctx_t ctx)
    case T_PARAM_DECL:
       return lower_param_ref(lu, decl);
 
+   case T_PSL_PARAM_DECL:
+      return psl_lower_param_ref(lu, decl);
+
    case T_GENERIC_DECL:
       return lower_generic_ref(lu, decl, ctx);
 
@@ -12813,6 +12816,7 @@ lower_unit_t *lower_unit_new(unit_registry_t *ur, lower_unit_t *parent,
 {
    lower_unit_t *new = xcalloc(sizeof(lower_unit_t));
    new->parent    = parent;
+   new->pscope    = (parent) ? parent->pscope : NULL;
    new->objects   = hash_new(128);
    new->container = container;
    new->vunit     = vunit;

--- a/src/lower.c
+++ b/src/lower.c
@@ -1017,8 +1017,8 @@ static bool lower_have_signal(vcode_reg_t reg)
    return vtype_is_signal(vcode_reg_type(reg));
 }
 
-static vcode_reg_t lower_coerce_arrays(lower_unit_t *lu, type_t from, type_t to,
-                                       vcode_reg_t reg)
+vcode_reg_t lower_coerce_arrays(lower_unit_t *lu, type_t from, type_t to,
+                                vcode_reg_t reg)
 {
    vcode_type_t reg_vtype = vcode_reg_type(reg);
    const bool have_uarray = vtype_kind(reg_vtype) == VCODE_TYPE_UARRAY;

--- a/src/lower.h
+++ b/src/lower.h
@@ -78,6 +78,8 @@ void lower_finished(lower_unit_t *lu);
 
 vcode_reg_t lower_lvalue(lower_unit_t *lu, tree_t expr);
 vcode_reg_t lower_rvalue(lower_unit_t *lu, tree_t expr);
+vcode_reg_t lower_coerce_arrays(lower_unit_t *lu, type_t from, type_t to,
+                                vcode_reg_t reg);
 
 vcode_type_t lower_type(type_t type);
 vcode_stamp_t lower_bounds(type_t type);

--- a/src/lower.h
+++ b/src/lower.h
@@ -47,6 +47,7 @@ typedef struct _lower_unit {
    vcode_unit_t     vunit;
    cover_data_t    *cover;
    cover_scope_t   *cscope;
+   psl_scope_t     *pscope;
    bool             finished;
    lower_mode_t     mode;
    unsigned         deferred;

--- a/src/parse.c
+++ b/src/parse.c
@@ -11430,7 +11430,7 @@ static psl_node_t p_psl_low_bound(tree_t head)
 
    BEGIN_WITH_HEAD("PSL Low Bound", head);
 
-   return p_hdl_expression(head, PSL_TYPE_NUMERIC);
+   return p_hdl_expression(head, PSL_TYPE_NUMBER);
 }
 
 static psl_node_t p_psl_high_bound(void)
@@ -11446,13 +11446,13 @@ static psl_node_t p_psl_high_bound(void)
       tree_set_ival(inf, INT32_MAX);
 
       psl_node_t p = psl_new(P_HDL_EXPR);
-      psl_set_type(p, PSL_TYPE_NUMERIC);
+      psl_set_type(p, PSL_TYPE_NUMBER);
       psl_set_tree(p, inf);
       psl_set_loc(p, CURRENT_LOC);
       return p;
    }
    else
-      return p_hdl_expression(NULL, PSL_TYPE_NUMERIC);
+      return p_hdl_expression(NULL, PSL_TYPE_NUMBER);
 }
 
 static psl_node_t p_psl_range(tree_t head)
@@ -11698,7 +11698,7 @@ static psl_node_t p_psl_builtin_function_call(void)
          psl_add_operand(p, p1);
 
          if (optional(tCOMMA)) {
-            psl_node_t p2 = p_hdl_expression(NULL, PSL_TYPE_NUMERIC);
+            psl_node_t p2 = p_hdl_expression(NULL, PSL_TYPE_NUMBER);
             psl_add_operand(p, p2);
 
             if (optional(tCOMMA))
@@ -11745,7 +11745,7 @@ static psl_node_t p_psl_builtin_function_call(void)
 
    case PSL_BUILTIN_NONDET_VECTOR:
       {
-         psl_node_t p1 = p_hdl_expression(NULL, PSL_TYPE_NUMERIC);
+         psl_node_t p1 = p_hdl_expression(NULL, PSL_TYPE_NUMBER);
          psl_add_operand(p, p1);
 
          consume(tCOMMA);
@@ -11859,7 +11859,7 @@ static psl_node_t p_psl_count(void)
    if (peek() == tTO)
       return p_psl_range(count);
    else
-      return p_hdl_expression(count, PSL_TYPE_NUMERIC);
+      return p_hdl_expression(count, PSL_TYPE_NUMBER);
 }
 
 static psl_node_t p_psl_proc_block(psl_node_t value)
@@ -12490,7 +12490,7 @@ static psl_node_t p_psl_fl_property(void)
             psl_set_flag(p, PSL_F_STRONG);
 
          if (optional(tLSQUARE)) {
-            psl_node_t count = p_hdl_expression(NULL, PSL_TYPE_NUMERIC);
+            psl_node_t count = p_hdl_expression(NULL, PSL_TYPE_NUMBER);
             psl_set_delay(p, count);
 
             consume(tRSQUARE);
@@ -12558,7 +12558,7 @@ static psl_node_t p_psl_fl_property(void)
          consume(tRPAREN);
 
          if (optional(tLSQUARE)) {
-            psl_node_t count = p_hdl_expression(NULL, PSL_TYPE_NUMERIC);
+            psl_node_t count = p_hdl_expression(NULL, PSL_TYPE_NUMBER);
             psl_set_delay(p, count);
 
             consume(tRSQUARE);

--- a/src/parse.c
+++ b/src/parse.c
@@ -12041,12 +12041,12 @@ static void p_psl_actual_parameter(psl_node_t node, psl_type_t type)
    case PSL_TYPE_NUMERIC:
    case PSL_TYPE_STRING:
    case PSL_TYPE_HDLTYPE:
-   case PSL_TYPE_ANY:
       arg = p_hdl_expression(NULL, type);
       break;
    case PSL_TYPE_SEQUENCE:
       arg = p_psl_sequence();
       break;
+   case PSL_TYPE_ANY:
    case PSL_TYPE_PROPERTY:
       arg = p_psl_property();
       break;
@@ -12074,6 +12074,7 @@ static void p_psl_actual_parameter_list(psl_node_t p)
       tree_t param_decl = (n < decl_params) ? psl_port(decl, n) : NULL;
       psl_type_t type = (param_decl) ? tree_subkind(param_decl) : PSL_TYPE_ANY;
       p_psl_actual_parameter(p, type);
+      n++;
    } while (optional(tCOMMA));
 
 }

--- a/src/parse.c
+++ b/src/parse.c
@@ -12001,7 +12001,7 @@ static void p_psl_formal_parameter(psl_node_t node)
    type_t type = p_psl_param_spec(node, &psl_type, &class);
 
    do {
-      tree_t p = tree_new(T_PARAM_DECL);
+      tree_t p = tree_new(T_PSL_PARAM_DECL);
       tree_set_ident(p, p_identifier());
       tree_set_loc(p, CURRENT_LOC);
       tree_set_class(p, class);
@@ -12024,7 +12024,7 @@ static void p_psl_formal_parameter_list(psl_node_t node)
       p_psl_formal_parameter(node);
 }
 
-static void p_psl_actual_parameter(psl_node_t node, bool seq)
+static void p_psl_actual_parameter(psl_node_t node, psl_type_t type)
 {
    // Actual_Parameter ::=
    //    AnyType | Sequence | Property
@@ -12033,12 +12033,32 @@ static void p_psl_actual_parameter(psl_node_t node, bool seq)
 
    BEGIN("PSL Actual parameter");
 
-   // "Sequence" includes "Any_Type" parsing (HDL or PSL expression)
-   // "Property" includes "Sequence" parsing
-   psl_add_operand(node, (seq) ? p_psl_sequence() : p_psl_property());
+   psl_node_t arg;
+   switch (type) {
+   case PSL_TYPE_BIT:
+   case PSL_TYPE_BOOLEAN:
+   case PSL_TYPE_BITVECTOR:
+   case PSL_TYPE_NUMERIC:
+   case PSL_TYPE_STRING:
+   case PSL_TYPE_HDLTYPE:
+   case PSL_TYPE_ANY:
+      arg = p_hdl_expression(NULL, type);
+      break;
+   case PSL_TYPE_SEQUENCE:
+      arg = p_psl_sequence();
+      break;
+   case PSL_TYPE_PROPERTY:
+      arg = p_psl_property();
+      break;
+   default:
+      fatal_trace("unexpected psl type kind %s in p_psl_actual_parameter",
+                  psl_type_str(type));
+   }
+
+   psl_add_operand(node, arg);
 }
 
-static void p_psl_actual_parameter_list(psl_node_t node, bool seq)
+static void p_psl_actual_parameter_list(psl_node_t p)
 {
 
    // sequence_Actual_Parameter { , sequence_Actual_Parameter }
@@ -12046,10 +12066,16 @@ static void p_psl_actual_parameter_list(psl_node_t node, bool seq)
 
    BEGIN("PSL Actual parameter list");
 
-   p_psl_actual_parameter(node, seq);
+   psl_node_t decl = psl_ref(p);
+   int decl_params = psl_ports(decl);
+   int n = 0;
 
-   while (optional(tCOMMA))
-      p_psl_actual_parameter(node, seq);
+   do {
+      tree_t param_decl = (n < decl_params) ? psl_port(decl, n) : NULL;
+      psl_type_t type = (param_decl) ? tree_subkind(param_decl) : PSL_TYPE_ANY;
+      p_psl_actual_parameter(p, type);
+   } while (optional(tCOMMA));
+
 }
 
 static psl_node_t p_psl_clocked_sere(psl_node_t head)
@@ -12306,7 +12332,7 @@ static psl_node_t p_psl_repeated_sere(psl_node_t head)
    return p;
 }
 
-static psl_node_t p_sequence_instance(tree_t decl)
+static psl_node_t p_psl_sequence_instance(tree_t decl)
 {
    // Name [ ( Actual_Parameter_List ) ]
 
@@ -12322,7 +12348,7 @@ static psl_node_t p_sequence_instance(tree_t decl)
    psl_set_ref(p, s_decl);
 
    if (optional(tLPAREN)) {
-      p_psl_actual_parameter_list(p, true);
+      p_psl_actual_parameter_list(p);
       consume(tRPAREN);
    }
 
@@ -12349,7 +12375,7 @@ static psl_node_t p_psl_sequence(void)
          if (tree_kind(name) == T_REF && tree_has_ref(name)) {
             tree_t decl = tree_ref(name);
             if (tree_kind(decl) == T_PSL_DECL)
-               head = p_sequence_instance(decl);
+               head = p_psl_sequence_instance(decl);
          }
 
          if (head == NULL)

--- a/src/prim.h
+++ b/src/prim.h
@@ -93,6 +93,8 @@ typedef struct _cover_scope cover_scope_t;
 typedef struct _cover_block cover_block_t;
 typedef struct _cover_rpt   cover_rpt_t;
 
+typedef struct _psl_scope   psl_scope_t;
+
 typedef struct loc_wr_ctx loc_wr_ctx_t;
 typedef struct loc_rd_ctx loc_rd_ctx_t;
 

--- a/src/psl/psl-dump.c
+++ b/src/psl/psl-dump.c
@@ -243,6 +243,49 @@ static void psl_dump_clocked(psl_node_t p)
    }
 }
 
+static void psl_dump_formal_parameter(tree_t port)
+{
+   print_syntax("%s %s", psl_type_str(tree_subkind(port)),
+                         istr(tree_ident(port)));
+}
+
+static void psl_dump_sequence_decl(psl_node_t p)
+{
+   print_syntax("sequence %s", istr(psl_ident(p)));
+
+   int ports = psl_ports(p);
+   if (ports > 0) {
+      print_syntax("(");
+      for (int i = 0; i < ports; i++) {
+         psl_dump_formal_parameter(psl_port(p, i));
+         if (i != ports - 1)
+            print_syntax(",");
+      }
+      print_syntax(")");
+   }
+
+   print_syntax(" is");
+
+   psl_dump(psl_value(p));
+}
+
+static void psl_dump_sequence_inst(psl_node_t p)
+{
+   psl_node_t decl = psl_ref(p);
+   print_syntax("%s", istr(psl_ident(decl)));
+
+   int ports = psl_operands(p);
+   if (ports) {
+      print_syntax("(");
+      for (int i = 0; i < ports; i++) {
+         psl_dump(psl_operand(p, i));
+         if (i != ports - 1)
+            print_syntax(",");
+      }
+      print_syntax(")");
+   }
+}
+
 void psl_dump(psl_node_t p)
 {
    switch (psl_kind(p)) {
@@ -308,6 +351,12 @@ void psl_dump(psl_node_t p)
       break;
    case P_CLOCKED:
       psl_dump_clocked(p);
+      break;
+   case P_SEQUENCE_DECL:
+      psl_dump_sequence_decl(p);
+      break;
+   case P_SEQUENCE_INST:
+      psl_dump_sequence_inst(p);
       break;
    default:
       print_syntax("\n");

--- a/src/psl/psl-fsm.c
+++ b/src/psl/psl-fsm.c
@@ -47,6 +47,7 @@ static fsm_state_t *add_state(psl_fsm_t *fsm, psl_node_t where)
    fsm_state_t *s = pool_calloc(fsm->pool, sizeof(fsm_state_t));
    s->id    = fsm->next_id++;
    s->where = where;
+   s->scope = fsm->curr_scope;
 
    *(fsm->tail) = s;
    fsm->tail = &(s->next);
@@ -636,6 +637,41 @@ static fsm_state_t *build_suffix_impl(psl_fsm_t *fsm, fsm_state_t *state,
    return final;
 }
 
+static psl_scope_t *psl_scope_new(psl_fsm_t *fsm)
+{
+   psl_scope_t *s = pool_malloc(fsm->pool, sizeof(psl_scope_t));
+   s->args = hash_new(8);
+   s->prev = fsm->last_scope;
+   fsm->last_scope = s;
+
+   return s;
+}
+
+static fsm_state_t *build_sequence_inst(psl_fsm_t *fsm, fsm_state_t *state,
+                                        psl_node_t p)
+{
+   psl_scope_t *scope = psl_scope_new(fsm);
+   psl_node_t decl = psl_ref(p);
+   const int n_ports = psl_ports(decl);
+
+   // Sequence arguments always passed by order
+   for (int i = 0; i < n_ports; i++) {
+      tree_t formal = psl_port(decl, i);
+      tree_t actual = psl_tree(psl_operand(p, i));
+      hash_put(scope->args, formal, actual);
+   }
+
+   scope->parent = fsm->curr_scope;
+   fsm->curr_scope = scope;
+   state->scope = scope;
+
+   fsm_state_t *last = build_node(fsm, state, psl_value(psl_ref(p)));
+
+   fsm->curr_scope = fsm->curr_scope->parent;
+
+   return last;
+}
+
 static fsm_state_t *build_node(psl_fsm_t *fsm, fsm_state_t *state, psl_node_t p)
 {
    switch (psl_kind(p)) {
@@ -673,6 +709,8 @@ static fsm_state_t *build_node(psl_fsm_t *fsm, fsm_state_t *state, psl_node_t p)
       return build_suffix_impl(fsm, state, p);
    case P_CLOCKED:
       return build_node(fsm, state, psl_value(p));
+   case P_SEQUENCE_INST:
+      return build_sequence_inst(fsm, state, p);
    default:
       CANNOT_HANDLE(p);
    }
@@ -849,6 +887,9 @@ psl_fsm_t *psl_fsm_new(psl_node_t p, ident_t label)
 
 void psl_fsm_free(psl_fsm_t *fsm)
 {
+   for (psl_scope_t *s = fsm->last_scope; s; s = s->prev)
+      hash_free(s->args);
+
    pool_free(fsm->pool);
    free(fsm);
 }

--- a/src/psl/psl-fsm.h
+++ b/src/psl/psl-fsm.h
@@ -47,6 +47,12 @@ typedef struct {
    psl_guard_t  right;
 } guard_binop_t;
 
+struct _psl_scope {
+   hash_t      *args;
+   psl_scope_t *parent;
+   psl_scope_t *prev;
+};
+
 typedef struct _fsm_edge {
    fsm_edge_t  *next;
    fsm_state_t *dest;
@@ -58,6 +64,7 @@ typedef struct _fsm_state {
    unsigned     id;
    fsm_state_t *next;
    fsm_edge_t  *edges;
+   psl_scope_t *scope;
    psl_node_t   where;
    psl_guard_t  guard;
    bool         initial;
@@ -75,6 +82,8 @@ typedef enum {
 typedef struct {
    fsm_state_t  *states;
    fsm_state_t **tail;
+   psl_scope_t  *curr_scope;
+   psl_scope_t  *last_scope;
    mem_pool_t   *pool;
    ident_t       label;
    psl_node_t    src;

--- a/src/psl/psl-lower.c
+++ b/src/psl/psl-lower.c
@@ -18,6 +18,7 @@
 #include "util.h"
 #include "common.h"
 #include "cov/cov-api.h"
+#include "hash.h"
 #include "lib.h"
 #include "lower.h"
 #include "option.h"
@@ -97,6 +98,22 @@ static vcode_reg_t psl_debug_locus(psl_node_t p)
 static vcode_reg_t psl_assert_severity(void)
 {
    return emit_const(vtype_int(0, 3), 2);
+}
+
+vcode_reg_t psl_lower_param_ref(lower_unit_t *lu, tree_t p)
+{
+   assert(lu->pscope != NULL);
+
+   psl_scope_t *scope = lu->pscope;
+   tree_t actual = hash_get(scope->args, p);
+
+   while (actual == NULL && scope->parent != NULL) {
+      scope = scope->parent;
+      actual = hash_get(scope->args, p);
+   }
+
+   assert(actual != NULL);
+   return lower_rvalue(lu, actual);
 }
 
 static vcode_reg_t psl_lower_guard(lower_unit_t *lu, psl_guard_t g)
@@ -202,6 +219,8 @@ static void psl_lower_state(lower_unit_t *lu, psl_fsm_t *fsm,
    vcode_type_t vbool = vtype_bool();
    vcode_reg_t vfalse = emit_const(vbool, 0);
    vcode_reg_t vtrue = emit_const(vbool, 1);
+
+   lu->pscope = state->scope;
 
    if (state->accept) {
       vcode_block_t cont_bb = vcode_active_block();
@@ -681,6 +700,9 @@ void psl_lower_decl(unit_registry_t *ur, lower_unit_t *parent, psl_node_t p,
    switch (psl_kind(p)) {
    case P_CLOCK_DECL:
       psl_lower_clock_decl(ur, parent, p, label);
+      break;
+   case P_SEQUENCE_DECL:
+      // Inlined in the directive where instantiated
       break;
    default:
       fatal_at(psl_loc(p), "cannot lower PSL declaration kind %s",

--- a/src/psl/psl-lower.c
+++ b/src/psl/psl-lower.c
@@ -113,7 +113,15 @@ vcode_reg_t psl_lower_param_ref(lower_unit_t *lu, tree_t p)
    }
 
    assert(actual != NULL);
-   return lower_rvalue(lu, actual);
+
+   type_t formal_type = tree_type(p);
+   type_t actual_type = tree_type(actual);
+   vcode_reg_t reg = lower_rvalue(lu, actual);
+
+   if (type_is_array(formal_type))
+      return lower_coerce_arrays(lu, actual_type, formal_type, reg);
+
+   return reg;
 }
 
 static vcode_reg_t psl_lower_guard(lower_unit_t *lu, psl_guard_t g)

--- a/src/psl/psl-node.c
+++ b/src/psl/psl-node.c
@@ -133,6 +133,11 @@ static const char *kind_text_map[P_LAST_PSL_KIND] = {
    "P_PARAM_SERE", "P_CLOCKED", "P_ENDPOINT_DECL",
 };
 
+static const char *type_text_map[PSL_TYPE_LAST] = {
+   "hdltype", "boolean", "bit", "bitvector", "numeric", "string", "sequence",
+   "property", "any",
+};
+
 static const change_allowed_t change_allowed[] = {
    { -1, -1 }
 };
@@ -223,6 +228,11 @@ void psl_set_subkind(psl_node_t p, unsigned sub)
 psl_type_t psl_type(psl_node_t p)
 {
    return lookup_item(&psl_object, p, I_CLASS)->ival;
+}
+
+const char *psl_type_str(psl_type_t type)
+{
+   return type_text_map[type];
 }
 
 void psl_set_type(psl_node_t p, psl_type_t type)

--- a/src/psl/psl-node.h
+++ b/src/psl/psl-node.h
@@ -81,6 +81,8 @@ typedef enum {
    PSL_TYPE_SEQUENCE,
    PSL_TYPE_PROPERTY,
    PSL_TYPE_ANY,
+
+   PSL_TYPE_LAST
 } psl_type_t;
 
 typedef enum {
@@ -147,6 +149,7 @@ void psl_set_subkind(psl_node_t p, unsigned sub);
 
 psl_type_t psl_type(psl_node_t p);
 void psl_set_type(psl_node_t p, psl_type_t type);
+const char *psl_type_str(psl_type_t type);
 
 tree_t psl_tree(psl_node_t p);
 bool psl_has_tree(psl_node_t p);

--- a/src/psl/psl-node.h
+++ b/src/psl/psl-node.h
@@ -81,6 +81,7 @@ typedef enum {
    PSL_TYPE_SEQUENCE,
    PSL_TYPE_PROPERTY,
    PSL_TYPE_ANY,
+   PSL_TYPE_NUMBER,
 
    PSL_TYPE_LAST
 } psl_type_t;

--- a/src/psl/psl-phase.h
+++ b/src/psl/psl-phase.h
@@ -41,4 +41,7 @@ vcode_reg_t psl_lower_fcall(lower_unit_t *lu, psl_node_t p);
 // Lower PSL union expression
 vcode_reg_t psl_lower_union(lower_unit_t *lu, psl_node_t p);
 
+// Lower PSL parameter reference
+vcode_reg_t psl_lower_param_ref(lower_unit_t *lu, tree_t p);
+
 #endif  // _PSL_PHASE_H

--- a/src/psl/psl-sem.c
+++ b/src/psl/psl-sem.c
@@ -231,7 +231,26 @@ static void psl_check_bit(psl_node_t p, nametab_t *tab)
                "type %s", type_pp(type));
 }
 
-static void psl_check_any(psl_node_t p, nametab_t *tab)
+static void psl_check_bitvector(psl_node_t p, nametab_t *tab)
+{
+   type_t std_bit_v = std_type(NULL, STD_BIT_VECTOR);
+   type_t std_ulogic_v = ieee_type(IEEE_STD_ULOGIC_VECTOR);
+   tree_t value = solve_types(tab, psl_tree(p), std_ulogic_v);
+   psl_set_tree(p, value);
+
+   type_t type = tree_type(value);
+   if (type_is_none(type))
+      return;   // Prevent cascading errors
+
+   if (!sem_check(value, tab))
+      return;
+
+   if (!type_eq(type, std_ulogic_v) && !type_eq(type, std_bit_v))
+      error_at(tree_loc(value), "expression must be a PSL BitVector but have "
+               "type %s", type_pp(type));
+}
+
+static void psl_check_any_hdltype_string(psl_node_t p, nametab_t *tab)
 {
    tree_t value = solve_types(tab, psl_tree(p), NULL);
    psl_set_tree(p, value);
@@ -256,11 +275,16 @@ static void psl_check_hdl_expr(psl_node_t p, nametab_t *tab)
    case PSL_TYPE_BIT:
       psl_check_bit(p, tab);
       break;
-   case PSL_TYPE_ANY:
-      psl_check_any(p, tab);
-      break;
    case PSL_TYPE_NUMBER:
       psl_check_number(p, tab);
+      break;
+   case PSL_TYPE_BITVECTOR:
+      psl_check_bitvector(p, tab);
+      break;
+   case PSL_TYPE_HDLTYPE:
+   case PSL_TYPE_ANY:
+   case PSL_TYPE_STRING:
+      psl_check_any_hdltype_string(p, tab);
       break;
    default:
       should_not_reach_here();

--- a/src/psl/psl-sem.c
+++ b/src/psl/psl-sem.c
@@ -284,9 +284,23 @@ static void psl_check_property_inst(psl_node_t p)
 
 }
 
-static void psl_check_sequence_inst(psl_node_t p)
+static void psl_check_sequence_inst(psl_node_t p, nametab_t *tab)
 {
+   psl_node_t decl = psl_ref(p);
 
+   int inst_params = psl_operands(p);
+   int decl_params = psl_ports(decl);
+
+   if (inst_params != decl_params) {
+      diag_t *d = diag_new(DIAG_ERROR, psl_loc(p));
+      diag_printf(d, "PSL sequence instance has incorrect number of arguments");
+      diag_hint(d, psl_loc(decl), "sequence declaration has %d argument(s)", decl_params);
+      diag_hint(d, psl_loc(p), "sequence instance has %d argument(s)", inst_params);
+      diag_emit(d);
+   }
+
+   for (int i = 0; i < inst_params; i++)
+      psl_check(psl_operand(p, i), tab);
 }
 
 static void psl_check_sere(psl_node_t p, nametab_t *tab)
@@ -537,7 +551,7 @@ void psl_check(psl_node_t p, nametab_t *tab)
       psl_check_property_inst(p);
       break;
    case P_SEQUENCE_INST:
-      psl_check_sequence_inst(p);
+      psl_check_sequence_inst(p, tab);
       break;
    case P_NEVER:
       psl_check_never(p, tab);

--- a/src/psl/psl-sem.c
+++ b/src/psl/psl-sem.c
@@ -185,7 +185,7 @@ static void psl_check_boolean(psl_node_t p, nametab_t *tab)
                "have type %s", type_pp(type));
 }
 
-static void psl_check_number(psl_node_t p, nametab_t *tab)
+static void psl_check_numeric(psl_node_t p, nametab_t *tab)
 {
    type_t std_int = std_type(NULL, STD_INTEGER);
    tree_t value = solve_types(tab, psl_tree(p), std_int);
@@ -203,7 +203,12 @@ static void psl_check_number(psl_node_t p, nametab_t *tab)
                "type %s", type_pp(type));
       return;
    }
+}
 
+static void psl_check_number(psl_node_t p, nametab_t *tab)
+{
+   psl_check_numeric(p, tab);
+   tree_t value = psl_tree(p);
    psl_check_static(value);
 }
 
@@ -246,13 +251,16 @@ static void psl_check_hdl_expr(psl_node_t p, nametab_t *tab)
       psl_check_boolean(p, tab);
       break;
    case PSL_TYPE_NUMERIC:
-      psl_check_number(p, tab);
+      psl_check_numeric(p, tab);
       break;
    case PSL_TYPE_BIT:
       psl_check_bit(p, tab);
       break;
    case PSL_TYPE_ANY:
       psl_check_any(p, tab);
+      break;
+   case PSL_TYPE_NUMBER:
+      psl_check_number(p, tab);
       break;
    default:
       should_not_reach_here();

--- a/src/sem.c
+++ b/src/sem.c
@@ -3926,6 +3926,7 @@ static bool sem_check_ref(tree_t t, nametab_t *tab)
    case T_PARAM_DECL:
    case T_PACKAGE:
    case T_PACK_INST:
+   case T_PSL_PARAM_DECL:
       break;
 
    case T_CONST_DECL:

--- a/src/tree.c
+++ b/src/tree.c
@@ -389,6 +389,9 @@ static const imask_t has_map[T_LAST_TREE_KIND] = {
 
    // T_CHOICE
    (I_NAME | I_RANGES),
+
+   // T_PSL_PARAM_DECL
+   (I_IDENT | I_TYPE | I_SUBKIND | I_CLASS),
 };
 
 static const char *kind_text_map[T_LAST_TREE_KIND] = {
@@ -432,6 +435,7 @@ static const char *kind_text_map[T_LAST_TREE_KIND] = {
    "T_GUARD",           "T_INERTIAL",        "T_ELEM_RESOLUTION",
    "T_LOOP",            "T_REPORT",          "T_PSL_DIRECT",
    "T_PSL_FCALL",       "T_PSL_UNION",       "T_CHOICE",
+   "T_PSL_PARAM_DECL"
 };
 
 static const change_allowed_t change_allowed[] = {

--- a/src/tree.h
+++ b/src/tree.h
@@ -404,6 +404,7 @@ typedef enum tree_kind {
    T_PSL_FCALL,
    T_PSL_UNION,
    T_CHOICE,
+   T_PSL_PARAM_DECL,
 
    T_LAST_TREE_KIND
 } tree_kind_t;

--- a/test/psl/parse4.vhd
+++ b/test/psl/parse4.vhd
@@ -54,7 +54,7 @@ begin
     -- psl cover p1(a);            -- Error
 
     -- Paramterized SERE
-    -- psl cover {for i in {1 to 3}: && {seq_b(i)}};
+    -- psl cover {for i in {1 to 3}: && {seq_b(2)}};
 
     -- Garbage after PSL directive
     -- psl asfasfa;

--- a/test/regress/gold/psl25.txt
+++ b/test/regress/gold/psl25.txt
@@ -1,0 +1,5 @@
+3500ps+1: seq_with_bit(s_bit) failed
+3500ps+1: seq_with_numeric(42) failed
+3500ps+1: seq_with_numeric(s_num) failed
+3500ps+1: seq_with_vector(s_vect) failed
+3500ps+1: seq_with_hdltype(s_enum) failed

--- a/test/regress/psl25.vhd
+++ b/test/regress/psl25.vhd
@@ -1,0 +1,82 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity psl25 is
+end entity;
+
+architecture tb of psl25 is
+
+    signal clk : natural;
+
+    signal a : bit := '1';
+    signal b : bit := '1';
+    signal c : bit := '1';
+
+    signal s_bit        : bit := '1';
+    signal s_num        : integer := 42;
+    signal s_vect       : bit_vector(3 downto 0) := "1010";
+    signal s_string     : string(1 to 5) := "HELLO";
+
+    type t_enum is (
+        ENUMERATOR_1,
+        ENUMERATOR_2,
+        ENUMERATOR_3,
+        ENUMERATOR_4
+    );
+    signal s_enum       : t_enum := ENUMERATOR_3;
+
+    constant fake_str   : string(1 to 3) := "ABC";
+begin
+
+    process
+    begin
+        wait for 500 ps;
+    	for i in 0 to 3 loop
+        	clk <= clk + 1;
+        	wait for 1 ns;
+        end loop;
+        wait;
+    end process;
+
+    -- psl default clock is clk'event;
+
+    ---------------------------------------------------------------------------
+    -- Sequence declarations
+    ---------------------------------------------------------------------------
+    -- psl sequence seq_with_bit(bit b) is {b = '1';b};
+    -- psl sequence seq_with_numeric(numeric n) is {n = 42;b};
+    -- psl sequence seq_with_vector(bitvector bv) is {bv = "1010";b};
+    -- psl sequence seq_with_string(string s) is {s = "HELLO";b};
+    -- psl sequence seq_with_hdltype(hdltype t_enum hdl) is {hdl = ENUMERATOR_3;b};
+
+    ---------------------------------------------------------------------------
+    -- Assertions - All should fail
+    ---------------------------------------------------------------------------
+
+    -- Should fail at 3500 ps
+    -- psl assert never {a;seq_with_bit(s_bit);c} report "seq_with_bit(s_bit) failed";
+    -- TODO: Passing '1' directly and std_logic fails due to
+    --       "bit" vs "std_logic" resolution
+
+    -- Should fail at 3500 ps
+    -- psl assert never {a;seq_with_numeric(42);c} report "seq_with_numeric(42) failed";
+    -- psl assert never {a;seq_with_numeric(s_num);c} report "seq_with_numeric(s_num) failed";
+
+    -- Should fail at 3500 ps
+    -- psl assert never {a;seq_with_vector(s_vect);c} report "seq_with_vector(s_vect) failed";
+    -- TODO: Passing "1010" or std_logic_vecto fails due to
+    --       "bit_vector" vs "std_logic_vector" resolution
+
+    -- Should fail at 3500 ps
+    -- psl assert never {a;seq_with_hdltype(s_enum);c} report "seq_with_hdltype(s_enum) failed";
+
+    ---------------------------------------------------------------------------
+    -- Assertions - None should fail
+    ---------------------------------------------------------------------------
+    -- psl assert never {seq_with_bit(to_bit('0'));c} report "seq_with_bit(to_bit('0') failed";
+    -- psl assert never {seq_with_numeric(58);c} report "seq_with_numeric(58) failed";
+    -- psl assert never {seq_with_vector(to_bit_vector("1011"));c} report "seq_with_vector(to_bit_vector(1011)) failed";
+    -- psl assert never {seq_with_string(fake_str);c} report "seq_with_string(fake_str) failed";
+    -- psl assert never {seq_with_hdltype(ENUMERATOR_2);c} report "seq_with_hdltype(ENUMERATOR_2) failed";
+
+end architecture;

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -1304,3 +1304,4 @@ ivtest27        verilog
 ivtest28        verilog
 ivtest29        verilog
 issue1505       vhpi,2008
+psl25           psl,2008,gold,fail

--- a/test/test_psl.c
+++ b/test/test_psl.c
@@ -104,6 +104,7 @@ START_TEST(test_sem1)
    const error_t expect[] = {
       { 12, "expression must be a PSL Boolean but have type INTEGER" },
       { 16, "expression must be a PSL Number but have type BIT" },
+      { 16, "expression must be static" },
       { 17, "expression must be static" },
       { 19, "expression must be a PSL Boolean but have type INTEGER" },
       { 20, "property is not in the simple subset as the left hand side of "
@@ -136,6 +137,7 @@ START_TEST(test_sem1)
       { 37, "operand of non-consecutive repetition operator must be Boolean" },
       { 38, "operand of goto repetition operator must be Boolean" },
       { 39, "expression must be a PSL Number but have type BIT" },
+      { 39, "expression must be static" },
       { 40, "no visible declaration for FOO" },
       { 40, "no visible declaration for Z" },
       { 41, "PSL endpoint declarations are not supported" },
@@ -185,7 +187,9 @@ START_TEST(test_parse4)
    input_from_file(TESTDIR "/psl/parse4.vhd");
 
    const error_t expect[] = {
+      { 20, "PSL sequence instance has incorrect number of arguments" },
       { 54, "P1 is not a PSL sequence" },
+      { 54, "PSL sequence instance has incorrect number of arguments" },
       { 60, "unexpected ; while parsing architecture statement part" },
       { -1, NULL }
    };

--- a/www/features.html.in
+++ b/www/features.html.in
@@ -837,12 +837,12 @@ table below.
   <tr>
     <td>6.5.3</td>
     <td>Instantiation</td>
-    <td class="feature-missing"></td>
+    <td class="feature-partial">master</td>
   </tr>
   <tr>
     <td>6.5.3.1</td>
     <td>Sequence instantiation</td>
-    <td class="feature-missing"></td>
+    <td class="feature-partial">master</td>
   </tr>
   <tr>
     <td>6.5.3.2</td>


### PR DESCRIPTION
Hi,

I revived a branch from more than a year ago attempting to implement PSL sequence instances,
and finally managed to do so.

The PSL parsing is extended to parse the argument based on the expected argument type.
Sem-check pass checks if the passed parameter values resolve to the type that the argument shall have.
I split the PSL_TYPE_NUMERIC from PSL_TYPE_NUMBER, since Number needs to be checked to be
constant.
I introduced new T_PSL_PARAM_DECLARATION to separate it from T_PARAM. When sequence is
instantiated, the parameter reference points to the `tree_t` that is being passed.
During PSL FSM build, I added a scoping. A scope is created upon entering PSL sequence instance.
The scope is populated by a hash table that contains mapping between actuals and formals.
All scopes are held in flat list (to be easily de-allocated), as well as hierarchical tree to allow
hierarchical upwards resolving of the actual. This should work hierarchically, e.g. if parameter
is passed across multiple levels of sequence instantinations.
When `psl_lower_param_ref` is called, the parameter is resolved to the `tree_t` being passed.
As the FSM is built, the sequence instance is "inlined" but all states hold a pointer to the scope,
therefore are able to resolve parameter references.

TODOS:
1. [ ] Move the "array coerce" back to the `lower.c` since the coercing can be done there and `lower_coerce_arrays` does not need to be exposed.
2. [ ] Try to simplify the parsing and parse everything as "Sequence" regardless of type.
3. [ ] Correctly resolve literals like `'1'` to be either `std_logic` or `bit`. Now resolved at analysis time, but this needs to be resolved at lower time since that is when the arguments are dereferenced to the actual.