### PR TITLE
vhpi: support multi-dimensional non-homogeneous array signals    

### DIFF
--- a/src/vhpi/vhpi-model.c
+++ b/src/vhpi/vhpi-model.c
@@ -1701,26 +1701,56 @@ static rt_scope_t *vhpi_get_scope_prefixedName(c_prefixedName *pn)
    if (pn->scope)
       return pn->scope;
 
-   rt_scope_t *parent = NULL;
-
-   c_prefixedName *ppn = is_prefixedName(pn->Prefix);
-   if (ppn != NULL)
-      parent = vhpi_get_scope_prefixedName(ppn);
-
-   c_objDecl *od = is_objDecl(pn->Prefix);
-   if (od != NULL)
-      parent = vhpi_get_scope_objDecl(od);
-
-   if (parent == NULL)
-      return NULL;
-
    c_vhpiObject *obj = &(pn->name.expr.object);
    c_indexedName *in = is_indexedName(obj);
    c_selectedName *sn = is_selectedName(obj);
-   if (in != NULL)
-      pn->scope = child_scope_at(parent, in->BaseIndex);
-   else if (sn != NULL)
+
+   if (in != NULL) {
+      // The runtime collapses a multi-dimensional non-homogeneous
+      // array (e.g. `array of array of record`) into one flat
+      // SCOPE_ARRAY whose children are the leaf element scopes —
+      // see lower_sub_signals in lower.c which uses type_elem_recur
+      // and the total flat length.  Walk past any consecutive
+      // indexedName ancestors to the anchor scope and index directly
+      // using this indexedName's cumulative offset divided by the
+      // element type's numElems.
+      c_vhpiObject *anchor = pn->Prefix;
+      c_prefixedName *ancestor = is_prefixedName(anchor);
+      while (ancestor != NULL && is_indexedName(anchor) != NULL) {
+         anchor = ancestor->Prefix;
+         ancestor = is_prefixedName(anchor);
+      }
+
+      rt_scope_t *anchor_scope = NULL;
+      c_objDecl *od = is_objDecl(anchor);
+      if (od != NULL)
+         anchor_scope = vhpi_get_scope_objDecl(od);
+      else if (ancestor != NULL)
+         anchor_scope = vhpi_get_scope_prefixedName(ancestor);
+
+      if (anchor_scope == NULL)
+         return NULL;
+
+      c_typeDecl *td = pn->name.expr.Type;
+      const vhpiIntT div = td->numElems > 0 ? td->numElems : 1;
+      pn->scope = child_scope_at(anchor_scope, in->offset / div);
+   }
+   else if (sn != NULL) {
+      rt_scope_t *parent = NULL;
+      c_prefixedName *ppn = is_prefixedName(pn->Prefix);
+      if (ppn != NULL)
+         parent = vhpi_get_scope_prefixedName(ppn);
+      else {
+         c_objDecl *od = is_objDecl(pn->Prefix);
+         if (od != NULL)
+            parent = vhpi_get_scope_objDecl(od);
+      }
+
+      if (parent == NULL)
+         return NULL;
+
       pn->scope = child_scope(parent, sn->Suffix->decl.tree);
+   }
    else
       fatal_trace("class kind %s not supported in %s",
                   vhpi_class_str(obj->kind), __func__);

--- a/test/dist.mk
+++ b/test/dist.mk
@@ -2199,6 +2199,7 @@ EXTRA_DIST += \
 	test/regress/vhpi17.vhd \
 	test/regress/vhpi18.vhd \
 	test/regress/vhpi19.vhd \
+	test/regress/vhpi20.vhd \
 	test/regress/vhpi1.vhd \
 	test/regress/vhpi2.vhd \
 	test/regress/vhpi3.vhd \

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -1265,6 +1265,7 @@ vhpi18          vhpi,2008
 issue1424       normal,gold,2019
 issue1428       vhpi,2008
 vhpi19          vhpi
+vhpi20          vhpi,2008
 issue1433       shell
 reflect6        normal,2019
 vlog32          verilog

--- a/test/regress/vhpi20.vhd
+++ b/test/regress/vhpi20.vhd
@@ -1,0 +1,22 @@
+package pack is
+    type cplx_t is record
+        r : bit_vector;
+        i : bit_vector;
+    end record;
+    type cplx_arr_t is array (natural range <>) of cplx_t;
+    type cplx_2d_t  is array (natural range <>) of cplx_arr_t;
+    type cplx_3d_t  is array (natural range <>) of cplx_2d_t;
+end package;
+
+-------------------------------------------------------------------------------
+
+use work.pack.all;
+
+entity vhpi20 is
+end entity;
+
+architecture test of vhpi20 is
+    signal x : cplx_3d_t(0 to 1)(0 to 1)(0 to 1)
+                        (r(7 downto 0), i(7 downto 0));
+begin
+end architecture;

