### PR TITLE
Fix VHPI fields of array record elements

### DIFF
--- a/src/vhpi/vhpi-model.c
+++ b/src/vhpi/vhpi-model.c
@@ -1940,6 +1940,25 @@ static void *vhpi_get_value_ptr(c_vhpiObject *obj)
       if (base == NULL)
          return NULL;
 
+      c_objDecl *pod = is_objDecl(pobj);
+      type_t ptype = pod != NULL ? pod->decl.type : NULL;
+      if (ptype != NULL && type_is_array(ptype)) {
+         if ((pod->Type != NULL && pod->Type->wrapped)
+             || !type_const_bounds(ptype))
+            base = ((ffi_uarray_t *)base)->ptr;
+
+         type_t elem = type_elem(ptype);
+         if (type_is_record(elem)) {
+            const jit_layout_t *l =
+               vhpi_get_prefix_kind(pobj) == vhpiSigDeclK
+                  || vhpi_get_prefix_kind(pobj) == vhpiPortDeclK
+                  ? signal_layout_of(elem) : layout_of(elem);
+            assert(l != NULL);
+            assert(ed->Position < l->nparts);
+            return base + l->parts[ed->Position].offset;
+         }
+      }
+
       const jit_layout_t *l = vhpi_get_layout(pobj);
       assert(l != NULL);
       assert(ed->Position < l->nparts);
