### PR TITLE
fail gracefully in resolve_record_ref_or_call upon referencing library.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 - Fixed several bugs related to concatenating arrays-of-arrays (#1534,
   #1539)
 - Several other minor bugs were resolved (#1506, #1516, #1522, #1529,
-  #1541, #1544, #1543, #1528, #1503, #1475).
+  #1541, #1544, #1543, #1528, #1503, #1475, #1535).
 
 ## Version 1.20.1 - 2026-04-22
 - Fix a crash while evaluating matching relational operator with

--- a/src/names.c
+++ b/src/names.c
@@ -2295,6 +2295,10 @@ static tree_t resolve_record_ref_or_call(nametab_t *tab, tree_t t, bool pcall)
       return NULL;
 
    tree_t prefix = solve_types(tab, tree_value(t), NULL);
+
+   if (get_library_ref(prefix) != NULL)
+      return NULL;
+
    tree_set_value(t, (prefix = implicit_dereference(tab, prefix)));
 
    tree_t decl = get_container_ref(prefix);

--- a/src/names.c
+++ b/src/names.c
@@ -2530,11 +2530,15 @@ tree_t resolve_pcall(nametab_t *tab, tree_t name)
       }
    case T_REF:
       {
-         tree_t call = tree_new(T_PCALL);
-         tree_set_ident2(call, tree_ident(name));
-         tree_set_loc(call, tree_loc(name));
+         const symbol_t *sym = iterate_symbol_for(tab, tree_ident(name));
+         if (sym == NULL || (sym->mask & N_OVERLOAD)) {
+            tree_t call = tree_new(T_PCALL);
+            tree_set_ident2(call, tree_ident(name));
+            tree_set_loc(call, tree_loc(name));
+            return call;
+         }
 
-         return call;
+         return NULL;
       }
    case T_FCALL:
       {
@@ -2555,6 +2559,9 @@ tree_t resolve_pcall(nametab_t *tab, tree_t name)
 
          return call;
       }
+   case T_PCALL:
+   case T_PROT_PCALL:
+      return name;
    default:
       return NULL;
    }

--- a/src/parse.c
+++ b/src/parse.c
@@ -13182,6 +13182,38 @@ static tree_t p_psl_or_concurrent_assert(ident_t label)
    return conc;
 }
 
