### PR TITLE
fix implicit loop labeling and nametab scope for loop labels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 - Fixed several bugs related to concatenating arrays-of-arrays (#1534,
   #1539)
 - Several other minor bugs were resolved (#1506, #1516, #1522, #1529,
-  #1541, #1544, #1543, #1528, #1503, #1475, #1535).
+  #1541, #1544, #1543, #1528, #1503, #1475, #1535. #1517).
 
 ## Version 1.20.1 - 2026-04-22
 - Fix a crash while evaluating matching relational operator with

--- a/src/parse.c
+++ b/src/parse.c
@@ -10201,25 +10201,18 @@ static void p_parameter_specification(tree_t loop, tree_kind_t pkind)
    insert_name(nametab, param, NULL);
 }
 
-static tree_t p_iteration_scheme(void)
+static void p_iteration_scheme(tree_t t)
 {
    // while condition | for parameter_specification
 
    BEGIN("iteration scheme");
 
-   if (optional(tWHILE)) {
-      tree_t t = tree_new(T_WHILE);
+   if (optional(tWHILE))
       tree_set_value(t, p_condition());
-      return t;
-   }
    else if (optional(tFOR)) {
-      tree_t t = tree_new(T_FOR);
       scope_set_container(nametab, t);
       p_parameter_specification(t, T_PARAM_DECL);
-      return t;
    }
-   else
-      return tree_new(T_LOOP);
 }
 
 static tree_t p_loop_statement(ident_t label)
@@ -10229,18 +10222,27 @@ static tree_t p_loop_statement(ident_t label)
 
    BEGIN("loop statement");
 
+   tree_t t;
+   if (scan(tWHILE))
+      t = tree_new(T_WHILE);
+   else if (scan(tFOR))
+      t = tree_new(T_FOR);
+   else
+      t = tree_new(T_LOOP);
+
+   // Need to put loop name to parent scope, but loop must be parsed in
+   // child scope since loop variable hiding is legal.
+   ensure_labelled(t, label);
+   if (label != NULL)
+      insert_name(nametab, t, NULL);
+
    push_scope(nametab);
 
-   tree_t t = p_iteration_scheme();
+   p_iteration_scheme(t);
 
    consume(tLOOP);
 
    scope_set_container(nametab, t);
-   set_label_and_loc(t, label, CURRENT_LOC);
-
-   if (label != NULL)
-      insert_name(nametab, t, NULL);
-
    sem_check(t, nametab);
 
    p_sequence_of_statements(t);
@@ -10251,7 +10253,6 @@ static tree_t p_loop_statement(ident_t label)
    consume(tSEMI);
 
    pop_scope(nametab);
-
    tree_set_loc(t, CURRENT_LOC);
    return t;
 }

--- a/src/parse.c
+++ b/src/parse.c
@@ -10201,18 +10201,39 @@ static void p_parameter_specification(tree_t loop, tree_kind_t pkind)
    insert_name(nametab, param, NULL);
 }
 
-static void p_iteration_scheme(tree_t t)
+static tree_t p_iteration_scheme(ident_t label)
 {
    // while condition | for parameter_specification
 
    BEGIN("iteration scheme");
 
-   if (optional(tWHILE))
-      tree_set_value(t, p_condition());
-   else if (optional(tFOR)) {
-      scope_set_container(nametab, t);
-      p_parameter_specification(t, T_PARAM_DECL);
+   tree_kind_t kind = T_LOOP;
+   if (peek() != tLOOP) {
+      switch (one_of(tWHILE, tFOR)) {
+      case tWHILE: kind = T_WHILE; break;
+      case tFOR:   kind = T_FOR; break;
+      default:     kind = T_LOOP; break;
+      }
    }
+
+   tree_t t = tree_new(kind);
+   set_label_and_loc(t, label, CURRENT_LOC);
+
+   push_scope(nametab);
+   scope_set_container(nametab, t);
+
+   switch (kind) {
+   case T_WHILE:
+      tree_set_value(t, p_condition());
+      break;
+   case T_FOR:
+      p_parameter_specification(t, T_PARAM_DECL);
+      break;
+   default:
+      break;
+   }
+
+   return t;
 }
 
 static tree_t p_loop_statement(ident_t label)
@@ -10222,37 +10243,26 @@ static tree_t p_loop_statement(ident_t label)
 
    BEGIN("loop statement");
 
-   tree_t t;
-   if (scan(tWHILE))
-      t = tree_new(T_WHILE);
-   else if (scan(tFOR))
-      t = tree_new(T_FOR);
-   else
-      t = tree_new(T_LOOP);
-
-   // Need to put loop name to parent scope, but loop must be parsed in
-   // child scope since loop variable hiding is legal.
-   ensure_labelled(t, label);
-   if (label != NULL)
-      insert_name(nametab, t, NULL);
-
-   push_scope(nametab);
-
-   p_iteration_scheme(t);
+   tree_t t = p_iteration_scheme(label);
 
    consume(tLOOP);
 
-   scope_set_container(nametab, t);
+   if (label != NULL)
+      insert_name(nametab, t, NULL);
+
    sem_check(t, nametab);
 
    p_sequence_of_statements(t);
 
    consume(tEND);
    consume(tLOOP);
+
    p_trailing_label(label);
+
    consume(tSEMI);
 
    pop_scope(nametab);
+
    tree_set_loc(t, CURRENT_LOC);
    return t;
 }

--- a/test/regress/gold/issue1517.xml
+++ b/test/regress/gold/issue1517.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<scope name="WORK">
+  <scope name="ISSUE1517" block_name="ISSUE1517-TEST" file="issue1517.vhd" line="4">
+    <scope name="_P0" line="6">
+      <scope name="_L0" line="8">
+        <statement hier="WORK.ISSUE1517._P0._L0" data="1"/>
+        <scope name="_S0" line="9">
+          <statement hier="WORK.ISSUE1517._P0._L0._S0" data="3"/>
+        </scope>
+      </scope>
+      <scope name="_L1" line="11">
+        <statement hier="WORK.ISSUE1517._P0._L1" data="1"/>
+        <scope name="_S0" line="12">
+          <statement hier="WORK.ISSUE1517._P0._L1._S0" data="4"/>
+        </scope>
+      </scope>
+      <scope name="_S2" line="14">
+        <statement hier="WORK.ISSUE1517._P0._S2" data="1"/>
+      </scope>
+    </scope>
+  </scope>
+</scope>

--- a/test/regress/issue1517.vhd
+++ b/test/regress/issue1517.vhd
@@ -1,0 +1,16 @@
+entity issue1517 is
+end entity;
+
+architecture test of issue1517 is
+begin
+    process
+    begin
+        for i in 0 to 2 loop
+            report "FIRST LOOP";
+        end loop;
+        for i in 0 to 3 loop
+            report "SECOND LOOP";
+        end loop;
+        wait;
+    end process;
+end architecture;

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -1390,3 +1390,4 @@ ivtest53        verilog
 real12          verilog,gold
 ivtest54        verilog
 udp2            verilog,gold
+issue1517       cover=statement


### PR DESCRIPTION
Fixes #1517

A bug in the parser was causing that multiple consecutive loops had the same implicit loop label since the
label was placed to the child nametab scope belonging to the loop, rather than to the parent scope.
The issue manifestated in code coverage where multiple coverage items with the same name were emitted,
causing conflicts and lower code coverage than reality (see the referenced issue).

A side effect of this was, that e.g. following code was accepted as valid:
```
loop_a : for i in 0 to 5 loop
   ...
end loop;
loop_a : for j in 0 to 1 loop
   ...
end loop;
```