@@ -4248,6 +4267,10 @@ static c_typeDecl *build_arrayTypeDecl(type_t type, tree_t decl,
       new_object(sizeof(c_arrayTypeDecl), vhpiArrayTypeDeclK);
    init_compositeTypeDecl(&(td->composite), decl, type, region);
 
+   c_elemDecl *ed = obj != NULL ? is_elemDecl(obj) : NULL;
+   if (ed != NULL && ed->Type == NULL)
+      ed->Type = &(td->composite.typeDecl);
+
    td->NumDimensions = dimension_of(type);
    td->composite.typeDecl.wrapped = !type_const_bounds(type);
 
@@ -4418,6 +4441,10 @@ static c_typeDecl *build_subTypeDecl(type_t type, tree_t where,
    c_subTypeDecl *td = new_object(sizeof(c_subTypeDecl), vhpiSubtypeDeclK);
    init_typeDecl(&(td->typeDecl), where, type, region);
 
+   c_elemDecl *ed = obj != NULL ? is_elemDecl(obj) : NULL;
+   if (ed != NULL && ed->Type == NULL)
+      ed->Type = &(td->typeDecl);
+
    hash_put(vhpi_context()->objcache, type, td);
 
    td->typeDecl.BaseType = cached_typeDecl(type_base_recur(type), NULL);
@@ -4499,6 +4526,9 @@ static c_typeDecl *build_anonymousSubTypeDecl(type_t type,
 
    c_abstractDecl *decl = is_abstractDecl(obj);
    assert(decl != NULL);
+
+   if (region == NULL)
+      region = decl->ImmRegion;
 
    c_typeDecl *td = build_subTypeDecl(type, decl->tree, region, obj);
    td->IsAnonymous = true;

--- a/test/dist.mk
+++ b/test/dist.mk
@@ -2315,6 +2315,7 @@ EXTRA_DIST += \
 	test/regress/vhpi18.vhd \
 	test/regress/vhpi19.vhd \
 	test/regress/vhpi1.vhd \
+	test/regress/vhpi21.vhd \
 	test/regress/vhpi2.vhd \
 	test/regress/vhpi3.vhd \
 	test/regress/vhpi4.vhd \

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -1265,6 +1265,7 @@ vhpi18          vhpi,2008
 issue1424       normal,gold,2019
 issue1428       vhpi,2008
 vhpi19          vhpi
+vhpi21          vhpi,2008
 issue1433       shell
 reflect6        normal,2019
 vlog32          verilog

--- a/test/regress/vhpi21.vhd
+++ b/test/regress/vhpi21.vhd
@@ -1,0 +1,247 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.math_real.all;
+
+package vhpi21_pkg is
+    type leaf_status_t is record
+        payload : std_logic_vector;
+    end record;
+
+    type leaf_status_array_t is array (natural range <>) of leaf_status_t;
+
+    type inner_status_t is record
+        item : leaf_status_array_t;
+    end record;
+
+    type status_t is record
+        inner : inner_status_t;
+    end record;
+
+    type sample_record_t is record
+        data  : std_logic_vector;
+        tag   : std_logic_vector(1 downto 0);
+        addr  : std_logic_vector;
+        valid : std_logic_vector(0 downto 0);
+    end record;
+
+    type sample_array_t is array (natural range <>) of sample_record_t;
+
+    function init_sample(
+        data_width : positive;
+        addr_width : positive) return sample_record_t;
+
+    function derived_data_width(width : positive) return positive;
+    function derived_addr_width(width : positive) return positive;
+end package;
+
+package body vhpi21_pkg is
+    function loop_identity(width : positive) return positive is
+    begin
+        return positive(integer(ceil(real(width))));
+    end function;
+
+    function derived_data_width(width : positive) return positive is
+    begin
+        return loop_identity(width);
+    end function;
+
+    function derived_addr_width(width : positive) return positive is
+    begin
+        return loop_identity(width);
+    end function;
+
+    function init_sample(
+        data_width : positive;
+        addr_width : positive) return sample_record_t is
+        variable r : sample_record_t(
+            data(data_width - 1 downto 0),
+            addr(addr_width - 1 downto 0));
+    begin
+        r.data  := (others => '0');
+        r.tag   := (others => '0');
+        r.addr  := (others => '0');
+        r.valid := (others => '0');
+        return r;
+    end function;
+end package body;
+
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity vhpi21_leaf_unit is
+    generic (
+        width : positive := 8);
+    port (
+        clk : in  std_logic;
+        y   : out std_logic_vector(width - 1 downto 0));
+end entity;
+
+architecture test of vhpi21_leaf_unit is
+begin
+    y <= (others => '0');
+end architecture;
+
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+use work.vhpi21_pkg.all;
+
+entity vhpi21_nested_unit is
+    generic (
+        width : positive := 8;
+        count : positive := 2);
+    port (
+        clk    : in  std_logic;
+        status : out status_t(
+            inner(
+                item(0 to count - 1)(
+                    payload(width - 1 downto 0)))));
+end entity;
+
+architecture test of vhpi21_nested_unit is
+    signal leaf_y : std_logic_vector(width - 1 downto 0);
+begin
+    u_leaf : entity work.vhpi21_leaf_unit
+        generic map (
+            width => width)
+        port map (
+            clk => clk,
+            y   => leaf_y);
+
+    status.inner.item(0).payload <= leaf_y;
+    status.inner.item(1).payload <= (others => '0');
+end architecture;
+
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+use work.vhpi21_pkg.all;
+
+entity vhpi21_sample_unit is
+    generic (
+        data_width : positive := 8;
+        addr_width : positive := 4);
+    port (
+        clk        : in  std_logic;
+        sample_in  : in  sample_record_t(
+            data(data_width - 1 downto 0),
+            addr(addr_width - 1 downto 0));
+        sample_out : out sample_record_t(
+            data(data_width - 1 downto 0),
+            addr(addr_width - 1 downto 0)));
+end entity;
+
+architecture test of vhpi21_sample_unit is
+begin
+    sample_out <= sample_in;
+end architecture;
+
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+use work.vhpi21_pkg.all;
+
+entity vhpi21_sample_array_unit is
+    generic (
+        data_width : positive := 8;
+        addr_width : positive := 4;
+        count      : positive := 2);
+    port (
+        clk : in std_logic);
+end entity;
+
+architecture test of vhpi21_sample_array_unit is
+    constant c_data_width : positive := derived_data_width(data_width);
+    constant c_addr_width : positive := derived_addr_width(addr_width);
+
+    signal sample : sample_array_t(0 to count - 1)(
+        data(c_data_width - 1 downto 0),
+        addr(c_addr_width - 1 downto 0)) := (
+        others => init_sample(c_data_width, c_addr_width));
+    signal sample_copy : sample_array_t(0 to count - 1)(
+        data(c_data_width - 1 downto 0),
+        addr(c_addr_width - 1 downto 0)) := (
+        others => init_sample(c_data_width, c_addr_width));
+begin
+    gen_sample : for i in 0 to count - 1 generate
+        u_sample : entity work.vhpi21_sample_unit
+            generic map (
+                data_width => c_data_width,
+                addr_width => c_addr_width)
+            port map (
+                clk        => clk,
+                sample_in  => sample((i - 1 + count) mod count),
+                sample_out => sample_copy(i));
+
+        sample(i).data <= (others => '0');
+        sample(i).tag <= (others => '0');
+        sample(i).addr <= (others => '0');
+        sample(i).valid <= (others => '0');
+    end generate;
+end architecture;
+
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+use work.vhpi21_pkg.all;
+
+entity vhpi21 is
+end entity;
+
+architecture test of vhpi21 is
+    constant width      : positive := 8;
+    constant addr_width : positive := 4;
+    constant count      : positive := 2;
+
+    signal clk : std_logic := '0';
+    signal status : status_t(
+        inner(
+            item(0 to count - 1)(
+                payload(width - 1 downto 0)))) := (
+        inner => (
+            item => (
+                others => (
+                    payload => (others => '0')))));
+    signal cache : leaf_status_array_t(0 to count - 1)(
+        payload(width - 1 downto 0)) := (
+        others => (
+            payload => (others => '0')));
+    signal sample : sample_array_t(0 to count - 1)(
+        data(width - 1 downto 0),
+        addr(addr_width - 1 downto 0)) := (
+        others => init_sample(width, addr_width));
+begin
+    u_nested : entity work.vhpi21_nested_unit
+        generic map (
+            width => width,
+            count => count)
+        port map (
+            clk    => clk,
+            status => status);
+
+    u_samples : entity work.vhpi21_sample_array_unit
+        generic map (
+            data_width => width,
+            addr_width => addr_width,
+            count      => count)
+        port map (
+            clk => clk);
+
+    gen_top_cache : for i in 0 to count - 1 generate
+        cache(i).payload <= (others => '0');
+        sample(i).data <= (others => '0');
+        sample(i).tag <= (others => '0');
+        sample(i).addr <= (others => '0');
+        sample(i).valid <= (others => '0');
+    end generate;
+end architecture;

--- a/test/vhpi/Makemodule.am
+++ b/test/vhpi/Makemodule.am
@@ -38,6 +38,7 @@ lib_vhpi_test_so_SOURCES = \
 	test/vhpi/vhpi18.c \
 	test/vhpi/issue1428.c \
 	test/vhpi/vhpi19.c \
+	test/vhpi/vhpi21.c \
 	test/vhpi/issue1463.c \
 	test/vhpi/issue1473.c \
 	test/vhpi/issue1505.c

--- a/test/vhpi/issue1161.c
+++ b/test/vhpi/issue1161.c
@@ -47,8 +47,7 @@ static void start_of_sim(const vhpiCbDataT *cb_data)
          vhpi_printf("elem %s", vhpi_get_str(vhpiNameP, e));
          vhpi_printf("size %d", vhpi_get(vhpiSizeP, e));
 
-         // XXX: should be 128?
-         fail_unless(vhpi_get(vhpiSizeP, e) == 256);
+         fail_unless(vhpi_get(vhpiSizeP, e) == 128);
 
          vhpiHandleT etype = VHPI_CHECK(vhpi_handle(vhpiType, e));
          fail_unless(vhpi_get(vhpiKindP, etype) == vhpiArrayTypeDeclK);

--- a/test/vhpi/vhpi21.c
+++ b/test/vhpi/vhpi21.c
@@ -1,0 +1,207 @@
+#include "vhpi_test.h"
+
+#include <stdio.h>
+
+static void check_vector(vhpiHandleT payload, const char *label,
+                         int size, int left, int right, const char *expected)
+{
+   check_handle(payload);
+   fail_unless(vhpi_get(vhpiKindP, payload) == vhpiSelectedNameK);
+   fail_unless(vhpi_get(vhpiSizeP, payload) == size);
+
+   vhpiHandleT payload_type = VHPI_CHECK(vhpi_handle(vhpiBaseType, payload));
+   check_handle(payload_type);
+   fail_unless(vhpi_get(vhpiKindP, payload_type) == vhpiArrayTypeDeclK);
+
+   vhpiHandleT constraints =
+      VHPI_CHECK(vhpi_iterator(vhpiConstraints, payload_type));
+   check_handle(constraints);
+
+   vhpiHandleT range = VHPI_CHECK(vhpi_scan(constraints));
+   check_handle(range);
+   fail_unless(vhpi_get(vhpiLeftBoundP, range) == left);
+   fail_unless(vhpi_get(vhpiRightBoundP, range) == right);
+   fail_if(vhpi_get(vhpiIsUpP, range));
+   fail_if(vhpi_get(vhpiIsNullP, range));
+   fail_unless(vhpi_get(vhpiIsDiscreteP, range));
+   fail_unless(vhpi_scan(constraints) == NULL);
+   check_error();
+
+   vhpiValueT value = {
+      .format = vhpiBinStrVal,
+   };
+   vhpiCharT buf[16];
+   value.bufSize = sizeof(buf);
+   value.value.str = buf;
+   VHPI_CHECK(vhpi_get_value(payload, &value));
+   vhpi_printf("%s = '%s'", label, (char *)buf);
+   check_string(buf, expected);
+
+   vhpi_release_handle(range);
+   vhpi_release_handle(constraints);
+   vhpi_release_handle(payload_type);
+}
+
+static void check_payload(vhpiHandleT payload, const char *label)
+{
+   check_vector(payload, label, 8, 7, 0, "00000000");
+}
+
+static void check_field(vhpiHandleT record, const char *prefix,
+                        const char *field, int size, int left, int right,
+                        const char *expected)
+{
+   char label[128];
+   snprintf(label, sizeof(label), "%s.%s", prefix, field);
+
+   vhpiHandleT handle = VHPI_CHECK(vhpi_handle_by_name(field, record));
+   check_vector(handle, label, size, left, right, expected);
+   vhpi_release_handle(handle);
+}
+
+static void check_sample_record(vhpiHandleT sample, const char *label)
+{
+   check_field(sample, label, "data", 8, 7, 0, "00000000");
+   check_field(sample, label, "tag", 2, 1, 0, "00");
+   check_field(sample, label, "addr", 4, 3, 0, "0000");
+   check_field(sample, label, "valid", 1, 0, 0, "0");
+}
+
+static void check_first_selected_field(vhpiHandleT sample, const char *label)
+{
+   fail_unless(vhpi_get(vhpiKindP, sample) == vhpiIndexedNameK);
+
+   vhpiHandleT base = VHPI_CHECK(vhpi_handle(vhpiBaseType, sample));
+   check_handle(base);
+   fail_unless(vhpi_get(vhpiKindP, base) == vhpiRecordTypeDeclK);
+   (void)vhpi_get_str(vhpiKindStrP, base);
+   (void)vhpi_get_str(vhpiFullCaseNameP, sample);
+   vhpi_release_handle(base);
+
+   vhpiHandleT selected = VHPI_CHECK(vhpi_iterator(vhpiSelectedNames, sample));
+   check_handle(selected);
+
+   vhpiHandleT field = VHPI_CHECK(vhpi_scan(selected));
+   check_handle(field);
+   check_vector(field, label, 8, 7, 0, "00000000");
+
+   vhpi_release_handle(field);
+   vhpi_release_handle(selected);
+}
+
+static void check_sample_instance(vhpiHandleT root)
+{
+   vhpiHandleT inst = VHPI_CHECK(vhpi_handle_by_name("u_samples", root));
+   check_handle(inst);
+
+   vhpiHandleT sample = VHPI_CHECK(vhpi_handle_by_name("sample", inst));
+   check_handle(sample);
+
+   vhpiHandleT sample0 =
+      VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, sample, 0));
+   check_handle(sample0);
+   check_first_selected_field(sample0, "u_samples.sample(0).data selected");
+   check_sample_record(sample0, "u_samples.sample(0)");
+
+   vhpiHandleT sample_copy =
+      VHPI_CHECK(vhpi_handle_by_name("sample_copy", inst));
+   check_handle(sample_copy);
+
+   vhpiHandleT sample_copy0 =
+      VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, sample_copy, 0));
+   check_handle(sample_copy0);
+   check_sample_record(sample_copy0, "u_samples.sample_copy(0)");
+
+   vhpi_release_handle(sample_copy0);
+   vhpi_release_handle(sample_copy);
+   vhpi_release_handle(sample0);
+   vhpi_release_handle(sample);
+   vhpi_release_handle(inst);
+}
+
+static void after_delay(const vhpiCbDataT *cb_data)
+{
+   vhpiHandleT root = VHPI_CHECK(vhpi_handle(vhpiRootInst, NULL));
+   fail_if(root == NULL);
+
+   check_sample_instance(root);
+
+   vhpiHandleT nested = VHPI_CHECK(vhpi_handle_by_name("u_nested", root));
+   check_handle(nested);
+
+   vhpiHandleT leaf = VHPI_CHECK(vhpi_handle_by_name("u_leaf", nested));
+   check_handle(leaf);
+
+   vhpiHandleT status = VHPI_CHECK(vhpi_handle_by_name("status", root));
+   check_handle(status);
+
+   vhpiHandleT inner = VHPI_CHECK(vhpi_handle_by_name("inner", status));
+   check_handle(inner);
+
+   vhpiHandleT item = VHPI_CHECK(vhpi_handle_by_name("item", inner));
+   check_handle(item);
+
+   vhpiHandleT item0 =
+      VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, item, 0));
+   check_handle(item0);
+
+   vhpiHandleT nested_payload =
+      VHPI_CHECK(vhpi_handle_by_name("payload", item0));
+   check_payload(nested_payload, "status.inner.item(0).payload");
+
+   vhpiHandleT cache = VHPI_CHECK(vhpi_handle_by_name("cache", root));
+   check_handle(cache);
+
+   vhpiHandleT cache0 =
+      VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, cache, 0));
+   check_handle(cache0);
+
+   vhpiHandleT cache_payload =
+      VHPI_CHECK(vhpi_handle_by_name("payload", cache0));
+   check_payload(cache_payload, "cache(0).payload");
+
+   vhpiHandleT sample = VHPI_CHECK(vhpi_handle_by_name("sample", root));
+   check_handle(sample);
+
+   vhpiHandleT sample0 =
+      VHPI_CHECK(vhpi_handle_by_index(vhpiIndexedNames, sample, 0));
+   check_handle(sample0);
+   check_sample_record(sample0, "sample(0)");
+
+   vhpi_release_handle(sample0);
+   vhpi_release_handle(sample);
+   vhpi_release_handle(cache_payload);
+   vhpi_release_handle(cache0);
+   vhpi_release_handle(cache);
+   vhpi_release_handle(nested_payload);
+   vhpi_release_handle(item0);
+   vhpi_release_handle(item);
+   vhpi_release_handle(inner);
+   vhpi_release_handle(status);
+   vhpi_release_handle(leaf);
+   vhpi_release_handle(nested);
+   vhpi_release_handle(root);
+}
+
+static void start_of_sim(const vhpiCbDataT *cb_data)
+{
+   static vhpiTimeT time_1fs = {
+      .low = 1,
+   };
+
+   vhpiCbDataT delay_cb = {
+      .reason = vhpiCbAfterDelay,
+      .cb_rtn = after_delay,
+      .time   = &time_1fs,
+   };
+   VHPI_CHECK(vhpi_register_cb(&delay_cb, 0));
+}
+
+void vhpi21_startup(void)
+{
+   vhpiCbDataT cb_data = {
+      .reason = vhpiCbStartOfSimulation,
+      .cb_rtn = start_of_sim,
+   };
+   VHPI_CHECK(vhpi_register_cb(&cb_data, 0));
+}

