### PR TITLE
Stricter checking for indexing and slicing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
 - Added the `$tcl_interactive` variable to distinguish `nvc -i` and `nvc
   --do` (#1608).
 - Several other minor bugs were resolved (#1587, #1594, #1409, #1597,
-  #1599, #1600, #1596, #1569, #1607).
+  #1599, #1600, #1596, #1569, #1607, #1610).
 
 ## Version 1.21.1 - 2026-06-20
 - Fixed a regression which caused calls to an overloaded subprogram with

--- a/src/names.c
+++ b/src/names.c
@@ -4783,7 +4783,8 @@ static tree_t solve_array_ref(nametab_t *tab, tree_t t)
    if (conv != NULL)
       return _solve_types(tab, conv);
 
-   type_t base_type = tree_type(deref);
+   type_t base_type = tree_has_type(deref)
+      ? tree_type(deref) : type_new(T_NONE);
 
    const int nparams = tree_params(t);
    for (int i = 0; i < nparams; i++) {
@@ -4822,7 +4823,7 @@ static tree_t solve_array_slice(nametab_t *tab, tree_t t)
    tree_t deref = implicit_dereference(tab, value);
    tree_set_value(t, deref);
 
-   type_t type = tree_type(deref);
+   type_t type = tree_has_type(deref) ? tree_type(deref) : type_new(T_NONE);
    type_t index_type = index_type_of(type, 0);
 
    tree_t r = tree_range(t, 0);

--- a/src/names.c
+++ b/src/names.c
@@ -4783,8 +4783,13 @@ static tree_t solve_array_ref(nametab_t *tab, tree_t t)
    if (conv != NULL)
       return _solve_types(tab, conv);
 
-   type_t base_type = tree_has_type(deref)
-      ? tree_type(deref) : type_new(T_NONE);
+   if (!tree_has_type(deref)) {
+      error_at(tree_loc(deref), "%pC %pI cannot be indexed", deref,
+               tree_ident(deref));
+      tree_set_type(deref, type_new(T_NONE));
+   }
+
+   type_t base_type = tree_type(deref);
 
    const int nparams = tree_params(t);
    for (int i = 0; i < nparams; i++) {
@@ -4823,7 +4828,13 @@ static tree_t solve_array_slice(nametab_t *tab, tree_t t)
    tree_t deref = implicit_dereference(tab, value);
    tree_set_value(t, deref);
 
-   type_t type = tree_has_type(deref) ? tree_type(deref) : type_new(T_NONE);
+   if (!tree_has_type(deref)) {
+      error_at(tree_loc(deref), "%pC %pI cannot be sliced", deref,
+               tree_ident(deref));
+      tree_set_type(deref, type_new(T_NONE));
+   }
+
+   type_t type = tree_type(deref);
    type_t index_type = index_type_of(type, 0);
 
    tree_t r = tree_range(t, 0);

--- a/src/printf.c
+++ b/src/printf.c
@@ -156,6 +156,12 @@ static int format_type(ostream_t *os, printf_state_t *state, printf_arg_t *arg)
    return ostream_puts(os, type_pp(type));
 }
 
+static int format_class(ostream_t *os, printf_state_t *state, printf_arg_t *arg)
+{
+   tree_t t = arg->value.p;
+   return ostream_puts(os, class_str(class_of(t)));
+}
+
 static int format_object_kind(ostream_t *os, printf_state_t *state,
                               printf_arg_t *arg)
 {
@@ -219,6 +225,7 @@ static fmt_fn_t get_pointer_formatter(char ch)
    case 'i': return format_ident;
    case 'I': return format_ident_toupper;
    case 'T': return format_type;
+   case 'C': return format_class;
    case 'K': return format_object_kind;
    case 'M': return format_mir;
    default: return NULL;

--- a/src/sem.c
+++ b/src/sem.c
@@ -4054,10 +4054,6 @@ static bool sem_check_record_ref(tree_t t, nametab_t *tab)
 static bool sem_check_array_ref(tree_t t, nametab_t *tab)
 {
    tree_t value = tree_value(t);
-   if (!tree_has_type(value))
-      sem_error(t, "%s %pI can't be indexed", class_str(class_of(value)),
-                tree_ident(value));
-
    if (!sem_check(value, tab))
       return false;
 
@@ -4099,10 +4095,6 @@ static bool sem_check_array_ref(tree_t t, nametab_t *tab)
 static bool sem_check_array_slice(tree_t t, nametab_t *tab)
 {
    tree_t value = tree_value(t);
-   if (!tree_has_type(value))
-      sem_error(t, "%s %pI can't be sliced", class_str(class_of(value)),
-                tree_ident(value));
-
    if (!sem_check(value, tab))
       return false;
 

--- a/src/sem.c
+++ b/src/sem.c
@@ -4054,6 +4054,10 @@ static bool sem_check_record_ref(tree_t t, nametab_t *tab)
 static bool sem_check_array_ref(tree_t t, nametab_t *tab)
 {
    tree_t value = tree_value(t);
+   if (!tree_has_type(value))
+      sem_error(t, "%s %pI can't be indexed", class_str(class_of(value)),
+                tree_ident(value));
+
    if (!sem_check(value, tab))
       return false;
 
@@ -4095,6 +4099,10 @@ static bool sem_check_array_ref(tree_t t, nametab_t *tab)
 static bool sem_check_array_slice(tree_t t, nametab_t *tab)
 {
    tree_t value = tree_value(t);
+   if (!tree_has_type(value))
+      sem_error(t, "%s %pI can't be sliced", class_str(class_of(value)),
+                tree_ident(value));
+
    if (!sem_check(value, tab))
       return false;
 

--- a/test/parse/issue1610.vhd
+++ b/test/parse/issue1610.vhd
@@ -1,0 +1,61 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity dummy is
+    port(
+        input  : in std_logic;
+        output : out std_logic
+    );
+end entity;
+
+architecture rtl of dummy is
+begin
+    output <= input;
+end architecture;
+
+------------------------------------------------------------------------
+-- Top-level example
+------------------------------------------------------------------------
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity scope_demo is
+end entity;
+
+architecture rtl of scope_demo is
+
+    signal u : std_logic_vector(3 downto 0) := "0000";
+
+begin
+
+    -- this is the problematic part:
+    gen : for i in 0 to 3 generate
+    begin
+        u : entity work.dummy
+            port map(
+                input  => u(i),
+                output => open
+            );
+    end generate;
+
+    -- this is handled correctly:
+    u : entity work.dummy
+        port map(
+            input  => u(0),
+            output => open
+        );
+
+    -- extended checks
+    ex : block
+        constant c0 : std_logic := scope_demo(0);
+        constant c1 : std_logic := rtl(0);
+        constant c2 : std_logic := ieee(0);
+        constant c3 : std_logic := ieee.std_logic_1164(0);
+        constant c4 : std_logic_vector(1 downto 0) := scope_demo(1 downto 0);
+        constant c5 : std_logic_vector(1 downto 0) := rtl(1 downto 0);
+        constant c7 : std_logic_vector(1 downto 0) := ieee(1 downto 0);
+        constant c6 : std_logic_vector(1 downto 0) := ieee.std_logic_1164(1 downto 0);
+    begin
+    end block;
+
+end architecture;

--- a/test/parse/issue1610.vhd
+++ b/test/parse/issue1610.vhd
@@ -1,10 +1,7 @@
-library ieee;
-use ieee.std_logic_1164.all;
-
 entity dummy is
     port(
-        input  : in std_logic;
-        output : out std_logic
+        input  : in bit;
+        output : out bit
     );
 end entity;
 
@@ -16,15 +13,13 @@ end architecture;
 ------------------------------------------------------------------------
 -- Top-level example
 ------------------------------------------------------------------------
-library ieee;
-use ieee.std_logic_1164.all;
 
 entity scope_demo is
 end entity;
 
 architecture rtl of scope_demo is
 
-    signal u : std_logic_vector(3 downto 0) := "0000";
+    signal u : bit_vector(3 downto 0) := "0000";
 
 begin
 
@@ -47,14 +42,14 @@ begin
 
     -- extended checks
     ex : block
-        constant c0 : std_logic := scope_demo(0);
-        constant c1 : std_logic := rtl(0);
-        constant c2 : std_logic := ieee(0);
-        constant c3 : std_logic := ieee.std_logic_1164(0);
-        constant c4 : std_logic_vector(1 downto 0) := scope_demo(1 downto 0);
-        constant c5 : std_logic_vector(1 downto 0) := rtl(1 downto 0);
-        constant c7 : std_logic_vector(1 downto 0) := ieee(1 downto 0);
-        constant c6 : std_logic_vector(1 downto 0) := ieee.std_logic_1164(1 downto 0);
+        constant c0 : bit := scope_demo(0);
+        constant c1 : bit := rtl(0);
+        constant c2 : bit := std(0);
+        constant c3 : bit := std.standard(0);
+        constant c4 : bit_vector(1 downto 0) := scope_demo(1 downto 0);
+        constant c5 : bit_vector(1 downto 0) := rtl(1 downto 0);
+        constant c7 : bit_vector(1 downto 0) := std(1 downto 0);
+        constant c6 : bit_vector(1 downto 0) := std.standard(1 downto 0);
     begin
     end block;
 

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -7708,6 +7708,31 @@ START_TEST(test_issue1607)
 }
 END_TEST
 
+START_TEST(test_issue1610)
+{
+   input_from_file(TESTDIR "/parse/issue1610.vhd");
+
+   const error_t expect[] = {
+      { 36, "label U can't be indexed" },
+      { 42, "U already declared in this region" },
+      { 50, "entity SCOPE_DEMO can't be indexed" },
+      { 51, "architecture RTL can't be indexed" },
+      { 52, "library IEEE can't be indexed" },
+      { 53, "package IEEE.STD_LOGIC_1164 can't be indexed" },
+      { 54, "entity SCOPE_DEMO can't be sliced" },
+      { 55, "architecture RTL can't be sliced" },
+      { 56, "library IEEE can't be sliced" },
+      { 57, "package IEEE.STD_LOGIC_1164 can't be sliced" },
+      { -1, NULL }
+   };
+   expect_errors(expect);
+
+   parse_and_check(T_ENTITY, T_ARCH, T_ENTITY, T_ARCH);
+
+   check_expected_errors();
+}
+END_TEST
+
 Suite *get_parse_tests(void)
 {
    Suite *s = suite_create("parse");
@@ -7913,6 +7938,7 @@ Suite *get_parse_tests(void)
    tcase_add_test(tc_core, test_issue1535);
    tcase_add_test(tc_core, test_issue1560);
    tcase_add_test(tc_core, test_issue1607);
+   tcase_add_test(tc_core, test_issue1610);
    suite_add_tcase(s, tc_core);
 
    return s;

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -7713,16 +7713,16 @@ START_TEST(test_issue1610)
    input_from_file(TESTDIR "/parse/issue1610.vhd");
 
    const error_t expect[] = {
-      { 36, "label U can't be indexed" },
-      { 42, "U already declared in this region" },
-      { 50, "entity SCOPE_DEMO can't be indexed" },
-      { 51, "architecture RTL can't be indexed" },
-      { 52, "library IEEE can't be indexed" },
-      { 53, "package IEEE.STD_LOGIC_1164 can't be indexed" },
-      { 54, "entity SCOPE_DEMO can't be sliced" },
-      { 55, "architecture RTL can't be sliced" },
-      { 56, "library IEEE can't be sliced" },
-      { 57, "package IEEE.STD_LOGIC_1164 can't be sliced" },
+      { 31, "label U cannot be indexed" },
+      { 37, "U already declared in this region" },
+      { 45, "entity SCOPE_DEMO cannot be indexed" },
+      { 46, "architecture RTL cannot be indexed" },
+      { 47, "library STD cannot be indexed" },
+      { 48, "package STD.STANDARD cannot be indexed" },
+      { 49, "entity SCOPE_DEMO cannot be sliced" },
+      { 50, "architecture RTL cannot be sliced" },
+      { 51, "library STD cannot be sliced" },
+      { 52, "package STD.STANDARD cannot be sliced" },
       { -1, NULL }
    };
    expect_errors(expect);


### PR DESCRIPTION
Hi there

To fix the reported crash the changes to `names.c` are sufficient. The error it would emit is `** Error: invalid use of label U`.

The changes to `sem.c` were made not only to change the error message but also to no also crash again in `tree_type(value)` in the semantic check itself. That case could be hit by the extended _wrong_ usage checks I've come up with.

Fixes #1610

For reference, GHDL reports:
```
issue1610.vhd:27:12:error: identifier "u" already used for a declaration
    signal u : std_logic_vector(3 downto 0) := "0000";
           ^
issue1610.vhd:42:5:error: previous declaration: component instance "u"
issue1610.vhd:34:9:warning: declaration of "u" hides component instance "u" [-Whide]
        u : entity work.dummy
        ^
issue1610.vhd:36:28:error: component instance "u" cannot be indexed or sliced
                input  => u(i),
                           ^
issue1610.vhd:44:24:error: component instance "u" cannot be indexed or sliced
            input  => u(0),
                       ^
issue1610.vhd:50:46:error: entity "scope_demo" cannot be indexed or sliced
        constant c0 : std_logic := scope_demo(0);
                                             ^
issue1610.vhd:51:39:error: architecture "rtl" of "scope_demo" cannot be indexed or sliced
        constant c1 : std_logic := rtl(0);
                                      ^
issue1610.vhd:52:40:error: library "ieee" cannot be indexed or sliced
        constant c2 : std_logic := ieee(0);
                                       ^
issue1610.vhd:53:55:error: package "std_logic_1164" cannot be indexed or sliced
        constant c3 : std_logic := ieee.std_logic_1164(0);
                                                      ^
issue1610.vhd:54:65:error: entity "scope_demo" cannot be indexed or sliced
        constant c4 : std_logic_vector(1 downto 0) := scope_demo(1 downto 0);
                                                                ^
issue1610.vhd:55:58:error: architecture "rtl" of "scope_demo" cannot be indexed or sliced
        constant c5 : std_logic_vector(1 downto 0) := rtl(1 downto 0);
                                                         ^
issue1610.vhd:56:59:error: library "ieee" cannot be indexed or sliced
        constant c7 : std_logic_vector(1 downto 0) := ieee(1 downto 0);
                                                          ^
issue1610.vhd:57:74:error: package "std_logic_1164" cannot be indexed or sliced
        constant c6 : std_logic_vector(1 downto 0) := ieee.std_logic_1164(1 downto 0);
```

Cheers, Nik