### PR TITLE
Fix crash on invalid mode view indexing

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -974,6 +974,7 @@ unsigned dimension_of(type_t type)
    case T_INCOMPLETE:
    case T_FILE:
    case T_SIGNATURE:
+   case T_VIEW:
       return 0;
    case T_INTEGER:
    case T_REAL:

--- a/test/parse/view1.vhd
+++ b/test/parse/view1.vhd
@@ -1,0 +1,19 @@
+entity view1 is end entity;
+
+architecture rtl of view1 is
+  type st_t is record
+    data : bit_vector;
+  end record;
+
+  view st_source_v of st_t is
+    data : out;
+  end view;
+
+  signal d : st_t(data(7 downto 0));
+begin
+  b1 : block
+  port (s : view st_source_v(data(7 downto 0)));
+  port map (s => d);
+  begin
+  end block;
+end architecture;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -7617,6 +7617,26 @@ START_TEST(test_issue1498)
 }
 END_TEST
 
+START_TEST(test_view1)
+{
+   set_standard(STD_19);
+
+   input_from_file(TESTDIR "/parse/view1.vhd");
+
+   const error_t expect[] = {
+      { 15, "no visible declaration for DATA" },
+      { 15, "cannot index non-array type ST_SOURCE_V" },
+      { 15, "name in mode view indication does not denote a mode view" },
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   parse_and_check(T_ENTITY, T_ARCH);
+
+   check_expected_errors();
+}
+END_TEST
+
 Suite *get_parse_tests(void)
 {
    Suite *s = suite_create("parse");
@@ -7817,6 +7837,7 @@ Suite *get_parse_tests(void)
    tcase_add_test(tc_core, test_tc1852);
    tcase_add_test(tc_core, test_issue1477);
    tcase_add_test(tc_core, test_issue1498);
+   tcase_add_test(tc_core, test_view1);
    suite_add_tcase(s, tc_core);
 
    return s;


### PR DESCRIPTION
I happened to write:
```vhd
port (s : view st_source_v(data(7 downto 0)));
```
instead of 
```vhd
port (s : view st_source_v of st_t(data(7 downto 0)));
```
for constraining a view mode of a record, which crashed NVC.

I tried to fix it.
The amount of relevant changes for the fix compared to the test is ... a lot. Feel free to throw away what is too verbose or unnecessary. :)

Cheers, Nik