+static bool is_component_instantiation_statement(ident_t label)
+{
+   const token_t p2 = peek_nth(2);
+
+   if (label == NULL)
+      return false;
+
+   if (p2 == tSEMI || p2 == tGENERIC || p2 == tPORT)
+      return true;
+
+   if (p2 != tDOT)
+      return false;
+
+   const token_t p4 = peek_nth(4);
+   const token_t p6 = peek_nth(6);
+   const token_t p7 = peek_nth(7);
+   bool rv = false;
+
+   if (p4 == tSEMI || p4 == tGENERIC || p4 == tPORT || p4 == tEOF)
+      rv = true;
+
+   if (p4 == tLPAREN && p6 == tRPAREN &&
+       (p7 == tSEMI || p7 == tGENERIC || p7 == tPORT || p7 == tEOF))
+      rv = true;
+
+   if (rv)
+      parse_error(CURRENT_LOC,
+                  "missing 'entity' keyword in entity binding indication.");
+
+   return rv;
+}
+
 static tree_t p_concurrent_statement(void)
 {
    // block_statement | process_statement | concurrent_procedure_call_statement
@@ -13233,8 +13265,7 @@ static tree_t p_concurrent_statement(void)
 
    case tID:
       {
-         const token_t p2 = peek_nth(2);
-         if ((label != NULL && p2 == tSEMI) || p2 == tGENERIC || p2 == tPORT)
+         if (is_component_instantiation_statement(label))
             return p_component_instantiation_statement(label, NULL);
          else {
             tree_t name = p_name(N_SUBPROGRAM), conc;

--- a/src/parse.c
+++ b/src/parse.c
@@ -10706,6 +10706,8 @@ static tree_t p_instantiated_unit(tree_t name)
          tree_set_ident2(t, tree_ident(name));
          if (tree_has_ref(name))
             tree_set_ref(t, tree_ref(name));
+         else
+            suppress_errors(nametab);
       }
       else {
          parse_error(tree_loc(name), "invalid instantiated unit name");
@@ -13182,38 +13184,6 @@ static tree_t p_psl_or_concurrent_assert(ident_t label)
    return conc;
 }
 
-static bool is_component_instantiation_statement(ident_t label)
-{
-   const token_t p2 = peek_nth(2);
-
-   if (label == NULL)
-      return false;
-
-   if (p2 == tSEMI || p2 == tGENERIC || p2 == tPORT)
-      return true;
-
-   if (p2 != tDOT)
-      return false;
-
-   const token_t p4 = peek_nth(4);
-   const token_t p6 = peek_nth(6);
-   const token_t p7 = peek_nth(7);
-   bool rv = false;
-
-   if (p4 == tSEMI || p4 == tGENERIC || p4 == tPORT || p4 == tEOF)
-      rv = true;
-
-   if (p4 == tLPAREN && p6 == tRPAREN &&
-       (p7 == tSEMI || p7 == tGENERIC || p7 == tPORT || p7 == tEOF))
-      rv = true;
-
-   if (rv)
-      parse_error(CURRENT_LOC,
-                  "missing 'entity' keyword in entity binding indication.");
-
-   return rv;
-}
-
 static tree_t p_concurrent_statement(void)
 {
    // block_statement | process_statement | concurrent_procedure_call_statement
@@ -13265,39 +13235,22 @@ static tree_t p_concurrent_statement(void)
 
    case tID:
       {
-         if (is_component_instantiation_statement(label))
-            return p_component_instantiation_statement(label, NULL);
-         else {
-            tree_t name = p_name(N_SUBPROGRAM), conc;
-            if (peek() == tLE)
-               return p_concurrent_signal_assignment_statement(label, name);
-            else if (scan(tGENERIC, tPORT))
-               return p_component_instantiation_statement(label, name);
-            else {
-               switch (tree_kind(name)) {
-               case T_REF:
-                  if (tree_has_ref(name)) {
-                     tree_t decl = tree_ref(name);
-                     if (tree_kind(decl) == T_COMPONENT)
-                        return p_component_instantiation_statement(label, name);
-                  }
-                  // Fall-through
-               case T_PROT_REF:
-               case T_RECORD_REF:
-               case T_ARRAY_REF:
-               case T_ARRAY_SLICE:
-               case T_FCALL:
-               case T_PROT_FCALL:
-                  return p_concurrent_procedure_call_statement(label, name);
-               default:
-                  parse_error(CURRENT_LOC, "expected concurrent statement");
-                  drop_tokens_until(&state, tSEMI);
-                  return ensure_labelled(tree_new(T_CONCURRENT), label);
-               }
-            }
-
-            return conc;
+         tree_t name = p_name(N_SUBPROGRAM);
+         switch (peek()) {
+         case tLE:
+            return p_concurrent_signal_assignment_statement(label, name);
+         case tGENERIC:
+         case tPORT:
+            return p_component_instantiation_statement(label, name);
+         case tLPAREN:
+            return p_concurrent_procedure_call_statement(label, name);
          }
+
+         tree_t call = resolve_pcall(nametab, name);
+         if (call == NULL)
+            return p_component_instantiation_statement(label, name);
+         else
+            return p_concurrent_procedure_call_statement(label, call);
       }
 
    case tPOSTPONED:

--- a/test/parse/issue1535.vhd
+++ b/test/parse/issue1535.vhd
@@ -13,5 +13,17 @@ end entity;
 
 architecture rtl of issue1535 is
 begin
-  i_test : work.sub;
+  i_test : work.sub;                    -- Error
+end architecture;
+
+package pack is
+    procedure proc;
+end package;
+
+use work.pack;
+
+architecture pcall of issue1535 is
+begin
+    x: pack.proc;                       -- OK
+    y : work.pack;                      -- Error
 end architecture;

--- a/test/parse/issue1535.vhd
+++ b/test/parse/issue1535.vhd
@@ -1,7 +1,17 @@
-entity test is
+entity sub is
 end entity;
 
-architecture rtl of test is
+architecture test of sub is
 begin
-  i_test : work.test1;
+end architecture;
+
+library work;
+use work.sub;
+
+entity issue1535 is
+end entity;
+
+architecture rtl of issue1535 is
+begin
+  i_test : work.sub;
 end architecture;

--- a/test/parse/issue1535.vhd
+++ b/test/parse/issue1535.vhd
@@ -1,0 +1,7 @@
+entity test is
+end entity;
+
+architecture rtl of test is
+begin
+  i_test : work.test1;
+end architecture;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -3445,8 +3445,8 @@ START_TEST(test_issue388)
 
    const error_t expect[] = {
       { 11, "unexpected => while parsing slice name, expecting one of" },
-      { 12, "invalid procedure call" },
-      { 14, "no visible subprogram declaration for CALL" },
+      { 12, "invalid instantiated unit name" },
+      { 12, "unexpected => while parsing component instantiation statement" },
       { -1, NULL }
    };
    expect_errors(expect);
@@ -3494,7 +3494,7 @@ START_TEST(test_names)
       {   0, "no implicit conversion was performed on the first argument" },
       { 106, "type of string literal cannot be determined from the" },
       {   0, "could be BIT_VECTOR or STRING" },
-      { 107, "no visible subprogram declaration for V" },
+      { 107, "invalid procedure call statement" },
       { 108, "no visible subprogram declaration for FOO" },
       { 222, "ambiguous use of name FOO" },
       { 233, "name X not found in function \"+\"" },
@@ -5976,7 +5976,6 @@ START_TEST(test_issue789)
       { 15, "invalid use of architecture RTL" },
       {  0, "declaration of literal RTL is hidden" },
       {  0, "name RTL refers to this architecture" },
-      { 31, "missing 'entity' keyword in entity binding indication." },
       { 31, "design unit WORK.TEST1 is not a component declaration" },
       { -1, NULL }
    };
@@ -6970,7 +6969,7 @@ START_TEST(test_issue1038)
    const error_t expect[] = {
       { 26, "unexpected next while parsing primary, expecting one of ??, (, "
             "integer, real, null, identifier, string, bit string or new" },
-      { 41, "no visible subprogram declaration for NATURAL" },
+      { 41, "invalid procedure call statement" },
       { 49, "type mark does not denote a type or a subtype" },
       { 49, "unexpected identifier while parsing subtype declaration" },
       { -1, NULL }
@@ -7645,13 +7644,13 @@ START_TEST(test_issue1535)
    input_from_file(TESTDIR "/parse/issue1535.vhd");
 
    const error_t expect[] = {
-      { 16, "missing 'entity' keyword in entity binding indication" },
       { 16, "design unit WORK.SUB is not a component declaration" },
+      { 28, "design unit WORK.PACK is not a component declaration" },
       { -1, NULL }
    };
    expect_errors(expect);
 
-   parse_and_check(T_ENTITY, T_ARCH, T_ENTITY, T_ARCH);
+   parse_and_check(T_ENTITY, T_ARCH, T_ENTITY, T_ARCH, T_PACKAGE, T_ARCH);
 
    check_expected_errors();
 }

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -5976,6 +5976,7 @@ START_TEST(test_issue789)
       { 15, "invalid use of architecture RTL" },
       {  0, "declaration of literal RTL is hidden" },
       {  0, "name RTL refers to this architecture" },
+      { 31, "missing 'entity' keyword in entity binding indication." },
       { 31, "design unit WORK.TEST1 is not a component declaration" },
       { -1, NULL }
    };
@@ -7644,12 +7645,13 @@ START_TEST(test_issue1535)
    input_from_file(TESTDIR "/parse/issue1535.vhd");
 
    const error_t expect[] = {
-      { 6, "invalid procedure call" },
+      { 16, "missing 'entity' keyword in entity binding indication" },
+      { 16, "design unit WORK.SUB is not a component declaration" },
       { -1, NULL }
    };
    expect_errors(expect);
 
-   parse_and_check(T_ENTITY, T_ARCH);
+   parse_and_check(T_ENTITY, T_ARCH, T_ENTITY, T_ARCH);
 
    check_expected_errors();
 }

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -7637,6 +7637,24 @@ START_TEST(test_view1)
 }
 END_TEST
 
