### PR TITLE
Ignore context type in mir_compare_layout.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
   names (#1602, #1603).
 - Verilog `disable` statements are now supported (#1605).
 - Several other minor bugs were resolved (#1587, #1594, #1409, #1597,
-  #1599, #1600).
+  #1599, #1600, #1596).
 
 ## Version 1.21.1 - 2026-06-20
 - Fixed a regression which caused calls to an overloaded subprogram with

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
   names (#1602, #1603).
 - Verilog `disable` statements are now supported (#1605).
 - Several other minor bugs were resolved (#1587, #1594, #1409, #1597,
-  #1599, #1600, #1596).
+  #1599, #1600, #1596, #1569).
 
 ## Version 1.21.1 - 2026-06-20
 - Fixed a regression which caused calls to an overloaded subprogram with

--- a/src/mir/mir-unit.c
+++ b/src/mir/mir-unit.c
@@ -419,8 +419,22 @@ void mir_compare_layout(mir_unit_t *a, mir_unit_t *b)
       goto differ;
 
    for (int i = 0; i < a->vars.count; i++) {
-      if (!mir_equals(a->vars.items[i].type, b->vars.items[i].type))
+      mir_type_t atype = a->vars.items[i].type;
+      mir_type_t btype = b->vars.items[i].type;
+
+      if (mir_equals(atype, btype))
+         continue;
+
+      const type_data_t *tda = mir_type_data(a, atype);
+      const type_data_t *tdb = mir_type_data(a, btype);
+
+      if (tda->class != tdb->class)
          goto differ;
+
+      if (tda->class == MIR_TYPE_CONTEXT)
+         continue;
+
+      goto differ;
    }
 
    return;

--- a/src/vlog/vlog-parse.c
+++ b/src/vlog/vlog-parse.c
@@ -6287,12 +6287,16 @@ static void p_module_or_generate_item(vlog_node_t mod)
    case tID:
       {
          vlog_node_t ref = peek_reference();
-         if (ref == NULL)
+         if (ref == NULL) {
             p_module_or_udp_instantiation(mod);
-         else
+            break;
+         }
+         else if (is_data_type(ref) || peek_nth(2) == tID) {
             p_module_common_item(mod);
+            break;
+         }
       }
-      break;
+      // Fall-through
    default:
       expect(tALWAYS, tALWAYSCOMB, tALWAYSFF, tALWAYSLATCH, tWIRE, tUWIRE,
              tSUPPLY0, tSUPPLY1, tTRI,  tTRI0, tTRI1, tTRIAND, tTRIOR, tTRIREG,

--- a/test/elab/issue1569.vhd
+++ b/test/elab/issue1569.vhd
@@ -1,0 +1,29 @@
+package fifo_generic_pkg is
+  generic (type t_element_type);
+
+  type t_fifo_item;
+  type t_fifo_item_ptr is access t_fifo_item;
+  type t_fifo_item is record
+        data    : t_element_type;
+        nxt_rec : t_fifo_item_ptr;
+  end record;
+end package fifo_generic_pkg;
+
+entity test_1 is
+end entity;
+
+architecture tb of test_1 is
+  package data_queue_pkg is new work.fifo_generic_pkg
+    generic map (t_element_type => bit_vector(63 downto 0));
+  use data_queue_pkg.all;
+begin
+end architecture;
+
+entity test is
+end entity;
+
+architecture tb of test is
+begin
+  i_test_1_0 : entity work.test_1;
+  i_test_1_1 : entity work.test_1;
+end architecture;

--- a/test/test_elab.c
+++ b/test/test_elab.c
@@ -2332,6 +2332,37 @@ START_TEST(test_issue1475)
 }
 END_TEST
 
+START_TEST(test_issue1569)
+{
+   set_standard(STD_08);
+
+   input_from_file(TESTDIR "/elab/issue1569.vhd");
+
+   tree_t e = run_elab();
+   fail_if(e == NULL);
+
+   tree_t top = tree_stmt(e, 0);
+
+   tree_t b0 = tree_stmt(top, 0);
+   ck_assert_tree_kind(b0, T_BLOCK);
+   fail_unless(tree_ident(b0) == ident_new("I_TEST_1_0"));
+
+   tree_t u1_h = tree_decl(b0, 0);
+   ck_assert_tree_kind(u1_h, T_HIER);
+
+   tree_t b1 = tree_stmt(top, 1);
+   ck_assert_tree_kind(b1, T_BLOCK);
+   fail_unless(tree_ident(b1) == ident_new("I_TEST_1_1"));
+
+   tree_t u3_h = tree_decl(b1, 0);
+   ck_assert_tree_kind(u3_h, T_HIER);
+
+   fail_unless(tree_ident2(u1_h) == tree_ident2(u3_h));
+
+   fail_if_errors();
+}
+END_TEST
+
 Suite *get_elab_tests(void)
 {
    Suite *s = suite_create("elab");
@@ -2450,6 +2481,7 @@ Suite *get_elab_tests(void)
    tcase_add_test(tc, test_issue1421);
    tcase_add_test(tc, test_issue1519);
    tcase_add_test(tc, test_issue1475);
+   tcase_add_test(tc, test_issue1569);
    suite_add_tcase(s, tc);
 
    return s;

--- a/test/test_vlog.c
+++ b/test/test_vlog.c
@@ -2063,6 +2063,22 @@ START_TEST(test_disable1)
 }
 END_TEST
 
+START_TEST(test_issue1596)
+{
+   input_from_file(TESTDIR "/vlog/issue1596.v");
+
+   const error_t expect[] = {
+      { 10, "unexpected identifier while parsing module or generate item" },
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   do_parse_only(V_MODULE);
+
+   check_expected_errors();
+}
+END_TEST
+
 Suite *get_vlog_tests(void)
 {
    Suite *s = suite_create("vlog");
@@ -2139,6 +2155,7 @@ Suite *get_vlog_tests(void)
    tcase_add_test(tc, test_href3);
    tcase_add_test(tc, test_constfunc2);
    tcase_add_test(tc, test_disable1);
+   tcase_add_test(tc, test_issue1596);
    suite_add_tcase(s, tc);
 
    return s;

--- a/test/vlog/issue1596.v
+++ b/test/vlog/issue1596.v
@@ -1,0 +1,20 @@
+module counter
+(
+    input  wire clk,
+    input  wire reset,
+    output wire [31:0] count_out
+);
+
+    reg [31:0] count;
+
+    count_out = count;
+    //assign count_out = count;
+
+    always @(posedge clk) begin
+        if (reset)
+            count <= 32'b0;
+        else
+            count <= count + 1'b1;
+    end
+
+endmodule


### PR DESCRIPTION
Fixes #1569.

I tried to look at 1569 since I wanted to examine bit the MIR.
I digged into this with Claude Code, and tried to let it fix the issue and reason about it.

What I got is following:

The fix only skips the context type comparisons in the `mir_compare_layout`.

The context type represents package instances or protected type. Since
the package instance type contains fully qualified name of the package,
it ends as different MIR type. Thus two instances of the same package with
same generics end as different type, despite being equal (therefore clonable).
If the package had different generics, there would not be attempt to clone the
package code.

Package type or Protected type can not be nested under arrays, records, signals
or access types. So there is no need to recurse down the MIR types and skip
check for context type there (that was one of the variants I got from Claude).

Even though protected type is MIR context type, I think its not possible to get
one `tree_t` (checked by the `elab.c`) where one instance would have the same
variable of different protected type without having different generics.

The `mir_compare_layout` is then not 100 % accurate anymore since
e.g. two units with one variable each of different protected type would be
considered equal. I am not sure if this minds since this is just a debug check.