--- a/test/regress/vhpi20.vhd
+++ b/test/regress/vhpi20.vhd
@@ -3,9 +3,16 @@ package pack is
         r : bit_vector;
         i : bit_vector;
     end record;
+
+    -- Pre-VHDL-2008: nested array types (array of array of ...)
     type cplx_arr_t is array (natural range <>) of cplx_t;
     type cplx_2d_t  is array (natural range <>) of cplx_arr_t;
     type cplx_3d_t  is array (natural range <>) of cplx_2d_t;
+
+    -- VHDL-2008: native multi-dimensional array types
+    type cplx_mat_t  is array (natural range <>, natural range <>) of cplx_t;
+    type slv_arr_t   is array (natural range <>) of bit_vector;
+    type slv_mat_t   is array (natural range <>, natural range <>) of bit_vector;
 end package;
 
 -------------------------------------------------------------------------------
@@ -16,7 +23,14 @@ entity vhpi20 is
 end entity;
 
 architecture test of vhpi20 is
+    -- Pre-VHDL-2008 nested 3-D array of record
     signal x : cplx_3d_t(0 to 1)(0 to 1)(0 to 1)
                         (r(7 downto 0), i(7 downto 0));
+    -- Native VHDL-2008 2-D array of record
+    signal y : cplx_mat_t(0 to 1, 0 to 1)(r(7 downto 0), i(7 downto 0));
+    -- Pre-VHDL-2008 1-D array of raw SLV (homogeneous)
+    signal z : slv_arr_t(0 to 3)(7 downto 0);
+    -- Native VHDL-2008 2-D array of raw SLV (homogeneous)
+    signal w : slv_mat_t(0 to 1, 0 to 1)(7 downto 0);
 begin
 end architecture;

--- a/test/vhpi/Makemodule.am
+++ b/test/vhpi/Makemodule.am
@@ -38,6 +38,7 @@ lib_vhpi_test_so_SOURCES = \
 	test/vhpi/vhpi18.c \
 	test/vhpi/issue1428.c \
 	test/vhpi/vhpi19.c \
+	test/vhpi/vhpi20.c \
 	test/vhpi/issue1463.c \
 	test/vhpi/issue1473.c \
 	test/vhpi/issue1505.c

--- a/test/vhpi/vhpi20.c
+++ b/test/vhpi/vhpi20.c
@@ -1,0 +1,61 @@
+#include "vhpi_test.h"
+
+#include <string.h>
+
+static void start_of_sim(const vhpiCbDataT *cb_data)
+{
+   vhpiHandleT root = VHPI_CHECK(vhpi_handle(vhpiRootInst, NULL));
+
+   vhpiHandleT x = VHPI_CHECK(vhpi_handle_by_name("x", root));
+
+   // Drill into x(1)(1)(1).r — exercises flat scope index 7 of 8 children
+   vhpiHandleT x1 = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, x, 1));
+   vhpiHandleT x11 = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, x1, 1));
+   vhpiHandleT x111 = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, x11, 1));
+
+   vhpiHandleT x111r = VHPI_CHECK(vhpi_handle_by_name("r", x111));
+
+   vhpiValueT value = {
+      .format = vhpiBinStrVal,
+   };
+   vhpiCharT buf[16];
+   value.bufSize = sizeof(buf);
+   value.value.str = buf;
+   VHPI_CHECK(vhpi_get_value(x111r, &value));
+   vhpi_printf("x(1)(1)(1).r = '%s'", (char *)buf);
+
+   vhpiEnumT bits[] = { 1, 0, 1, 0, 1, 0, 1, 0 };
+   value.format = vhpiLogicVecVal;
+   value.value.enumvs = bits;
+   value.bufSize = sizeof(bits);
+   VHPI_CHECK(vhpi_put_value(x111r, &value, vhpiDepositPropagate));
+
+   // And x(0)(1)(0).r — exercises flat scope index 2
+   vhpiHandleT x0 = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, x, 0));
+   vhpiHandleT x01 = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, x0, 1));
+   vhpiHandleT x010 = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, x01, 0));
+   vhpiHandleT x010r = VHPI_CHECK(vhpi_handle_by_name("r", x010));
+
+   VHPI_CHECK(vhpi_get_value(x010r, &value));
+   vhpi_printf("x(0)(1)(0).r = '%s'", (char *)buf);
+
+   vhpi_release_handle(x010r);
+   vhpi_release_handle(x010);
+   vhpi_release_handle(x01);
+   vhpi_release_handle(x0);
+   vhpi_release_handle(x111r);
+   vhpi_release_handle(x111);
+   vhpi_release_handle(x11);
+   vhpi_release_handle(x1);
+   vhpi_release_handle(x);
+   vhpi_release_handle(root);
+}
+
+void vhpi20_startup(void)
+{
+   vhpiCbDataT cb_data = {
+      .reason = vhpiCbStartOfSimulation,
+      .cb_rtn = start_of_sim,
+   };
+   VHPI_CHECK(vhpi_register_cb(&cb_data, 0));
+}