+START_TEST(test_issue1535)
+{
+   set_standard(STD_08);
+
+   input_from_file(TESTDIR "/parse/issue1535.vhd");
+
+   const error_t expect[] = {
+      { 6, "invalid procedure call" },
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   parse_and_check(T_ENTITY, T_ARCH);
+
+   check_expected_errors();
+}
+END_TEST
+
 Suite *get_parse_tests(void)
 {
    Suite *s = suite_create("parse");
@@ -7838,6 +7856,7 @@ Suite *get_parse_tests(void)
    tcase_add_test(tc_core, test_issue1477);
    tcase_add_test(tc_core, test_issue1498);
    tcase_add_test(tc_core, test_view1);
+   tcase_add_test(tc_core, test_issue1535);
    suite_add_tcase(s, tc_core);
 
    return s;

--- a/test/test_sem.c
+++ b/test/test_sem.c
@@ -687,7 +687,7 @@ START_TEST(test_procedure)
       { 162, "formal parameter ARG with type containing an access type " },
       { 167, "formal parameter ARG with type containing an access type " },
       { 172, "formal parameter ARG with type containing an access type " },
-      { 180, "no visible subprogram declaration for X" },
+      { 180, "invalid procedure call statement" },
       { 183, "declaration may not include the reserved word BUS" },
       { 193, "signal parameter Y must be denoted by a static signal name" },
       { 201, "formal parameter X already has an associated actual" },
@@ -2103,7 +2103,7 @@ START_TEST(test_issue359)
 
    const error_t expect[] = {
       {  8, "FOO already declared in this region" },
-      { 16, "no visible subprogram declaration for FOO" },
+      { 16, "cannot index non-array type INTEGER" },
       { -1, NULL }
    };
    expect_errors(expect);


### PR DESCRIPTION
Resolve library reference in `resolve_record_ref_or_call` in case the record prefix being referenced is a library.

Fixes #1535.

I did not know how to fix this on the parser level since the reproducer is de-facto valid syntax for start of record field assignment, e.g.:
```
label : my_rec.my_sig <= '1';
```