### PR TITLE
Constant fold replication count in Verilog concatenation

### DIFF
--- a/src/vlog/vlog-fold.c
+++ b/src/vlog/vlog-fold.c
@@ -139,6 +139,20 @@ static vlog_node_t fold_part_select(vlog_node_t v, fold_ctx_t *ctx)
    return v;
 }
 
+static vlog_node_t fold_concat(vlog_node_t v, fold_ctx_t *ctx)
+{
+   if (vlog_has_value(v)) {
+      vlog_node_t value = vlog_value(v);
+      if (!is_folded(value)) {
+         vlog_node_t result = fold_call_thunk(value, ctx);
+         if (result != NULL)
+            vlog_set_value(v, result);
+      }
+   }
+
+   return v;
+}
+
 static void vlog_fold_pre_cb(vlog_node_t v, void *context)
 {
    fold_ctx_t *ctx = context;
@@ -165,6 +179,8 @@ static vlog_node_t vlog_fold_post_cb(vlog_node_t v, void *context)
       return fold_dimension(v, context);
    case V_PART_SELECT:
       return fold_part_select(v, context);
+   case V_CONCAT:
+      return fold_concat(v, context);
    case V_GEN_BLOCK:
    case V_FOR_GENERATE:
    case V_IF_GENERATE:

--- a/test/regress/constfunc2.v
+++ b/test/regress/constfunc2.v
@@ -1,0 +1,51 @@
+module constfunc2;
+
+  function integer double;
+    input integer x;
+    begin
+      double = x * 2;
+    end
+  endfunction
+
+  function integer add_one;
+    input integer x;
+    begin
+      add_one = x + 1;
+    end
+  endfunction
+
+  parameter integer WIDTH = double(4);   // 8
+
+  // Replication count uses binary expression on a parameter computed
+  // by a user function call.  The expressions below must be folded to
+  // a constant integer before lowering.
+
+  reg [9:0]  data1;
+  reg [15:0] data2;
+  reg [15:0] data3;
+  reg [7:0]  data4;
+
+  initial begin
+    data1 = {(WIDTH + 1){1'b1}};           // 9 ones
+    data2 = {(WIDTH << 1){1'b1}};          // 16 ones
+    data3 = {(WIDTH * 2){1'b1}};           // 16 ones
+    data4 = {(add_one(WIDTH) - 1){1'b1}};  // 8 ones
+
+    $display("WIDTH = %0d", WIDTH);
+    $display("data1 = %b", data1);
+    $display("data2 = %b", data2);
+    $display("data3 = %b", data3);
+    $display("data4 = %b", data4);
+
+    if (data1 === 10'h1FF
+        && data2 === 16'hFFFF
+        && data3 === 16'hFFFF
+        && data4 === 8'hFF)
+      $display("PASSED");
+    else
+      $display("FAILED");
+
+    $finish;
+  end
+
+endmodule // constfunc2

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -1394,3 +1394,4 @@ issue1517       cover=statement
 issue1518       verilog
 ivtest55        verilog,gold
 real13          verilog
+constfunc2      verilog


### PR DESCRIPTION
Completes constant folding introduced in e9e33ba1d by also folding the replication count of a concatenation node.  Without this an expression like {(WIDTH + 1){1'b1}}, where WIDTH is a parameter computed from a user function call, would fail with "expression is not constant" because vlog_get_const cannot evaluate a V_BINARY.