--- a/test/vhpi/vhpi20.c
+++ b/test/vhpi/vhpi20.c
@@ -6,48 +6,154 @@ static void start_of_sim(const vhpiCbDataT *cb_data)
 {
    vhpiHandleT root = VHPI_CHECK(vhpi_handle(vhpiRootInst, NULL));
 
-   vhpiHandleT x = VHPI_CHECK(vhpi_handle_by_name("x", root));
+   // -----------------------------------------------------------------------
+   // x: pre-VHDL-2008 nested 3-D array of record (cplx_3d_t)
+   // Exercises multi-level indexedName chaining for non-homogeneous arrays.
+   // -----------------------------------------------------------------------
+   {
+      vhpiHandleT x = VHPI_CHECK(vhpi_handle_by_name("x", root));
 
-   // Drill into x(1)(1)(1).r — exercises flat scope index 7 of 8 children
-   vhpiHandleT x1 = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, x, 1));
-   vhpiHandleT x11 = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, x1, 1));
-   vhpiHandleT x111 = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, x11, 1));
+      // x(1)(1)(1).r — flat leaf index 7 of 8
+      vhpiHandleT x1   = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, x, 1));
+      vhpiHandleT x11  = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, x1, 1));
+      vhpiHandleT x111 = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, x11, 1));
+      vhpiHandleT x111r = VHPI_CHECK(vhpi_handle_by_name("r", x111));
 
-   vhpiHandleT x111r = VHPI_CHECK(vhpi_handle_by_name("r", x111));
+      vhpiValueT value = { .format = vhpiBinStrVal };
+      vhpiCharT buf[16];
+      value.bufSize = sizeof(buf);
+      value.value.str = buf;
+      VHPI_CHECK(vhpi_get_value(x111r, &value));
+      vhpi_printf("x(1)(1)(1).r = '%s'", (char *)buf);
 
-   vhpiValueT value = {
-      .format = vhpiBinStrVal,
-   };
-   vhpiCharT buf[16];
-   value.bufSize = sizeof(buf);
-   value.value.str = buf;
-   VHPI_CHECK(vhpi_get_value(x111r, &value));
-   vhpi_printf("x(1)(1)(1).r = '%s'", (char *)buf);
+      vhpiEnumT bits[] = { 1, 0, 1, 0, 1, 0, 1, 0 };
+      value.format = vhpiLogicVecVal;
+      value.value.enumvs = bits;
+      value.bufSize = sizeof(bits);
+      VHPI_CHECK(vhpi_put_value(x111r, &value, vhpiDepositPropagate));
 
-   vhpiEnumT bits[] = { 1, 0, 1, 0, 1, 0, 1, 0 };
-   value.format = vhpiLogicVecVal;
-   value.value.enumvs = bits;
-   value.bufSize = sizeof(bits);
-   VHPI_CHECK(vhpi_put_value(x111r, &value, vhpiDepositPropagate));
+      // x(0)(1)(0).r — flat leaf index 2
+      vhpiHandleT x0   = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, x, 0));
+      vhpiHandleT x01  = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, x0, 1));
+      vhpiHandleT x010 = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, x01, 0));
+      vhpiHandleT x010r = VHPI_CHECK(vhpi_handle_by_name("r", x010));
 
-   // And x(0)(1)(0).r — exercises flat scope index 2
-   vhpiHandleT x0 = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, x, 0));
-   vhpiHandleT x01 = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, x0, 1));
-   vhpiHandleT x010 = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, x01, 0));
-   vhpiHandleT x010r = VHPI_CHECK(vhpi_handle_by_name("r", x010));
+      value.format = vhpiBinStrVal;
+      value.bufSize = sizeof(buf);
+      value.value.str = buf;
+      VHPI_CHECK(vhpi_get_value(x010r, &value));
+      vhpi_printf("x(0)(1)(0).r = '%s'", (char *)buf);
 