--- a/test/vhpi/vhpi_test.c
+++ b/test/vhpi/vhpi_test.c
@@ -61,6 +61,7 @@ static const vhpi_test_t tests[] = {
    { "vhpi18",    vhpi18_startup },
    { "issue1428", issue1428_startup },
    { "vhpi19",    vhpi19_startup },
+   { "vhpi21",    vhpi21_startup },
    { "issue1463", issue1463_startup },
    { "issue1473", issue1473_startup },
    { "issue1505", issue1505_startup },

--- a/test/vhpi/vhpi_test.h
+++ b/test/vhpi/vhpi_test.h
@@ -59,6 +59,7 @@ void vhpi16_startup(void);
 void vhpi17_startup(void);
 void vhpi18_startup(void);
 void vhpi19_startup(void);
+void vhpi21_startup(void);
 void issue744_startup(void);
 void issue762_startup(void);
 void issue978_startup(void);


### PR DESCRIPTION
  Fix a VHPI crash/incorrect lookup when external tools inspect a field inside a record that is stored in an array.

  For example, this kind of VHDL object could fail through VHPI:

  ```vhdl
  type sample_record_t is record
     data  : std_logic_vector;
     valid : std_logic_vector(0 downto 0);
  end record;

  type sample_array_t is array (natural range <>) of sample_record_t;

  signal sample : sample_array_t(0 to 1)(
     data(7 downto 0));
```
  A VHPI client inspecting this path:
```
  sample(0).data
```
  could get a bad size/constraint, read from the wrong memory location, or crash while NVC was building the VHPI type information.

  This change fixes that by making NVC:

  - keep the constrained field type available while building VHPI subtype metadata
  - calculate field addresses from the selected record element, not from the whole array object
  - unwrap array storage when the runtime representation uses an unconstrained array wrapper

  The existing issue1161 test also had a stale expectation. `AIn(0).Data` is 8 lanes × 16 bits = 128 bits, not 256 bits, so that check is corrected.
