### PR TITLE
Fix INTERNAL foreign-call signature mismatch

### DIFF
--- a/src/rt/assert.c
+++ b/src/rt/assert.c
@@ -193,7 +193,7 @@ static format_part_t *check_format(const char *str)
 }
 
 DLLEXPORT
-void _std_env_set_assert_format_valid(jit_scalar_t *args)
+void _std_env_set_assert_format_valid(jit_scalar_t *args, tlab_t *tlab)
 {
    uint8_t level = args[2].integer;
    const uint8_t *format_ptr = args[3].pointer;
@@ -214,7 +214,7 @@ void _std_env_set_assert_format_valid(jit_scalar_t *args)
 }
 
 DLLEXPORT
-void _std_env_set_assert_format(jit_scalar_t *args)
+void _std_env_set_assert_format(jit_scalar_t *args, tlab_t *tlab)
 {
    uint8_t level = args[2].integer;
    const uint8_t *format_ptr = args[3].pointer;

--- a/src/rt/simpkg.c
+++ b/src/rt/simpkg.c
@@ -23,13 +23,13 @@
 #include "rt/rt.h"
 
 DLLEXPORT
-void _nvc_ieee_warnings(jit_scalar_t *args)
+void _nvc_ieee_warnings(jit_scalar_t *args, tlab_t *tlab)
 {
    args[0].integer = (opt_get_int(OPT_IEEE_WARNINGS) == IEEE_WARNINGS_ON);
 }
 
 DLLEXPORT
-void _nvc_current_delta(jit_scalar_t *args)
+void _nvc_current_delta(jit_scalar_t *args, tlab_t *tlab)
 {
    rt_model_t *m = get_model_or_null();
 

--- a/src/rt/standard.c
+++ b/src/rt/standard.c
@@ -91,7 +91,7 @@ static void to_string_real_format(jit_scalar_t *args, tlab_t *tlab,
 }
 
 DLLEXPORT
-void _std_standard_now(jit_scalar_t *args)
+void _std_standard_now(jit_scalar_t *args, tlab_t *tlab)
 {
    rt_model_t *m = get_model_or_null();
    args[0].integer = m ? model_now(m, NULL) : 0;


### PR DESCRIPTION
`ffi_internal_t` (`jit-ffi.h:89`) is `void (*)(jit_scalar_t *, tlab_t *)` and `jit_internal_entry` calls through it as `(*fn)(args, tlab)` (`jit-ffi.c:320`), but five callees are declared one-arg:

- `_nvc_ieee_warnings`, `_nvc_current_delta` (`rt/simpkg.c`)
- `_std_standard_now` (`rt/standard.c`)
- `_std_env_set_assert_format`, `_std_env_set_assert_format_valid` (`rt/assert.c`)

Works on x86-64 since the extra arg lands in `rsi` and is ignored, but it's UB. Building master with `clang -fsanitize=function` and running any sim that hits one:

```
jit-ffi.c:320: runtime error: call to function _std_standard_now through
pointer to incorrect function type 'void (*)(jit_scalar_t *, struct _tlab *)'
```

Match the declarations to the typedef. None of the five use `tlab`, so no behaviour change.