-   VHPI_CHECK(vhpi_get_value(x010r, &value));
-   vhpi_printf("x(0)(1)(0).r = '%s'", (char *)buf);
+      vhpi_release_handle(x010r);
+      vhpi_release_handle(x010);
+      vhpi_release_handle(x01);
+      vhpi_release_handle(x0);
+      vhpi_release_handle(x111r);
+      vhpi_release_handle(x111);
+      vhpi_release_handle(x11);
+      vhpi_release_handle(x1);
+      vhpi_release_handle(x);
+   }
 
-   vhpi_release_handle(x010r);
-   vhpi_release_handle(x010);
-   vhpi_release_handle(x01);
-   vhpi_release_handle(x0);
-   vhpi_release_handle(x111r);
-   vhpi_release_handle(x111);
-   vhpi_release_handle(x11);
-   vhpi_release_handle(x1);
-   vhpi_release_handle(x);
+   // -----------------------------------------------------------------------
+   // y: native VHDL-2008 2-D array of record (cplx_mat_t(0 to 1, 0 to 1))
+   // vhpiIndexedNames expands all dimension combinations into a flat list;
+   // a single vhpi_handle_by_index call reaches any element directly.
+   // -----------------------------------------------------------------------
+   {
+      vhpiHandleT y = VHPI_CHECK(vhpi_handle_by_name("y", root));
+
+      // Flat list order (row-major): (0,0)=0  (0,1)=1  (1,0)=2  (1,1)=3
+      // y(0,1).i — list position 1
+      vhpiHandleT y01  = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, y, 1));
+      vhpiHandleT y01i = VHPI_CHECK(vhpi_handle_by_name("i", y01));
+
+      vhpiValueT value = { .format = vhpiBinStrVal };
+      vhpiCharT buf[16];
+      value.bufSize = sizeof(buf);
+      value.value.str = buf;
+      VHPI_CHECK(vhpi_get_value(y01i, &value));
+      vhpi_printf("y(0,1).i = '%s'", (char *)buf);
+
+      vhpiEnumT bits[] = { 0, 0, 0, 0, 1, 1, 1, 1 };
+      value.format = vhpiLogicVecVal;
+      value.value.enumvs = bits;
+      value.bufSize = sizeof(bits);
+      VHPI_CHECK(vhpi_put_value(y01i, &value, vhpiDepositPropagate));
+
+      // y(1,0).r — list position 2
+      vhpiHandleT y10  = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, y, 2));
+      vhpiHandleT y10r = VHPI_CHECK(vhpi_handle_by_name("r", y10));
+
+      value.format = vhpiBinStrVal;
+      value.bufSize = sizeof(buf);
+      value.value.str = buf;
+      VHPI_CHECK(vhpi_get_value(y10r, &value));
+      vhpi_printf("y(1,0).r = '%s'", (char *)buf);
+
+      vhpi_release_handle(y10r);
+      vhpi_release_handle(y10);
+      vhpi_release_handle(y01i);
+      vhpi_release_handle(y01);
+      vhpi_release_handle(y);
+   }
+
+   // -----------------------------------------------------------------------
+   // z: pre-VHDL-2008 1-D array of raw bit_vector (slv_arr_t(0 to 3))
+   // Homogeneous: the whole signal is one flat signal; offset arithmetic
+   // selects the element without a scope lookup.
+   // -----------------------------------------------------------------------
+   {
+      vhpiHandleT z = VHPI_CHECK(vhpi_handle_by_name("z", root));
+
+      // z(2) — list position 2
+      vhpiHandleT z2 = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, z, 2));
+
+      vhpiValueT value = { .format = vhpiBinStrVal };
+      vhpiCharT buf[16];
+      value.bufSize = sizeof(buf);
+      value.value.str = buf;
+      VHPI_CHECK(vhpi_get_value(z2, &value));
+      vhpi_printf("z(2) = '%s'", (char *)buf);
+
+      vhpiEnumT bits[] = { 1, 1, 0, 0, 0, 0, 1, 1 };
+      value.format = vhpiLogicVecVal;
+      value.value.enumvs = bits;
+      value.bufSize = sizeof(bits);
+      VHPI_CHECK(vhpi_put_value(z2, &value, vhpiDepositPropagate));
+
+      vhpi_release_handle(z2);
+      vhpi_release_handle(z);
+   }
+
+   // -----------------------------------------------------------------------
+   // w: native VHDL-2008 2-D array of raw bit_vector (slv_mat_t(0 to 1, 0 to 1))
+   // Combines native multi-dim indexing with homogeneous (SLV) element access.
+   // -----------------------------------------------------------------------
+   {
+      vhpiHandleT w = VHPI_CHECK(vhpi_handle_by_name("w", root));
+
+      // Flat list order: (0,0)=0  (0,1)=1  (1,0)=2  (1,1)=3
+      // w(1,1) — list position 3
+      vhpiHandleT w11 = VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, w, 3));
+
+      vhpiValueT value = { .format = vhpiBinStrVal };
+      vhpiCharT buf[16];
+      value.bufSize = sizeof(buf);
+      value.value.str = buf;
+      VHPI_CHECK(vhpi_get_value(w11, &value));
+      vhpi_printf("w(1,1) = '%s'", (char *)buf);
+
+      vhpiEnumT bits[] = { 0, 1, 0, 1, 0, 1, 0, 1 };
+      value.format = vhpiLogicVecVal;
+      value.value.enumvs = bits;
+      value.bufSize = sizeof(bits);
+      VHPI_CHECK(vhpi_put_value(w11, &value, vhpiDepositPropagate));
+
+      vhpi_release_handle(w11);
+      vhpi_release_handle(w);
+   }
+
    vhpi_release_handle(root);
 }
 

