### PR TITLE
fix record others choice covering different sized arrays with dynamic value

### DIFF
--- a/src/lower.c
+++ b/src/lower.c
@@ -113,6 +113,8 @@ static vcode_reg_t lower_record_aggregate(lower_unit_t *lu, tree_t expr,
                                           vcode_reg_t hint);
 static vcode_reg_t lower_aggregate(lower_unit_t *lu, tree_t expr,
                                    vcode_reg_t hint);
+static vcode_reg_t lower_array_aggregate(lower_unit_t *lu, tree_t expr,
+                                         type_t type, vcode_reg_t hint);
 static void lower_decls(lower_unit_t *lu, tree_t scope, gen_stack_t *gs);
 static void lower_check_array_sizes(lower_unit_t *lu, type_t ltype,
                                     type_t rtype, vcode_reg_t lval,
@@ -3694,6 +3696,38 @@ static vcode_reg_t lower_record_sub_aggregate(lower_unit_t *lu, tree_t value,
       return lower_rvalue(lu, value);
 }
 
+static vcode_reg_t lower_record_others(lower_unit_t *lu, tree_t value,
+                                       tree_t field, bool is_const)
+{
+   type_t ftype = tree_type(field);
+
+   if (is_const && type_is_array(ftype)) {
+      int nvals;
+         vcode_reg_t *values LOCAL =
+            lower_const_array_aggregate(lu, value, ftype, 0, &nvals);
+         return emit_const_array(lower_type(ftype), values, nvals);
+   }
+   else if (is_const && type_is_record(ftype))
+      return lower_record_aggregate(lu, value, true, true, VCODE_INVALID_REG);
+   else if (type_is_scalar(ftype) || type_is_access(ftype))
+      return lower_rvalue(lu, value);
+   else if (type_is_array(ftype)) {
+      if (tree_kind(value) == T_AGGREGATE)
+         return lower_array_aggregate(lu, value, ftype, VCODE_INVALID_REG);
+      else {
+         vcode_reg_t value_reg = lower_rvalue(lu, value);
+         if (!type_is_unconstrained(ftype)) {
+            vcode_reg_t locus = lower_debug_locus(field);
+            lower_check_array_sizes(lu, ftype, tree_type(value),
+                                    VCODE_INVALID_REG, value_reg, locus);
+         }
+         return lower_coerce_arrays(lu, tree_type(value), ftype, value_reg);
+      }
+   }
+   else
+      return lower_rvalue(lu, value);
+}
+
 static vcode_reg_t lower_record_aggregate(lower_unit_t *lu, tree_t expr,
                                           bool nest, bool is_const,
                                           vcode_reg_t hint)
@@ -3735,7 +3769,7 @@ static vcode_reg_t lower_record_aggregate(lower_unit_t *lu, tree_t expr,
          for (int j = 0; j < nfields; j++) {
             if (vals[j] == VCODE_INVALID_REG) {
                tree_t field = type_field(type, j);
-               vals[j] = lower_record_sub_aggregate(lu, value, field, is_const);
+               vals[j] = lower_record_others(lu, value, field, is_const);
                map[j] = value;
             }
          }
@@ -3989,11 +4023,10 @@ static vcode_reg_t lower_aggregate_bounds(lower_unit_t *lu, tree_t expr,
 }
 
 static vcode_reg_t lower_array_aggregate(lower_unit_t *lu, tree_t expr,
-                                         vcode_reg_t hint)
+                                         type_t type, vcode_reg_t hint)
 {
    emit_debug_info(tree_loc(expr));
 
-   type_t type = tree_type(expr);
    type_t elem_type = type_elem(type);
    type_t scalar_elem_type = type_elem_recur(type);
 
@@ -4519,7 +4552,7 @@ static vcode_reg_t lower_aggregate(lower_unit_t *lu, tree_t expr,
       return lower_record_aggregate(lu, expr, false,
                                     lower_is_const(expr), hint);
    else if (type_is_array(type))
-      return lower_array_aggregate(lu, expr, hint);
+      return lower_array_aggregate(lu, expr, type, hint);
    else
       fatal_trace("invalid type %s in lower_aggregate", type_pp(type));
 }

--- a/test/regress/issue1248.vhd
+++ b/test/regress/issue1248.vhd
@@ -1,0 +1,45 @@
+LIBRARY ieee;
+USE ieee.std_logic_1164.ALL;
+
+entity issue1248 is
+end entity;
+
+architecture test of issue1248 is
+
+    TYPE rec_1 IS RECORD
+        x : std_logic_vector(1 DOWNTO 0);
+    END RECORD;
+
+    TYPE rec_2 IS RECORD
+        a : std_logic_vector(3 DOWNTO 0);
+        b : std_logic_vector(7 DOWNTO 0);
+        m : rec_1;
+    END RECORD;
+
+    signal RST_REC_2 : rec_2;
+    signal B : std_logic := 'X';
+
+begin
+    process
+    begin
+        assert (RST_REC_2.a = "UUUU");
+        assert (RST_REC_2.b = "UUUUUUUU");
+
+        B <= 'Z';
+
+        wait for 1 ns;
+
+        RST_REC_2 <= (
+            m      => (OTHERS => (OTHERS => '0')),
+            OTHERS => (OTHERS => B)
+        );
+
+        wait for 1 ns;
+
+        assert (RST_REC_2.a = "ZZZZ");
+        assert (RST_REC_2.b = "ZZZZZZZZ");
+
+        wait;
+    end process;
+
+end architecture;

--- a/test/regress/testlist.txt
+++ b/test/regress/testlist.txt
@@ -1470,3 +1470,4 @@ issue1641       tcl,vhpi,no-collapse,2008
 issue1630       cover,shell
 issue1579       vhpi
 issue1640       verilog
+issue1248       normal


### PR DESCRIPTION
fixes #1248

This also fixes: https://github.com/nickg/nvc/issues/1589

The case with "constant value" had this right, for non-constant
values, the record field length was queried correctly, and per-array constant was
generated with corect size (see issue389 in lower).
For dynamic case, this fell into `lower_rvalue` and run-time size check.
`lower_rvalue` picked only size of the first array covered by the record others choice,
hence giving the error.

I tried to go for least intrusive solution.
Emiting array aggregate per-each recrod others choice was the way to go, but the
type needed to be enforced from the field being covered rather than the value, which
resulted in the first field being covered.

I split it from `lower_record_sub_aggregate` because:
- Putting it under there caused regressions that I did not really want to debug. FWI, this was related to the case where the new code was reached from some of the `A_NAMED` or `A_POS` in the `lower_record_aggregate`.
- AFAICT, the first special case in `lower_record_sub_aggregate` for "const string" could have issue if multiple string fields with different values will be initialized by differently sized string literals.
- I don't know what does the `emit_undefined` is for.