--- a/test/vhpi/vhpi_test.c
+++ b/test/vhpi/vhpi_test.c
@@ -61,6 +61,7 @@ static const vhpi_test_t tests[] = {
    { "vhpi18",    vhpi18_startup },
    { "issue1428", issue1428_startup },
    { "vhpi19",    vhpi19_startup },
+   { "vhpi20",    vhpi20_startup },
    { "issue1463", issue1463_startup },
    { "issue1473", issue1473_startup },
    { "issue1505", issue1505_startup },

--- a/test/vhpi/vhpi_test.h
+++ b/test/vhpi/vhpi_test.h
@@ -59,6 +59,7 @@ void vhpi16_startup(void);
 void vhpi17_startup(void);
 void vhpi18_startup(void);
 void vhpi19_startup(void);
+void vhpi20_startup(void);
 void issue744_startup(void);
 void issue762_startup(void);
 void issue978_startup(void);


### PR DESCRIPTION
                                                                                                                                                                                                                      
  Add VHPI support for drilling into signals whose type is a
  multi-dimensional `array of … of array of record` (or any other
  non-homogeneous element). Previously `vhpi_get_value` /                                                                                                                                                                                         
  `vhpi_put_value` on `dut.X(0)(0)(0).r` SIGSEGV'd inside                                                                                                                                                                                         
  `child_scope_at`, because the runtime represents every dimension as                                                                                                                                                                             
  a single flat `SCOPE_ARRAY` of leaf-element scopes (see                                                                                                                                                                                         
  `lower_sub_signals` — `type_elem_recur` + total flat length), but                                                                                                                                                                               
  `vhpi_get_scope_prefixedName` was walking one dimension at a time                                                                                                                                                                               
  and trying to `child_scope_at` into intermediate sub-scopes that                                                                                                                                                                                
  don't exist.                                                                                                                                                                                                                                    
                                                                                                                                                                                                                              
                  
  When resolving the scope of a `c_indexedName`, skip past any                                                                                                                                                                                    
  consecutive `c_indexedName` ancestors to the anchor (the outer
  `objDecl` or `selectedName`) and index that anchor's scope once,                                                                                                                                                                                
  using this indexedName's cumulative `offset` divided by the leaf                                                                                                                                                                                
  type's `numElems`. The same formula gives the right index for any
  depth, and reduces to `BaseIndex` in the existing 1-D case                                                                                                                                                                                      
  (`offset = BaseIndex * numElems`).                                                                                                                                                                                                              
                                                                                                                                                                                                                                                  
  `c_selectedName` handling is unchanged; the recursion split keeps                                                                                                                                                                               
  indexed/selected on independent paths.
                                                                                                                                                                                                                                                  
  ## Test         
                                                                                                                                                                                                                                                  
  `test/regress/vhpi20.vhd` declares a 2×2×2 `array of array of array
  of record` signal. `test/vhpi/vhpi20.c` round-trips both
  `vhpi_get_value` and `vhpi_put_value` on:                                                                                                                                                                                                       
   
  - `x(1)(1)(1).r` — flat scope index 7 of 8                                                                                                                                                                                                      
  - `x(0)(1)(0).r` — flat scope index 2 of 8
                                                                                                                                                                                                                                                  
  On master the first `vhpi_get_value` segfaults in `child_scope_at`;                                                                                                                                                                             
  with this change both succeed.